### PR TITLE
Remove usage of methods from okhttp3.internal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         junitGradlePluignVersion = '1.3.1.1'
         junitVersion = '5.4.2'
         kotlinVersion = '1.3.31'
+        mockitoVersion = '2.28.2'
         okhttp3Version = '3.12.2'
         retrofitVersion = '2.5.0'
         roomVersion = '1.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         junitGradlePluignVersion = '1.3.1.1'
         junitVersion = '5.4.2'
         kotlinVersion = '1.3.31'
-        mockitoVersion = '2.28.2'
+        mockkVersion = '1.9.3'
         okhttp3Version = '3.12.2'
         retrofitVersion = '2.5.0'
         roomVersion = '1.1.1'

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -5,3 +5,17 @@ build:
     # LongParameterList: 1
     # style: 1
     # comments: 1
+
+complexity:
+  active: true
+  ComplexCondition:
+    active: true
+    threshold: 5
+
+style:
+  ReturnCount:
+    active: true
+    max: 5
+    excludedFunctions: "equals"
+    excludeLabeled: false
+    excludeReturnFromLambda: true

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
 
     implementation "android.arch.persistence.room:runtime:$roomVersion"
     kapt "android.arch.persistence.room:compiler:$roomVersion"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
 
     implementation "android.arch.persistence.room:runtime:$roomVersion"
     kapt "android.arch.persistence.room:compiler:$roomVersion"

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.chuckerteam.chucker.api.Chucker.LOG_TAG
 import com.chuckerteam.chucker.api.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.api.internal.support.IOUtils
+import com.chuckerteam.chucker.api.internal.support.hasBody
 import java.io.IOException
 import java.nio.charset.Charset
 import java.nio.charset.UnsupportedCharsetException
@@ -12,7 +13,6 @@ import java.util.concurrent.TimeUnit
 import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.Response
-import okhttp3.internal.http.HttpHeaders
 import okio.Buffer
 import okio.BufferedSource
 
