### PR TITLE
Display explanation text on tabs if empty

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorListFragment.java
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorListFragment.java
@@ -3,12 +3,14 @@ package com.chuckerteam.chucker.internal.ui.error;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -23,12 +25,15 @@ import com.chuckerteam.chucker.R;
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple;
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.List;
 
 public class ErrorListFragment extends Fragment {
 
     private ErrorAdapter adapter;
     private ErrorAdapter.ErrorClickListListener listener;
+    private View tutorialView;
 
     public static Fragment newInstance() {
         return new ErrorListFragment();
@@ -41,7 +46,7 @@ public class ErrorListFragment extends Fragment {
     }
 
     @Override
-    public void onAttach(Context context) {
+    public void onAttach(@NotNull Context context) {
         super.onAttach(context);
         if (context instanceof ErrorAdapter.ErrorClickListListener) {
             listener = (ErrorAdapter.ErrorClickListListener) context;
@@ -52,6 +57,11 @@ public class ErrorListFragment extends Fragment {
             @Override
             public void onChanged(@Nullable List<RecordedThrowableTuple> tuples) {
                 adapter.setData(tuples);
+                if (tuples == null || tuples.size() == 0) {
+                    tutorialView.setVisibility(View.VISIBLE);
+                } else {
+                    tutorialView.setVisibility(View.GONE);
+                }
             }
         });
     }
@@ -60,14 +70,14 @@ public class ErrorListFragment extends Fragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.chucker_fragment_error_list, container, false);
+        tutorialView = view.findViewById(R.id.tutorial);
+        view.<TextView>findViewById(R.id.link).setMovementMethod(LinkMovementMethod.getInstance());
 
-        if (view instanceof RecyclerView) {
-            RecyclerView recyclerView = (RecyclerView) view;
-            recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
-            recyclerView.addItemDecoration(new DividerItemDecoration(getContext(), DividerItemDecoration.VERTICAL));
-            adapter = new ErrorAdapter(getContext(), listener);
-            recyclerView.setAdapter(adapter);
-        }
+        RecyclerView recyclerView = view.findViewById(R.id.list);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
+        recyclerView.addItemDecoration(new DividerItemDecoration(getContext(), DividerItemDecoration.VERTICAL));
+        adapter = new ErrorAdapter(getContext(), listener);
+        recyclerView.setAdapter(adapter);
 
         return view;
     }

--- a/library/src/main/res/layout/chucker_fragment_error_list.xml
+++ b/library/src/main/res/layout/chucker_fragment_error_list.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  ~ Copyright (C) 2017 Jeff Gilfelt.
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +13,48 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  -->
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/list"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:scrollbars="vertical"
-    app:layoutManager="LinearLayoutManager"
-    tools:listitem="@layout/chucker_list_item_error" />
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="vertical"
+        app:layoutManager="LinearLayoutManager"
+        tools:listitem="@layout/chucker_list_item_error" />
+
+    <LinearLayout
+        android:id="@+id/tutorial"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="@dimen/chucker_doub_grid"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <TextView
+            style="@style/Chucker.TextAppearance.ListItem"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/chucker_setup" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/chucker_base_grid"
+            android:gravity="center_vertical"
+            android:text="@string/chucker_errors_tutorial" />
+
+        <TextView
+            android:id="@+id/link"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/chucker_base_grid"
+            android:gravity="center_vertical"
+            android:text="@string/chucker_check_readme" />
+    </LinearLayout>
+</FrameLayout>

--- a/library/src/main/res/layout/chucker_fragment_transaction_list.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_list.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  ~ Copyright (C) 2017 Jeff Gilfelt.
  ~
  ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +13,49 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  -->
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/list"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:scrollbars="vertical"
-    app:layoutManager="LinearLayoutManager"
-    tools:context="com.chuckerteam.chucker.internal.ui.transaction.TransactionListFragment"
-    tools:listitem="@layout/chucker_list_item_transaction" />
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="vertical"
+        app:layoutManager="LinearLayoutManager"
+        tools:context="com.chuckerteam.chucker.internal.ui.transaction.TransactionListFragment"
+        tools:listitem="@layout/chucker_list_item_transaction" />
+
+    <LinearLayout
+        android:id="@+id/tutorial"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="@dimen/chucker_doub_grid"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <TextView
+            style="@style/Chucker.TextAppearance.ListItem"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/chucker_setup" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/chucker_base_grid"
+            android:gravity="center_vertical"
+            android:text="@string/chucker_network_tutorial" />
+
+        <TextView
+            android:id="@+id/link"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/chucker_base_grid"
+            android:gravity="center_vertical"
+            android:text="@string/chucker_check_readme" />
+    </LinearLayout>
+</FrameLayout>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -44,9 +44,13 @@
     <string name="chucker_body_content_truncated">\n\n--- Content truncated ---</string>
     <string name="chucker_tab_network">Network</string>
     <string name="chucker_tab_errors">Errors</string>
+    <string name="chucker_network_tutorial">This tab displays network requests recorded with the ChuckerInterceptor. Add the interceptor to your OkHttp client to reap the benefits.</string>
+    <string name="chucker_errors_tutorial">This tab displays error recorded with the ChuckerCollector.onError method. Call this method when an error is thrown to check your stacktrace live.</string>
     <string name="chucker_notification_category">Chucker notifications</string>
     <string name="chucker_share_error_title">Error report</string>
     <string name="chucker_share_error_content"><![CDATA[Date: %1$s\nException: %2$s\nTag: %3$s\nMessage: %4$s\n\n%5$s]]></string>
     <string name="chucker_clear_http_confirmation">Do you want to clear complete network calls history?</string>
     <string name="chucker_clear_error_confirmation">Do you want to clear complete errors history?</string>
+    <string name="chucker_check_readme"><a href="https://github.com/ChuckerTeam/chucker/blob/develop/README.md#configure-">Check the setup instructions on GitHub</a></string>
+    <string name="chucker_setup">Setup</string>
 </resources>


### PR DESCRIPTION
When the network tab or errors tab is empty, will display a short explanation tab and a direct link to the chucker README file.
Fixes #106

![Screenshot_1568896807](https://user-images.githubusercontent.com/1741661/65244705-6fd65d00-daeb-11e9-91e9-4f144442eceb.png)
![Screenshot_1568896814](https://user-images.githubusercontent.com/1741661/65244706-6fd65d00-daeb-11e9-8deb-c4884d5be9a5.png)