### PR TITLE
Using vector in all api versions instead of png generation

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -12,6 +12,7 @@ android {
         versionName VERSION_NAME
         versionCode VERSION_CODE.toInteger()
         consumerProguardFiles 'proguard-rules.pro'
+        vectorDrawables.useSupportLibrary = true
     }
 
     kotlinOptions {

--- a/library/src/main/res/layout/chucker_list_item_transaction.xml
+++ b/library/src/main/res/layout/chucker_list_item_transaction.xml
@@ -54,7 +54,7 @@
         android:layout_width="@dimen/chucker_doub_grid"
         android:layout_height="@dimen/chucker_doub_grid"
         android:contentDescription="@string/chucker_ssl"
-        android:src="@drawable/chucker_ic_https_grey_24dp"
+        app:srcCompat="@drawable/chucker_ic_https_grey_24dp"
         android:tint="@color/chucker_color_primary"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="@+id/chucker_path"


### PR DESCRIPTION
With the previous setup, PNG files of vector drawables were generated for using in api level kitkat and below.

## :camera: Screeshots
Generated PNGs before change <img width="591" alt="Screenshot 2019-11-12 at 1 43 29 AM" src="https://user-images.githubusercontent.com/1777963/68617807-ff95f780-04ed-11ea-98f6-d085c65543e7.png">

Generated folder after change
<img width="366" alt="Screenshot 2019-11-12 at 1 42 42 AM" src="https://user-images.githubusercontent.com/1777963/68617842-11779a80-04ee-11ea-92ae-bb51ded52781.png">


## :page_facing_up: Context
https://developer.android.com/studio/write/vector-asset-studio#apilevel
Discussed about how PNGs are generated for vector drawables and what are the alternatives

## :pencil: Changes
chucker librarie's build.gradle and `chucker_list_item_transaction.xml`


## :warning: Breaking
Nope. Tested on API level 19, 21 and 27 and works fine

## :pencil: How to test
Use chucker in api level 19 or below

## :crystal_ball: Next steps
NA
