### PR TITLE
LeakCanary memory leak report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         gsonVersion = '2.8.5'
         junitGradlePluignVersion = '1.3.1.1'
         junitVersion = '5.4.2'
+        leakcanary = "1.6.3"
         kotlinVersion = '1.3.41'
         mockkVersion = '1.9.3'
         okhttp3Version = '3.12.2'

--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/HomePageAdapter.java
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/HomePageAdapter.java
@@ -9,6 +9,8 @@ import com.chuckerteam.chucker.R;
 import com.chuckerteam.chucker.api.internal.ui.error.ErrorListFragment;
 import com.chuckerteam.chucker.api.internal.ui.transaction.TransactionListFragment;
 
+import java.lang.ref.WeakReference;
+
 /**
  * @author Olivier Perez
  */
@@ -17,11 +19,11 @@ class HomePageAdapter extends FragmentPagerAdapter {
     static final int SCREEN_HTTP_INDEX = 0;
     static final int SCREEN_ERROR_INDEX = 1;
 
-    private final Context context;
+    private final WeakReference<Context> context;
 
      HomePageAdapter(Context context, FragmentManager fragmentManager) {
         super(fragmentManager);
-        this.context = context;
+        this.context = new WeakReference<>(context);
     }
 
     @Override
@@ -40,6 +42,10 @@ class HomePageAdapter extends FragmentPagerAdapter {
 
     @Override
     public CharSequence getPageTitle(int position) {
+        Context context = this.context.get();
+        if (context == null) {
+            return null;
+        }
         if (position == SCREEN_HTTP_INDEX) {
             return context.getString(R.string.chucker_tab_network);
         } else {

--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/transaction/TransactionActivity.java
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/transaction/TransactionActivity.java
@@ -53,7 +53,7 @@ public class TransactionActivity extends BaseChuckerActivity {
     }
 
     TextView title;
-    Adapter adapter;
+    PagerAdapter adapter;
 
     private long transactionId;
     private HttpTransaction transaction;
@@ -127,7 +127,7 @@ public class TransactionActivity extends BaseChuckerActivity {
     }
 
     private void setupViewPager(ViewPager viewPager) {
-        adapter = new Adapter(getApplicationContext(), getSupportFragmentManager());
+        adapter = new PagerAdapter(getApplicationContext(), getSupportFragmentManager());
         viewPager.setAdapter(adapter);
         viewPager.addOnPageChangeListener(new SimpleOnPageChangedListener() {
             @Override
@@ -147,15 +147,15 @@ public class TransactionActivity extends BaseChuckerActivity {
         startActivity(Intent.createChooser(sendIntent, null));
     }
 
-    static class Adapter extends FragmentStatePagerAdapter {
+    class PagerAdapter extends FragmentStatePagerAdapter {
         private final WeakReference<Context> context;
-        private static final int[] TITLE_RES_IDS = {
+        private final int[] TITLE_RES_IDS = {
                 R.string.chucker_overview,
                 R.string.chucker_request,
                 R.string.chucker_response
         };
 
-        Adapter(Context context, FragmentManager fm) {
+        PagerAdapter(Context context, FragmentManager fm) {
             super(fm);
             this.context = new WeakReference<>(context);
         }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp3Version"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakcanary"
+    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakcanary"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".SampleApplication"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/SampleApplication.java
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/SampleApplication.java
@@ -1,0 +1,21 @@
+package com.chuckerteam.chucker.sample;
+
+import android.app.Application;
+
+import com.squareup.leakcanary.LeakCanary;
+
+public class SampleApplication extends Application {
+    @Override public void onCreate() {
+        super.onCreate();
+        initLeakCanary();
+    }
+
+    private void initLeakCanary() {
+        if (LeakCanary.isInAnalyzerProcess(this)) {
+            // This process is dedicated to LeakCanary for heap analysis.
+            // You should not init your app in this process.
+            return;
+        }
+        LeakCanary.install(this);
+    }
+}


### PR DESCRIPTION
- AndroidX migration

- [LeakCanary](https://github.com/square/leakcanary) reports some memory leaks on Transaction*Fragment's adapter. I think the cause is that viewpager adapter holds child fragment's reference in arraylist. So I've changed some codes.
