### PR TITLE
Add positions to string formatting placeholders

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="chucker_tab_errors">Errors</string>
     <string name="chucker_notification_category">Chucker notifications</string>
     <string name="chucker_share_error_title">Error report</string>
-    <string name="chucker_share_error_content"><![CDATA[Date: %s\nException: %s\nTag: %s\nMessage: %s\n\n%s]]></string>
+    <string name="chucker_share_error_content"><![CDATA[Date: %1$s\nException: %2$s\nTag: %3$s\nMessage: %4$s\n\n%5$s]]></string>
     <string name="chucker_clear_http_confirmation">Do you want to clear complete network calls history?</string>
     <string name="chucker_clear_error_confirmation">Do you want to clear complete errors history?</string>
 </resources>


### PR DESCRIPTION
Fixes lint warning `warn: multiple substitutions specified in non-positional format; did you mean to add the formatted="false" attribute?.`
This warning is also propagated to app using Chucker.