### PR TITLE
Fix inconsistency when referencing screen constants from Java

### DIFF
--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -8,8 +8,8 @@ import android.content.Intent
  */
 object Chucker {
 
-    val SCREEN_HTTP = 1
-    val SCREEN_ERROR = 2
+    const val SCREEN_HTTP = 1
+    const val SCREEN_ERROR = 2
 
     val isOp = false
 


### PR DESCRIPTION
Java Apps references the SCREEN_HTTP/SCREEN_ERROR constants differently when the const keyword is added/removed
This fixes the inconsistency between library and library-no-op