### PR TITLE
Do not display URL Query if the query is null

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/data/entity/HttpTransaction.kt
@@ -194,7 +194,7 @@ internal class HttpTransaction(
         this.url = url
         val uri = Uri.parse(url)
         host = uri.host
-        path = ("${uri.path}${if (uri.query != null) "?" else ""}${uri.query}").toString()
+        path = ("${uri.path}${uri.query?.let { "?$it" } ?: ""}")
         scheme = uri.scheme
         return this
     }


### PR DESCRIPTION
Fixes #37 

Making sure the path is displayed correctly if the query segment is null.

| Before | After |
| -- | -- |
| ![Screenshot_1554058851](https://user-images.githubusercontent.com/3001957/55293632-cb574600-53f8-11e9-95b2-25064081b940.png) | ![Screenshot_1554058833](https://user-images.githubusercontent.com/3001957/55293633-cf836380-53f8-11e9-8cda-3214dba0a6c0.png) |

