### PR TITLE
Detekt to 1.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         classpath "de.mannodermaus.gradle.plugins:android-junit5:$junitGradlePluignVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokkaVersion"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0-RC14"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.1"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:8.0.0"
     }
 }

--- a/gradle/kotlin-static-analysis.gradle
+++ b/gradle/kotlin-static-analysis.gradle
@@ -19,7 +19,7 @@ ktlint {
 }
 
 detekt {
-    toolVersion = "1.0.0-RC14"
+    toolVersion = "1.0.1"
     config = files("../detekt-config.yml")
     buildUponDefaultConfig = true
     filters = ".*/resources/.*,.*/build/.*"

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -17,9 +17,15 @@ object Chucker {
         return Intent()
     }
 
-    @JvmStatic fun registerDefaultCrashHandler(collector: ChuckerCollector) {}
+    @JvmStatic fun registerDefaultCrashHandler(collector: ChuckerCollector) {
+        // Empty method for the library-no-op artifact
+    }
 
-    @JvmStatic fun dismissTransactionsNotification(context: Context) {}
+    @JvmStatic fun dismissTransactionsNotification(context: Context) {
+        // Empty method for the library-no-op artifact
+    }
 
-    @JvmStatic fun dismissErrorsNotification(context: Context) {}
+    @JvmStatic fun dismissErrorsNotification(context: Context) {
+        // Empty method for the library-no-op artifact
+    }
 }

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -11,5 +11,7 @@ class ChuckerCollector @JvmOverloads constructor(
     var retentionPeriod: RetentionManager.Period = RetentionManager.Period.ONE_WEEK
 ) {
 
-    fun onError(obj: Any?, obj2: Any?) {}
+    fun onError(obj: Any?, obj2: Any?) {
+        // Empty method for the library-no-op artifact
+    }
 }

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
@@ -12,6 +12,7 @@ class RetentionManager @JvmOverloads constructor(
 
     @Synchronized
     fun doMaintenance() {
+        // Empty method for the library-no-op artifact
     }
 
     enum class Period {

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -62,7 +62,9 @@ class MainActivity : AppCompatActivity() {
 
     private fun doHttpActivity() {
         val cb = object : Callback<Void> {
-            override fun onResponse(call: Call<Void>, response: Response<Void>) {}
+            override fun onResponse(call: Call<Void>, response: Response<Void>) {
+                // no-op
+            }
             override fun onFailure(call: Call<Void>, t: Throwable) { t.printStackTrace() }
         }
 


### PR DESCRIPTION
Given that detekt is now at stable and at `1.0.1`, makes sense to keep it up to date.