### PR TITLE
Add missing @JvmOverload on the ChuckerInterceptor

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -37,7 +37,7 @@ import com.chuckerteam.chucker.api.Chucker.LOG_TAG
  * results.
  * @param headersToRedact
  */
-class ChuckerInterceptor constructor(
+class ChuckerInterceptor @JvmOverloads constructor(
         private val context: Context,
         private val collector: ChuckerCollector = ChuckerCollector(context),
         private val maxContentLength : Long = 250000L,


### PR DESCRIPTION
This was causing the library being harder to use from Java,
as you would need to provide all the parameters to initialise a
ChuckerInterceptor.