### PR TITLE
Fix application name retrieval.

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/MainActivity.java
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/MainActivity.java
@@ -84,10 +84,9 @@ public class MainActivity extends BaseChuckerActivity implements TransactionAdap
         }
     }
 
-    private String getApplicationName() {
+    private CharSequence getApplicationName() {
         ApplicationInfo applicationInfo = getApplicationInfo();
-        int stringId = applicationInfo.labelRes;
-        return stringId == 0 ? applicationInfo.nonLocalizedLabel.toString() : getString(stringId);
+        return applicationInfo.loadLabel(getPackageManager());
     }
 
     @Override


### PR DESCRIPTION
Change manual checks to `ApplicationInfo#loadLabel()` call.
Remove unnecessary conversion to String.
Fixes #73 