### PR TITLE
Add no-op check to Chuck utility class

### DIFF
--- a/library-no-op/src/main/java/com/readystatesoftware/chuck/Chuck.java
+++ b/library-no-op/src/main/java/com/readystatesoftware/chuck/Chuck.java
@@ -26,4 +26,9 @@ public class Chuck {
     public static Intent getLaunchIntent(Context context) {
         return new Intent();
     }
+
+    public static boolean isNoOp() {
+        return true;
+    }
+
 }

--- a/library/src/main/java/com/readystatesoftware/chuck/Chuck.java
+++ b/library/src/main/java/com/readystatesoftware/chuck/Chuck.java
@@ -34,4 +34,13 @@ public class Chuck {
     public static Intent getLaunchIntent(Context context) {
         return new Intent(context, MainActivity.class).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     }
+
+    /**
+     * Returns whether this is a no operation instance of chuck.
+     *
+     * @return true if this is a no operation instance.
+     */
+    public static boolean isNoOp() {
+        return false;
+    }
 }

--- a/sample/src/main/java/com/readystatesoftware/chuck/sample/MainActivity.java
+++ b/sample/src/main/java/com/readystatesoftware/chuck/sample/MainActivity.java
@@ -21,6 +21,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
+import android.widget.Button;
 import com.readystatesoftware.chuck.Chuck;
 import com.readystatesoftware.chuck.ChuckInterceptor;
 
@@ -42,7 +43,11 @@ public class MainActivity extends AppCompatActivity {
                 doHttpActivity();
             }
         });
-        findViewById(R.id.launch_chuck_directly).setOnClickListener(new View.OnClickListener() {
+
+        Button launchChuckButton = (Button) findViewById(R.id.launch_chuck_directly);
+        launchChuckButton.setVisibility(Chuck.isNoOp() ? View.GONE : View.VISIBLE);
+
+        launchChuckButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 launchChuckDirectly();


### PR DESCRIPTION
Add a no-op check in `Chuck` utilities class, which can be used to check if we currently have a no operation instance of chuck.