### PR TITLE
Add date formatting for requestDate and responseDate

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -12,8 +12,9 @@ import androidx.room.PrimaryKey
 import com.chuckerteam.chucker.internal.support.FormatUtils
 import com.chuckerteam.chucker.internal.support.JsonConverter
 import com.google.gson.reflect.TypeToken
+import java.util.Date
+import kotlin.collections.ArrayList
 import okhttp3.Headers
-import java.util.*
 
 /**
  * Represent a full HTTP transaction (with Request and Response). Instances of this classes

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -12,8 +12,8 @@ import androidx.room.PrimaryKey
 import com.chuckerteam.chucker.internal.support.FormatUtils
 import com.chuckerteam.chucker.internal.support.JsonConverter
 import com.google.gson.reflect.TypeToken
-import java.util.ArrayList
 import okhttp3.Headers
+import java.util.*
 
 /**
  * Represent a full HTTP transaction (with Request and Response). Instances of this classes
@@ -87,10 +87,10 @@ internal class HttpTransaction(
         }
 
     val requestDateString: String?
-        get() = requestDate?.toString()
+        get() = requestDate?.let { Date(it).toString() }
 
     val responseDateString: String?
-        get() = responseDate?.toString()
+        get() = responseDate?.let { Date(it).toString() }
 
     val durationString: String?
         get() = tookMs?.let { "$it ms" }


### PR DESCRIPTION
## :camera: Screeshots
<img width="378" alt="fixed_formatting" src="https://user-images.githubusercontent.com/13467769/69188166-aa2c9c80-0b24-11ea-9df6-703aee318fb8.png">

## :page_facing_up: Context
Fix for a small issue with dates formatting reported in #158 

## :pencil: Changes
Changed getters for `requestDateString` and `responseDateString` to create new `Date` object with `Long` value store in correspondent field of transaction.

## :crystal_ball: Next steps
I think that we can update `HttpTransaction` model to use `Date` instead of `Long` for `requestDate` and `responseDate`. For now decided just make explicit formatting, but we can get rid of it.

Fixes #158 