### PR TITLE
Fix for null values being omitted in the parsed body

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/internal/support/JsonConvertor.java
+++ b/library/src/main/java/com/chuckerteam/chucker/api/internal/support/JsonConvertor.java
@@ -32,6 +32,7 @@ public class JsonConvertor {
     public static Gson getInstance() {
         if (gson == null) {
             gson = new GsonBuilder()
+                    .serializeNulls()
                     .setPrettyPrinting()
                     .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                     .registerTypeAdapter(Date.class, new DateTypeAdapter())

--- a/library/src/test/java/com/chuckerteam/chucker/api/internal/support/FormatUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/internal/support/FormatUtilsTest.kt
@@ -1,0 +1,64 @@
+package com.chuckerteam.chucker.api.internal.support
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FormatUtilsTest {
+
+    @Test
+    fun testFormatJson_withNullValues() {
+        val parsedJson = FormatUtils.formatJson(
+            """
+            {
+              "field": null
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(
+            """
+            {
+              "field": null
+            }
+            """.trimIndent(),
+            parsedJson
+        )
+    }
+
+    @Test
+    fun testFormatJson_withEmptyValues() {
+        val parsedJson = FormatUtils.formatJson(
+            """
+            {
+              "field": ""
+            }
+            """.trimIndent()
+        )
+
+        assertEquals(
+            """
+            {
+              "field": ""
+            }
+            """.trimIndent(),
+            parsedJson
+        )
+    }
+
+    @Test
+    fun testFormatJson_willPrettyPrint() {
+        val parsedJson = FormatUtils.formatJson(
+            """{ "field1": "something", "field2": "else" }"""
+        )
+
+        assertEquals(
+            """
+            {
+              "field1": "something",
+              "field2": "else"
+            }
+            """.trimIndent(),
+            parsedJson
+        )
+    }
+}


### PR DESCRIPTION
Looks like when we're parsing the JSON body for pretty printing we're actually omitting nulls.
This PR fixes this plus I've attached some JUnit tests to make sure all works fine.

Fixes #80