@@ -106,7 +106,7 @@ class ChuckerInterceptor @JvmOverloads constructor(
         val responseEncodingIsSupported = io.bodyHasSupportedEncoding(response.headers().get("Content-Encoding"))
         transaction.isResponseBodyPlainText = responseEncodingIsSupported
 
-        if (HttpHeaders.hasBody(response) && responseEncodingIsSupported) {
+        if (response.hasBody() && responseEncodingIsSupported) {
             val source = getNativeSource(response)
             source.request(java.lang.Long.MAX_VALUE)
             val buffer = source.buffer()

--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/support/OkHttpUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/support/OkHttpUtils.kt
@@ -1,0 +1,40 @@
+@file:JvmName("OkHttpUtils")
+
+package com.chuckerteam.chucker.api.internal.support
+
+import java.net.HttpURLConnection.HTTP_NOT_MODIFIED
+import java.net.HttpURLConnection.HTTP_NO_CONTENT
+import java.net.HttpURLConnection.HTTP_OK
+import okhttp3.Response
+
+const val HTTP_CONTINUE = 100
+
+/** Returns true if the response must have a (possibly 0-length) body. See RFC 7231.  */
+fun Response.hasBody(): Boolean {
+    // HEAD requests never yield a body regardless of the response headers.
+    if (this.request().method() == "HEAD") {
+        return false
+    }
+
+    val responseCode = this.code()
+    if ((responseCode < HTTP_CONTINUE || responseCode >= HTTP_OK) &&
+        responseCode != HTTP_NO_CONTENT &&
+        responseCode != HTTP_NOT_MODIFIED
+    ) {
+        return true
+    }
+
+    // If the Content-Length or Transfer-Encoding headers disagree with the response code, the
+    // response is malformed. For best compatibility, we honor the headers.
+    return this.contentLenght != -1L || this.isChunked
+}
+
+val Response.contentLenght: Long
+    get() {
+        return this.header("Content-Length")?.toLongOrNull() ?: -1
+    }
+
+val Response.isChunked: Boolean
+    get() {
+        return this.header("Transfer-Encoding").equals("chunked", ignoreCase = true)
+    }

--- a/library/src/test/java/com/chuckerteam/chucker/api/internal/support/OkHttpUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/internal/support/OkHttpUtilsTest.kt
@@ -1,114 +1,121 @@
 package com.chuckerteam.chucker.api.internal.support
 
+import io.mockk.every
+import io.mockk.mockk
 import okhttp3.Request
 import okhttp3.Response
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.mockito.Mockito.`when` as whenever
-import org.mockito.Mockito.mock
 
 class OkHttpUtilsTest {
 
     @Test
     fun contentLength_withNoHeader_returnsInvalidValue() {
-        val mockResponse = mock(Response::class.java)
-        whenever(mockResponse.header("Content-Length")).thenReturn(null)
+        val mockResponse = mockk<Response>()
+        every { mockResponse.header("Content-Length") } returns null
 
         assertEquals(-1, mockResponse.contentLenght)
     }
 
     @Test
     fun contentLength_withZeroLenght_returnsZero() {
-        val mockResponse = mock(Response::class.java)
-        whenever(mockResponse.header("Content-Length")).thenReturn("0")
+        val mockResponse = mockk<Response>()
+        every { mockResponse.header("Content-Length") } returns "0"
 
         assertEquals(0L, mockResponse.contentLenght)
     }
 
     @Test
     fun contentLength_withRealLenght_returnsValue() {
-        val mockResponse = mock(Response::class.java)
-        whenever(mockResponse.header("Content-Length")).thenReturn("42")
+        val mockResponse = mockk<Response>()
+        every { mockResponse.header("Content-Length") } returns "42"
 
         assertEquals(42L, mockResponse.contentLenght)
     }
 
     @Test
     fun isChunked_withNotChunked() {
-        val mockResponse = mock(Response::class.java)
-        whenever(mockResponse.header("Transfer-Encoding")).thenReturn("gzip")
+        val mockResponse = mockk<Response>()
+        every { mockResponse.header("Transfer-Encoding") } returns "gzip"
 
-        assertEquals(false, mockResponse.isChunked)
+        assertFalse(mockResponse.isChunked)
     }
 
     @Test
     fun isChunked_withNoTransferEncoding() {
-        val mockResponse = mock(Response::class.java)
-        whenever(mockResponse.header("Content-Length")).thenReturn(null)
+        val mockResponse = mockk<Response>()
+        every { mockResponse.header("Content-Length") } returns null
+        every { mockResponse.header("Transfer-Encoding") } returns null
 
-        assertEquals(false, mockResponse.isChunked)
+        assertFalse(mockResponse.isChunked)
     }
 
     @Test
     fun isChunked_withChunked() {
-        val mockResponse = mock(Response::class.java)
-        whenever(mockResponse.header("Transfer-Encoding")).thenReturn("chunked")
+        val mockResponse = mockk<Response>()
+        every { mockResponse.header("Transfer-Encoding") } returns "chunked"
 
-        assertEquals(true, mockResponse.isChunked)
+        assertTrue(mockResponse.isChunked)
     }
 
     @Test
     fun hasBody_withHeadMethod() {
-        val mockResponse = mock(Response::class.java)
-        val mockRequest = mock(Request::class.java)
-        whenever(mockRequest.method()).thenReturn("HEAD")
-        whenever(mockResponse.request()).thenReturn(mockRequest)
+        val mockResponse = mockk<Response>()
+        val mockRequest = mockk<Request>()
+        every { mockRequest.method() } returns "HEAD"
+        every { mockResponse.request() } returns mockRequest
 
-        assertEquals(false, mockResponse.hasBody())
+        assertFalse(mockResponse.hasBody())
     }
 
     @Test
     fun hasBody_with404_hasBody() {
-        val mockResponse = mock(Response::class.java)
-        val mockRequest = mock(Request::class.java)
-        whenever(mockRequest.method()).thenReturn("")
-        whenever(mockResponse.request()).thenReturn(mockRequest)
-        whenever(mockResponse.code()).thenReturn(404)
+        val mockResponse = mockk<Response>()
+        val mockRequest = mockk<Request>()
+        every { mockRequest.method() } returns ""
+        every { mockResponse.request() } returns mockRequest
+        every { mockResponse.code() } returns 404
 
-        assertEquals(true, mockResponse.hasBody())
+        assertTrue(mockResponse.hasBody())
     }
 
     @Test
     fun hasBody_with204NoContent_doesNotHaveBody() {
-        val mockResponse = mock(Response::class.java)
-        val mockRequest = mock(Request::class.java)
-        whenever(mockRequest.method()).thenReturn("")
-        whenever(mockResponse.request()).thenReturn(mockRequest)
-        whenever(mockResponse.code()).thenReturn(204)
+        val mockResponse = mockk<Response>()
+        val mockRequest = mockk<Request>()
+        every { mockRequest.method() } returns ""
+        every { mockResponse.request() } returns mockRequest
+        every { mockResponse.code() } returns 204
+        every { mockResponse.header("Content-Length") } returns null
+        every { mockResponse.header("Transfer-Encoding") } returns null
 
-        assertEquals(false, mockResponse.hasBody())
+        assertFalse(mockResponse.hasBody())
     }
 
     @Test
     fun hasBody_with304NotModified_doesNotHaveBody() {
-        val mockResponse = mock(Response::class.java)
-        val mockRequest = mock(Request::class.java)
-        whenever(mockRequest.method()).thenReturn("")
-        whenever(mockResponse.request()).thenReturn(mockRequest)
-        whenever(mockResponse.code()).thenReturn(304)
+        val mockResponse = mockk<Response>()
+        val mockRequest = mockk<Request>()
+        every { mockRequest.method() } returns ""
+        every { mockResponse.request() } returns mockRequest
+        every { mockResponse.code() } returns 304
+        every { mockResponse.header("Content-Length") } returns null
+        every { mockResponse.header("Transfer-Encoding") } returns null
 
-        assertEquals(false, mockResponse.hasBody())
+        assertFalse(mockResponse.hasBody())
     }
 
     @Test
     fun hasBody_withMalformedRequest_doesHaveBody() {
-        val mockResponse = mock(Response::class.java)
-        val mockRequest = mock(Request::class.java)
-        whenever(mockRequest.method()).thenReturn("")
-        whenever(mockResponse.request()).thenReturn(mockRequest)
-        whenever(mockResponse.code()).thenReturn(304)
-        whenever(mockResponse.header("Content-Length")).thenReturn("42")
+        val mockResponse = mockk<Response>()
+        val mockRequest = mockk<Request>()
+        every { mockRequest.method() } returns ""
+        every { mockResponse.request() } returns mockRequest
+        every { mockResponse.code() } returns 304
+        every { mockResponse.header("Content-Length") } returns "42"
 
-        assertEquals(true, mockResponse.hasBody())
+        assertTrue(mockResponse.hasBody())
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/api/internal/support/OkHttpUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/internal/support/OkHttpUtilsTest.kt
@@ -1,0 +1,114 @@
+package com.chuckerteam.chucker.api.internal.support
+
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when` as whenever
+import org.mockito.Mockito.mock
+
+class OkHttpUtilsTest {
+
+    @Test
+    fun contentLength_withNoHeader_returnsInvalidValue() {
+        val mockResponse = mock(Response::class.java)
+        whenever(mockResponse.header("Content-Length")).thenReturn(null)
+
+        assertEquals(-1, mockResponse.contentLenght)
+    }
+
+    @Test
+    fun contentLength_withZeroLenght_returnsZero() {
+        val mockResponse = mock(Response::class.java)
+        whenever(mockResponse.header("Content-Length")).thenReturn("0")
+
+        assertEquals(0L, mockResponse.contentLenght)
+    }
+
+    @Test
+    fun contentLength_withRealLenght_returnsValue() {
+        val mockResponse = mock(Response::class.java)
+        whenever(mockResponse.header("Content-Length")).thenReturn("42")
+
+        assertEquals(42L, mockResponse.contentLenght)
+    }
+
+    @Test
+    fun isChunked_withNotChunked() {
+        val mockResponse = mock(Response::class.java)
+        whenever(mockResponse.header("Transfer-Encoding")).thenReturn("gzip")
+
+        assertEquals(false, mockResponse.isChunked)
+    }
+
+    @Test
+    fun isChunked_withNoTransferEncoding() {
+        val mockResponse = mock(Response::class.java)
+        whenever(mockResponse.header("Content-Length")).thenReturn(null)
+
+        assertEquals(false, mockResponse.isChunked)
+    }
+
+    @Test
+    fun isChunked_withChunked() {
+        val mockResponse = mock(Response::class.java)
+        whenever(mockResponse.header("Transfer-Encoding")).thenReturn("chunked")
+
+        assertEquals(true, mockResponse.isChunked)
+    }
+
+    @Test
+    fun hasBody_withHeadMethod() {
+        val mockResponse = mock(Response::class.java)
+        val mockRequest = mock(Request::class.java)
+        whenever(mockRequest.method()).thenReturn("HEAD")
+        whenever(mockResponse.request()).thenReturn(mockRequest)
+
+        assertEquals(false, mockResponse.hasBody())
+    }
+
+    @Test
+    fun hasBody_with404_hasBody() {
+        val mockResponse = mock(Response::class.java)
+        val mockRequest = mock(Request::class.java)
+        whenever(mockRequest.method()).thenReturn("")
+        whenever(mockResponse.request()).thenReturn(mockRequest)
+        whenever(mockResponse.code()).thenReturn(404)
+
+        assertEquals(true, mockResponse.hasBody())
+    }
+
+    @Test
+    fun hasBody_with204NoContent_doesNotHaveBody() {
+        val mockResponse = mock(Response::class.java)
+        val mockRequest = mock(Request::class.java)
+        whenever(mockRequest.method()).thenReturn("")
+        whenever(mockResponse.request()).thenReturn(mockRequest)
+        whenever(mockResponse.code()).thenReturn(204)
+
+        assertEquals(false, mockResponse.hasBody())
+    }
+
+    @Test
+    fun hasBody_with304NotModified_doesNotHaveBody() {
+        val mockResponse = mock(Response::class.java)
+        val mockRequest = mock(Request::class.java)
+        whenever(mockRequest.method()).thenReturn("")
+        whenever(mockResponse.request()).thenReturn(mockRequest)
+        whenever(mockResponse.code()).thenReturn(304)
+
+        assertEquals(false, mockResponse.hasBody())
+    }
+
+    @Test
+    fun hasBody_withMalformedRequest_doesHaveBody() {
+        val mockResponse = mock(Response::class.java)
+        val mockRequest = mock(Request::class.java)
+        whenever(mockRequest.method()).thenReturn("")
+        whenever(mockResponse.request()).thenReturn(mockRequest)
+        whenever(mockResponse.code()).thenReturn(304)
+        whenever(mockResponse.header("Content-Length")).thenReturn("42")
+
+        assertEquals(true, mockResponse.hasBody())
+    }
+}

--- a/library/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/library/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/library/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/library/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Chucker was using one methods from the aforementioned package.
Those methods are risky to use as they may be broken between releases
and I'm cleaning them up.

Specifically the method `hasBody` has now been moved to an extension
function inside our internal package. This will make easier to migrate
to OkHttp 4.x as the above method has been removed.

Fixes #52

Thanks @ZacSweers for the report <3