### PR TITLE
Prepare 3.0.0-alpha2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=3.0.0-alpha1
+VERSION_NAME=3.0.0-alpha2
 # 3*100*100 + 0*100 + 0 => 30000
 VERSION_CODE=30000
 GROUP=com.github.chuckerteam.chucker


### PR DESCRIPTION
Bumping the version to `-alpha2` so users can benefit of the OkHttp4 fixes