### PR TITLE
Fix notification importance for Android Q

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.java
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.java
@@ -79,7 +79,7 @@ public class NotificationHelper {
             notificationManager.createNotificationChannel(
                     new NotificationChannel(CHANNEL_ID,
                             context.getString(R.string.chucker_notification_category),
-                            NotificationManager.IMPORTANCE_LOW));
+                            NotificationManager.IMPORTANCE_DEFAULT));
         }
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -23,9 +23,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentStatePagerAdapter
 import androidx.lifecycle.Observer
 import androidx.viewpager.widget.ViewPager
 import com.chuckerteam.chucker.R

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPagerAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPagerAdapter.kt
@@ -8,14 +8,14 @@ import com.chuckerteam.chucker.R
 import java.lang.ref.WeakReference
 
 internal class TransactionPagerAdapter(context: Context, fm: FragmentManager) :
-        FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+    FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 
     private val context: WeakReference<Context> = WeakReference(context)
 
     private val titleResIds = intArrayOf(
-            R.string.chucker_overview,
-            R.string.chucker_request,
-            R.string.chucker_response
+        R.string.chucker_overview,
+        R.string.chucker_request,
+        R.string.chucker_response
     )
 
     override fun getItem(position: Int): Fragment = when (position) {
@@ -28,5 +28,5 @@ internal class TransactionPagerAdapter(context: Context, fm: FragmentManager) :
     override fun getCount(): Int = titleResIds.size
 
     override fun getPageTitle(position: Int): CharSequence? =
-            context.get()?.getString(titleResIds[position])
+        context.get()?.getString(titleResIds[position])
 }


### PR DESCRIPTION
## :camera: Screeshots
<img src="https://user-images.githubusercontent.com/13467769/67051552-14c47400-f144-11e9-850f-0bf2d8ec57f5.png" width="300"> <img src="https://user-images.githubusercontent.com/13467769/67051554-14c47400-f144-11e9-8ba7-90e9323f466e.png" width="300">

## :page_facing_up: Context
On Android Q notifications won't appear in status bar and it might confuse devs, who expect to see notifications as soon as network activity happens. Above you can find screenshots of such issue when notifications present only in shade, while status bar is empty.

## :pencil: Changes
Changed importance from `IMPORTANCE_LOW` to `IMPORTANCE_DEFAULT` in notification channel properties.