### PR TITLE
Pass the -module-name Kotlin Compiler flag

### DIFF
--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -4,6 +4,10 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion rootProject.compileSdkVersion
 
+    compileOptions {
+        kotlinOptions.freeCompilerArgs += ['-module-name', "com.github.ChuckerTeam.Chucker.library-no-op"]
+    }
+
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -7,6 +7,10 @@ apply plugin: 'org.jetbrains.dokka-android'
 android {
     compileSdkVersion rootProject.compileSdkVersion
 
+    compileOptions {
+        kotlinOptions.freeCompilerArgs += ['-module-name', "com.github.ChuckerTeam.Chucker.library-no-op"]
+    }
+
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         versionName VERSION_NAME


### PR DESCRIPTION
Attempt to fix #134 by passing a compiler flag to prevent name clashing with the `META-INF/library_release.kotlin_module` filename.

Fixes #134

## :pencil: Changes
Adding a Kotlin compiler flag inside both `library` and `library-no-op`.

## :warning: Breaking
Nop

## :pencil: How to test
Ideally we could publish the artifact locally and check that the file is properly named inside the Jar