### PR TITLE
Fix crash when clicking notification

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/data/repository/RepositoryProvider.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/data/repository/RepositoryProvider.kt
@@ -1,6 +1,7 @@
 package com.chuckerteam.chucker.api.internal.data.repository
 
 import android.content.Context
+import com.chuckerteam.chucker.api.internal.data.repository.RepositoryProvider.initialize
 import com.chuckerteam.chucker.api.internal.data.room.ChuckerDatabase
 
 /**
@@ -24,9 +25,15 @@ internal object RepositoryProvider {
         }
     }
 
-    @JvmStatic fun initialize(context: Context) {
-        val db = ChuckerDatabase.create(context)
-        transactionRepository = HttpTransactionDatabaseRepository(db)
-        throwableRepository = RecordedThrowableDatabaseRepository(db)
+    /**
+     * Idempotent method. Must be called before accessing the repositories.
+     */
+    @JvmStatic
+    fun initialize(context: Context) {
+        if (transactionRepository == null || throwableRepository == null) {
+            val db = ChuckerDatabase.create(context)
+            transactionRepository = HttpTransactionDatabaseRepository(db)
+            throwableRepository = RecordedThrowableDatabaseRepository(db)
+        }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/BaseChuckerActivity.java
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/BaseChuckerActivity.java
@@ -15,7 +15,11 @@
  */
 package com.chuckerteam.chucker.api.internal.ui;
 
+import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+
+import com.chuckerteam.chucker.api.internal.data.repository.RepositoryProvider;
 
 public abstract class BaseChuckerActivity extends AppCompatActivity {
 
@@ -23,6 +27,12 @@ public abstract class BaseChuckerActivity extends AppCompatActivity {
 
     public static boolean isInForeground() {
         return inForeground;
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        RepositoryProvider.initialize(this);
     }
 
     @Override
@@ -36,5 +46,4 @@ public abstract class BaseChuckerActivity extends AppCompatActivity {
         super.onPause();
         inForeground = false;
     }
-
 }


### PR DESCRIPTION
Clicking the notification after the app would have been closed or killed would trigger a crash because the repositories were only initialized when creating the Intercaptor.
Fixes #68