### PR TITLE
[FIX] no-op Chuck#init method is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ repositories {
 
 ```gradle
 dependencies {
-  debugImplementation 'fr.o80.chucker:library:2.0.3'
-  releaseImplementation 'fr.o80.chucker:library-no-op:2.0.3'
+  debugImplementation 'fr.o80.chucker:library:2.0.4'
+  releaseImplementation 'fr.o80.chucker:library-no-op:2.0.4'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,9 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=2.0.3
-# 2*10*10 + 0*10 + 1 => 20001
-VERSION_CODE=20003
+VERSION_NAME=2.0.4
+# 2*100*100 + 3*100 + 1 => 20301
+VERSION_CODE=20004
 GROUP=fr.o80.chucker
 
 POM_REPO_NAME=Chucker

--- a/library-no-op/src/main/java/com/readystatesoftware/chuck/api/Chuck.java
+++ b/library-no-op/src/main/java/com/readystatesoftware/chuck/api/Chuck.java
@@ -26,6 +26,9 @@ public class Chuck {
     public static final int SCREEN_HTTP = 1;
     public static final int SCREEN_ERROR = 2;
 
+    public static void init(Context context) {
+    }
+
     public static Intent getLaunchIntent(Context context, int screen) {
         return new Intent();
     }


### PR DESCRIPTION
- Add `Chuck.init(Context)` to no-op library
- Bump to 2.0.4