### PR TITLE
Fix image being loaded twice for request and response

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/data/entity/HttpTransaction.kt
@@ -6,6 +6,8 @@ import android.arch.persistence.room.ColumnInfo
 import android.arch.persistence.room.Entity
 import android.arch.persistence.room.Ignore
 import android.arch.persistence.room.PrimaryKey
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.net.Uri
 import com.chuckerteam.chucker.api.internal.support.FormatUtils
 import com.chuckerteam.chucker.api.internal.support.JsonConvertor
@@ -126,6 +128,13 @@ internal class HttpTransaction(
 
     val isSsl: Boolean
         get() = scheme?.toLowerCase() == "https"
+
+    val responseImageBitmap: Bitmap?
+        get() {
+            return responseImageData?.let {
+                BitmapFactory.decodeByteArray(it, 0, it.size)
+            }
+        }
 
     fun setRequestHeaders(headers: Headers) {
         setRequestHeaders(toHttpHeaderList(headers))

--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -16,7 +16,6 @@
 package com.chuckerteam.chucker.api.internal.ui.transaction
 
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import android.os.AsyncTask
 import android.os.Bundle
 import android.support.v4.app.Fragment
@@ -135,11 +134,6 @@ internal class TransactionPayloadFragment : Fragment(), TransactionFragment, Sea
         override fun doInBackground(vararg params: Pair<Int, HttpTransaction>):
         UiPayload {
             val (type, transaction) = params[0]
-
-            val responseImageBitmap = transaction.responseImageData?.let { imageData ->
-                BitmapFactory.decodeByteArray(imageData, 0, imageData.size)
-            }
-
             return when (type) {
                 TYPE_REQUEST -> UiPayload(
                     transaction.getRequestHeadersString(true),
@@ -150,7 +144,7 @@ internal class TransactionPayloadFragment : Fragment(), TransactionFragment, Sea
                     transaction.getResponseHeadersString(true),
                     transaction.getFormattedResponseBody(),
                     transaction.isResponseBodyPlainText,
-                    responseImageBitmap
+                    transaction.responseImageBitmap
                 )
             }
         }

--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -136,7 +136,7 @@ internal class TransactionPayloadFragment : Fragment(), TransactionFragment, Sea
         UiPayload {
             val (type, transaction) = params[0]
 
-            val bitmap = transaction.responseImageData?.let { imageData ->
+            val responseImageBitmap = transaction.responseImageData?.let { imageData ->
                 BitmapFactory.decodeByteArray(imageData, 0, imageData.size)
             }
 
@@ -144,14 +144,13 @@ internal class TransactionPayloadFragment : Fragment(), TransactionFragment, Sea
                 TYPE_REQUEST -> UiPayload(
                     transaction.getRequestHeadersString(true),
                     transaction.getFormattedRequestBody(),
-                    transaction.isRequestBodyPlainText,
-                    bitmap
+                    transaction.isRequestBodyPlainText
                 )
                 else -> UiPayload(
                     transaction.getResponseHeadersString(true),
                     transaction.getFormattedResponseBody(),
                     transaction.isResponseBodyPlainText,
-                    bitmap
+                    responseImageBitmap
                 )
             }
         }
@@ -167,7 +166,7 @@ internal class TransactionPayloadFragment : Fragment(), TransactionFragment, Sea
         val headersString: String,
         val bodyString: String?,
         val isPlainText: Boolean,
-        val image: Bitmap?
+        val image: Bitmap? = null
     )
 
     companion object {


### PR DESCRIPTION
Apparently #72 and #67 interacted in a way that created a bug in image parsing.
The response image is loaded now both for request and response. It should be loaded only for the response:

| Request | Response |
| -- | -- |
| ![Screenshot_1565253248](https://user-images.githubusercontent.com/3001957/62688517-4f35c600-b9c9-11e9-8c4d-7a551a6d743a.png) | ![Screenshot_1565253250](https://user-images.githubusercontent.com/3001957/62688521-51982000-b9c9-11e9-8f7d-1225a748e8f6.png) |