### PR TITLE
Make sure dependency examples have the proper case

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ repositories {
 
 ```gradle
 dependencies {
-  debugImplementation 'com.github.chuckerteam.chucker:library:2.0.4'
-  releaseImplementation 'com.github.chuckerteam.chucker:library-no-op:2.0.4'
+  debugImplementation 'com.github.ChuckerTeam.Chucker:library:2.0.4'
+  releaseImplementation 'com.github.ChuckerTeam.Chucker:library-no-op:2.0.4'
 }
 ```
 
@@ -115,8 +115,8 @@ repositories {
 
 ```gradle
 dependencies {
-  debugImplementation 'com.github.chuckerteam.chucker:library:develop-SNAPSHOT'
-  releaseImplementation 'com.github.chuckerteam.chucker:library-no-op:develop-SNAPSHOT'
+  debugImplementation 'com.github.ChuckerTeam.Chucker:library:develop-SNAPSHOT'
+  releaseImplementation 'com.github.ChuckerTeam.Chucker:library-no-op:develop-SNAPSHOT'
 }
 ```
 


### PR DESCRIPTION
Looks like having the dependency coordinates all lowercase is not working.
Updating to use the one copy-pasted from Jitpack.