### PR TITLE
Update/components versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,15 +6,15 @@ buildscript {
         constraintLayoutVersion = '1.1.3'
         dokkaVersion = '0.9.17'
         gradleBintrayVersion = '1.8.4'
-        gsonVersion = '2.8.5'
+        gsonVersion = '2.8.6'
         junitGradlePluignVersion = '1.3.1.1'
         junitVersion = '5.4.2'
         kotlinVersion = '1.3.50'
         leakcanaryVersion = '2.0-beta-4'
         materialComponentsVersion = '1.1.0-beta02'
         mockkVersion = '1.9.3'
-        okhttp3Version = '3.12.2'
-        retrofitVersion = '2.5.0'
+        okhttp3Version = '3.12.6'
+        retrofitVersion = '2.6.2'
         roomVersion = '2.1.0'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 buildscript {
     ext {
-        androidGradleVersion = '3.4.2'
+        androidGradleVersion = '3.5.2'
         androidMavenGradleVersion = '2.1'
+        appCompatVersion = '1.1.0'
         constraintLayoutVersion = '1.1.3'
         dokkaVersion = '0.9.17'
         gradleBintrayVersion = '1.8.4'
@@ -9,13 +10,12 @@ buildscript {
         junitGradlePluignVersion = '1.3.1.1'
         junitVersion = '5.4.2'
         kotlinVersion = '1.3.50'
-        leakcanary = '2.0-beta-2'
-        material = '1.1.0-beta01'
+        leakcanaryVersion = '2.0-beta-4'
+        materialComponentsVersion = '1.1.0-beta02'
         mockkVersion = '1.9.3'
         okhttp3Version = '3.12.2'
         retrofitVersion = '2.5.0'
         roomVersion = '2.1.0'
-        supportLibVersion = '1.1.0-rc01'
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,14 @@ buildscript {
         androidMavenGradleVersion = '2.1'
         appCompatVersion = '1.1.0'
         constraintLayoutVersion = '1.1.3'
-        dokkaVersion = '0.9.17'
+        detektVersion = '1.1.1'
+        dokkaVersion = '0.10.0'
         gradleBintrayVersion = '1.8.4'
         gsonVersion = '2.8.6'
         junitGradlePluignVersion = '1.3.1.1'
         junitVersion = '5.4.2'
         kotlinVersion = '1.3.50'
+        ktLintVersion = '9.1.1'
         leakcanaryVersion = '2.0-beta-4'
         materialComponentsVersion = '1.1.0-beta02'
         mockkVersion = '1.9.3'
@@ -30,9 +32,9 @@ buildscript {
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:$gradleBintrayVersion"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:$junitGradlePluignVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokkaVersion"
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.1.0"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:8.0.0"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktLintVersion"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -20,7 +20,7 @@ artifacts {
 
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:$okhttp3Version"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -51,7 +51,7 @@ artifacts {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation "com.google.code.gson:gson:$gsonVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttp3Version"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'org.jetbrains.dokka-android'
+apply plugin: 'org.jetbrains.dokka'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -23,13 +23,15 @@ dokka {
     outputFormat = 'html'
     outputDirectory = "$buildDir/javadoc"
 
-    includeNonPublic = false
-    reportUndocumented = true
-    skipEmptyPackages = true
+    configuration {
+        includeNonPublic = false
+        reportUndocumented = true
+        skipEmptyPackages = true
 
-    packageOptions {
-        prefix = "com.chuckerteam.chucker.internal"
-        suppress = true
+        perPackageOption {
+            prefix = "com.chuckerteam.chucker.internal"
+            suppress = true
+        }
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 
     implementation "com.google.code.gson:gson:$gsonVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttp3Version"
-    implementation "com.google.android.material:material:$material"
+    implementation "com.google.android.material:material:$materialComponentsVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakcanaryVersion"
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 
 apply from: rootProject.file('gradle/kotlin-static-analysis.gradle')

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -40,12 +40,12 @@ dependencies {
     debugImplementation project(':library')
     releaseImplementation project(':library-no-op')
 
-    implementation "com.google.android.material:material:$material"
-    implementation "androidx.appcompat:appcompat:$supportLibVersion"
+    implementation "com.google.android.material:material:$materialComponentsVersion"
+    implementation "androidx.appcompat:appcompat:$appCompatVersion"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp3Version"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakcanary"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:$leakcanaryVersion"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 }


### PR DESCRIPTION
## :page_facing_up: Context
Updates for libs and plugins used by Chucker to keep everything up-to-date and have less breaking changes in future.

## :pencil: Changes
Updated network libs, quality control libs, slightly cleaned up build file and made all dependencies use versions declared in `ext` block

## :pencil: How to test
Tested on a few devices and saw no issues with network tools updates. As to quality control things, like Ktlint - it is better see if build on CI runs smooth.

## :crystal_ball: Next steps
In future we might need to update OkHttp further, but it is currently impossible, since version 3.13 and higher requires 21 (Android 5) as minSDK. It means that soon we might need to bump minimal supported version for Chucker as well.
