### PR TITLE
Add ability to export the list of transactions

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -22,6 +22,10 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
         return transcationDao.getById(transactionId)
     }
 
+    override fun getAllTransactions(): LiveData<List<HttpTransaction>> {
+        return transcationDao.getAll()
+    }
+
     override fun getSortedTransactionTuples(): LiveData<List<HttpTransactionTuple>> {
         return transcationDao.getSortedTuples()
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
@@ -24,4 +24,6 @@ internal interface HttpTransactionRepository {
     fun getFilteredTransactionTuples(code: String, path: String): LiveData<List<HttpTransactionTuple>>
 
     fun getTransaction(transactionId: Long): LiveData<HttpTransaction>
+
+    fun getAllTransactions(): LiveData<List<HttpTransaction>>
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -39,6 +39,9 @@ internal interface HttpTransactionDao {
     @Query("SELECT * FROM transactions WHERE id = :id")
     fun getById(id: Long): LiveData<HttpTransaction>
 
+    @Query("SELECT * FROM transactions")
+    fun getAll(): LiveData<List<HttpTransaction>>
+
     @Query("DELETE FROM transactions WHERE requestDate <= :threshold")
     fun deleteBefore(threshold: Long)
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ShareUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ShareUtils.kt
@@ -1,0 +1,19 @@
+package com.chuckerteam.chucker.internal.support
+
+import android.content.Context
+import android.content.Intent
+
+fun Context.share(
+    content: String,
+    title: String? = null,
+    subject: String? = null
+) {
+    val sendIntent = Intent().apply {
+        action = Intent.ACTION_SEND
+        title?.let { putExtra(Intent.EXTRA_TITLE, it) }
+        subject?.let { putExtra(Intent.EXTRA_SUBJECT, it) }
+        putExtra(Intent.EXTRA_TEXT, content)
+        type = "text/plain"
+    }
+    startActivity(Intent.createChooser(sendIntent, null))
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -29,6 +29,7 @@ import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.support.FormatUtils
+import com.chuckerteam.chucker.internal.support.share
 import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
 import com.google.android.material.tabs.TabLayout
 
@@ -112,15 +113,6 @@ internal class TransactionActivity : BaseChuckerActivity() {
             }
         })
         viewPager.currentItem = selectedTabPosition
-    }
-
-    private fun share(content: String) {
-        val sendIntent = Intent().apply {
-            action = Intent.ACTION_SEND
-            putExtra(Intent.EXTRA_TEXT, content)
-            type = "text/plain"
-        }
-        startActivity(Intent.createChooser(sendIntent, null))
     }
 
     companion object {

--- a/library/src/main/res/menu/chucker_transactions_list.xml
+++ b/library/src/main/res/menu/chucker_transactions_list.xml
@@ -21,8 +21,13 @@
         android:icon="@drawable/chucker_ic_search_white_24dp"
         app:showAsAction="collapseActionView|ifRoom"
         app:actionViewClass="androidx.appcompat.widget.SearchView" />
+    <item android:title="@string/chucker_export"
+        android:id="@+id/export"
+        android:icon="@drawable/chucker_ic_share_white_24dp"
+        app:showAsAction="ifRoom" />
     <item android:title="@string/chucker_clear"
         android:id="@+id/clear"
         android:icon="@drawable/chucker_ic_delete_white_24dp"
         app:showAsAction="always" />
+
 </menu>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -18,6 +18,11 @@
     <string name="chucker_name">Chucker</string>
     <string name="chucker_http_notification_title">Recording HTTP activity</string>
     <string name="chucker_clear">Clear</string>
+    <string name="chucker_export">Export</string>
+    <string name="chucker_export_empty_text">Nothing to export</string>
+    <string name="chucker_export_separator">==================</string>
+    <string name="chucker_export_prefix">/* Export Start */</string>
+    <string name="chucker_export_postfix">/*  Export End  */</string>
     <string name="chucker_cancel">Cancel</string>
     <string name="chucker_overview">Overview</string>
     <string name="chucker_request">Request</string>
@@ -51,6 +56,7 @@
     <string name="chucker_share_error_content"><![CDATA[Date: %1$s\nException: %2$s\nTag: %3$s\nMessage: %4$s\n\n%5$s]]></string>
     <string name="chucker_clear_http_confirmation">Do you want to clear complete network calls history?</string>
     <string name="chucker_clear_error_confirmation">Do you want to clear complete errors history?</string>
+    <string name="chucker_export_http_confirmation">Export all http calls</string>
     <string name="chucker_check_readme"><a href="https://github.com/ChuckerTeam/chucker/blob/develop/README.md#configure-">Check the setup instructions on GitHub</a></string>
     <string name="chucker_setup">Setup</string>
 </resources>


### PR DESCRIPTION
## :camera: Screeshots
*Show us what you've changed, we love images.*

[Demo Video](https://youtu.be/FepIzHvDRN8)

## :page_facing_up: Context
*Why did you changed something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link?*

I am looking to provide a potential fix to  #91 

## :pencil: Changes
*Which code did you change? How?*

- Added some strings to `strings.xml`
- Added a menu option to `chucker_transactions_list.xml`
- Added a share function to `TransactionListFragment.kt`
- Added logic to show the `AlertDialog` in `TransactionListFragment.kt`
- Added functions to get all transactions in a `List`

## :paperclip: Related PR
*PR that blocks this one, or the ones blocked by this PR*

None

## :warning: Breaking
*Is there something breaking in the API? Any class or method signature changed?*

No

## :pencil: How to test
*Is there a special case to test your changes?*

No special cases. Just try to share!

## :crystal_ball: Next steps
*Do we have to plan something else after the merge?*

No