### PR TITLE
Unification for activities start

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -82,7 +82,7 @@ class MainActivity :
     }
 
     override fun onErrorClick(throwableId: Long, position: Int) {
-        startActivity(ErrorActivity.newInstance(this, throwableId))
+        ErrorActivity.start(this, throwableId)
     }
 
     override fun onTransactionClick(transactionId: Long, position: Int) {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
@@ -15,8 +15,6 @@ import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import java.text.DateFormat
 
-private const val TEXT_PLAIN = "text/plain"
-
 internal class ErrorActivity : AppCompatActivity() {
 
     private var throwableId: Long = 0
@@ -105,6 +103,7 @@ internal class ErrorActivity : AppCompatActivity() {
 
     companion object {
         private const val EXTRA_THROWABLE_ID = "transaction_id"
+        private const val TEXT_PLAIN = "text/plain"
 
         fun start(context: Context, throwableId: Long) {
             val intent = Intent(context, ErrorActivity::class.java)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
@@ -15,7 +15,6 @@ import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import java.text.DateFormat
 
-private const val EXTRA_THROWABLE_ID = "EXTRA_THROWABLE_ID"
 private const val TEXT_PLAIN = "text/plain"
 
 internal class ErrorActivity : AppCompatActivity() {
@@ -105,11 +104,13 @@ internal class ErrorActivity : AppCompatActivity() {
     }
 
     companion object {
-        @JvmStatic
-        fun newInstance(context: Context, throwableId: Long) =
-            Intent(context, ErrorActivity::class.java).apply {
-                putExtra(EXTRA_THROWABLE_ID, throwableId)
-            }
+        private const val EXTRA_THROWABLE_ID = "transaction_id"
+
+        fun start(context: Context, throwableId: Long) {
+            val intent = Intent(context, ErrorActivity::class.java)
+            intent.putExtra(EXTRA_THROWABLE_ID, throwableId)
+            context.startActivity(intent)
+        }
     }
 
     private val RecordedThrowable.formattedDate: String

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -40,6 +40,7 @@ internal class TransactionActivity : BaseChuckerActivity() {
     private lateinit var title: TextView
     private lateinit var adapter: PagerAdapter
 
+    private var selectedTabPosition = 0
     private var transactionId: Long = 0
     private var transaction: HttpTransaction? = null
 
@@ -61,7 +62,7 @@ internal class TransactionActivity : BaseChuckerActivity() {
         val tabLayout = findViewById<TabLayout>(R.id.tabs)
         tabLayout.setupWithViewPager(viewPager)
 
-        transactionId = intent.getLongExtra(ARG_TRANSACTION_ID, 0)
+        transactionId = intent.getLongExtra(EXTRA_TRANSACTION_ID, 0)
     }
 
     override fun onResume() {
@@ -149,14 +150,11 @@ internal class TransactionActivity : BaseChuckerActivity() {
     }
 
     companion object {
+        private const val EXTRA_TRANSACTION_ID = "transaction_id"
 
-        private const val ARG_TRANSACTION_ID = "transaction_id"
-        private var selectedTabPosition = 0
-
-        @JvmStatic
         fun start(context: Context, transactionId: Long) {
             val intent = Intent(context, TransactionActivity::class.java)
-            intent.putExtra(ARG_TRANSACTION_ID, transactionId)
+            intent.putExtra(EXTRA_TRANSACTION_ID, transactionId)
             context.startActivity(intent)
         }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -40,7 +40,6 @@ internal class TransactionActivity : BaseChuckerActivity() {
     private lateinit var title: TextView
     private lateinit var adapter: PagerAdapter
 
-    private var selectedTabPosition = 0
     private var transactionId: Long = 0
     private var transaction: HttpTransaction? = null
 
@@ -151,6 +150,7 @@ internal class TransactionActivity : BaseChuckerActivity() {
 
     companion object {
         private const val EXTRA_TRANSACTION_ID = "transaction_id"
+        private var selectedTabPosition = 0
 
         fun start(context: Context, transactionId: Long) {
             val intent = Intent(context, TransactionActivity::class.java)


### PR DESCRIPTION
Minor set of changes to make a unified way of how `TransactionActivity` and `ErrorActivity` start, since after recent merges these operations looked quite different.
