### PR TITLE
Fixed typo in the Chucker Gradle implementation string

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ repositories {
 ```groovy
 dependencies {
   debugImplementation "com.github.ChuckerTeam.Chucker:library:3.0.0"
-  releaseImplementation "com.github.ChuckerTeam.chucker:library-no-op:3.0.0"
+  releaseImplementation "com.github.ChuckerTeam.Chucker:library-no-op:3.0.0"
 }
 ```
 


### PR DESCRIPTION
One of the two dependency was lowercase, I'm fixing it.