### PR TITLE
Hide the RetentionManager in the API (Issue #31)

### DIFF
--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -8,7 +8,7 @@ import android.content.Context
 class ChuckerCollector @JvmOverloads constructor(
     context: Context,
     var showNotification: Boolean = true,
-    var retentionManager: Any? = null
+    var retentionPeriod: RetentionManager.Period = RetentionManager.Period.ONE_WEEK
 ) {
 
     fun onError(obj: Any?, obj2: Any?) {}

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -18,9 +18,9 @@ import com.chuckerteam.chucker.api.internal.support.NotificationHelper
  * by this collector. The default is one week.
  */
 class ChuckerCollector @JvmOverloads constructor(
-        context: Context,
-        var showNotification: Boolean = true,
-        retentionPeriod: RetentionManager.Period = RetentionManager.Period.ONE_WEEK
+    context: Context,
+    var showNotification: Boolean = true,
+    retentionPeriod: RetentionManager.Period = RetentionManager.Period.ONE_WEEK
 ) {
     private val retentionManager: RetentionManager = RetentionManager(context, retentionPeriod)
     private val notificationHelper: NotificationHelper = NotificationHelper(context)

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -18,11 +18,11 @@ import com.chuckerteam.chucker.api.internal.support.NotificationHelper
  * by this collector. The default is one week.
  */
 class ChuckerCollector @JvmOverloads constructor(
-    context: Context,
-    var showNotification: Boolean = true,
-    var retentionManager: RetentionManager = RetentionManager(context)
+        context: Context,
+        var showNotification: Boolean = true,
+        retentionPeriod: RetentionManager.Period = RetentionManager.Period.ONE_WEEK
 ) {
-
+    private val retentionManager: RetentionManager = RetentionManager(context, retentionPeriod)
     private val notificationHelper: NotificationHelper = NotificationHelper(context)
 
     init {

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -8,9 +8,7 @@ import com.chuckerteam.chucker.api.Chucker
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.chuckerteam.chucker.api.RetentionManager
-import kotlinx.android.synthetic.main.activity_main.do_http
-import kotlinx.android.synthetic.main.activity_main.launch_chucker_directly
-import kotlinx.android.synthetic.main.activity_main.trigger_exception
+import kotlinx.android.synthetic.main.activity_main.*
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Call
@@ -37,7 +35,7 @@ class MainActivity : AppCompatActivity() {
         collector = ChuckerCollector(
             context = this,
             showNotification = true,
-            retentionManager = RetentionManager(this, RetentionManager.Period.ONE_HOUR)
+            retentionPeriod = RetentionManager.Period.ONE_HOUR
         )
 
         Chucker.registerDefaultCrashHandler(collector)


### PR DESCRIPTION
This PR starts the process of hiding the `RetentionManager` in the public API by deprecating the existing method (with appropriate Javadoc) and internally it treats the `RetentionManager` as an implementation detail, so users would only need to supply a _retention period_ and the `ChuckCollector` manages an instance of it.  This means that the API effectively changes from
```kotlin
collector = ChuckCollector(this)
        .showNotification(true)
        .retentionManager(RetentionManager(this, ChuckCollector.Period.ONE_HOUR))
```
to
```kotlin
collector = ChuckCollector(this)
        .showNotification(true)
        .retentionPeriod(ChuckCollector.Period.ONE_HOUR)
```
I took a conservative approach (by deprecating the existing method) as I didn't know if you already had production usages of that piece of code.