### PR TITLE
Prepare 3.0.1 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This is a hotfix release for Chucker `3.0.0`.
 
 * Fix: [#96] Limit size of binary image to 1 million bytes.
 
+**Contributors**
+
+This release was possible thanks to the contribution of: @redwarp
+
 
 Version 3.0.0 *(2019-08-12)*
 ----------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Change Log
 ==========
 
+Version 3.0.1 *(2019-08-16)*
+----------------------------
+
+This is a hotfix release for Chucker `3.0.0`.
+
+**Summary of Changes**
+
+* Fix: [#96] Limit size of binary image to 1 million bytes.
+
+
 Version 3.0.0 *(2019-08-12)*
 ----------------------------
 
@@ -183,3 +193,4 @@ Initial release.
 [#81]: https://github.com/ChuckerTeam/chucker/pull/81
 [#86]: https://github.com/ChuckerTeam/chucker/pull/86
 [#87]: https://github.com/ChuckerTeam/chucker/pull/87
+[#96]: https://github.com/ChuckerTeam/chucker/pull/96

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ repositories {
 
 ```groovy
 dependencies {
-  debugImplementation "com.github.ChuckerTeam.Chucker:library:3.0.0"
-  releaseImplementation "com.github.ChuckerTeam.Chucker:library-no-op:3.0.0"
+  debugImplementation "com.github.ChuckerTeam.Chucker:library:3.0.1"
+  releaseImplementation "com.github.ChuckerTeam.Chucker:library-no-op:3.0.1"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,9 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=3.0.0
-# 3*100*100 + 0*100 + 0 => 30000
-VERSION_CODE=30000
+VERSION_NAME=3.0.1
+# 3*100*100 + 0*100 + 1 => 30001
+VERSION_CODE=30001
 GROUP=com.github.chuckerteam.chucker
 
 POM_REPO_NAME=Chucker


### PR DESCRIPTION
Since we had a regression on `3.0.0` related to images being bigger than 1Mb, it's probably worth to do a point release here.