### PR TITLE
Prevent potential XXE attacks from XML formatting

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/support/FormatUtils.java
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/support/FormatUtils.java
@@ -1,18 +1,3 @@
-/*
- * Copyright (C) 2017 Jeff Gilfelt.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.chuckerteam.chucker.api.internal.support;
 
 import android.content.Context;
@@ -33,6 +18,7 @@ import java.io.StringWriter;
 import java.util.List;
 import java.util.Locale;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
@@ -73,7 +59,11 @@ public class FormatUtils {
 
     public static String formatXml(String xml) {
         try {
-            Transformer serializer = SAXTransformerFactory.newInstance().newTransformer();
+            SAXTransformerFactory transformerFactory = (SAXTransformerFactory) SAXTransformerFactory.newInstance();
+            transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            transformerFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalDTD", "");
+            transformerFactory.setAttribute("http://javax.xml.XMLConstants/property/accessExternalStylesheet", "");
+            Transformer serializer = transformerFactory.newTransformer();
             serializer.setOutputProperty(OutputKeys.INDENT, "yes");
             serializer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
             Source xmlSource = new SAXSource(new InputSource(new ByteArrayInputStream(xml.getBytes())));


### PR DESCRIPTION
This PR replicates https://github.com/jgilfelt/chuck/pull/84

The fix will prevent the library from loading external resources when parsing an XML from a response body.