### PR TITLE
Prepare 2.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,9 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=2.0.1
-# 2*10*10 + 0*10 + 1 => 20001
-VERSION_CODE=20001
+VERSION_NAME=2.1.0-SNAPSHOT
+# 2*100*100 + 1*100 + 0 => 20100
+VERSION_CODE=20100
 GROUP=fr.o80.chucker
 
 POM_REPO_NAME=Chucker


### PR DESCRIPTION
I set the version number to **2.1.0-SNAPSHOT**, it will allow us to publish unstable versions _if needed_.