### PR TITLE
Crash fix when proguard is enabled

### DIFF
--- a/library/src/main/res/layout/chucker_fragment_error_list.xml
+++ b/library/src/main/res/layout/chucker_fragment_error_list.xml
@@ -25,7 +25,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
-        app:layoutManager="LinearLayoutManager"
         tools:listitem="@layout/chucker_list_item_error" />
 
     <LinearLayout

--- a/library/src/main/res/layout/chucker_fragment_transaction_list.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_list.xml
@@ -25,7 +25,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
-        app:layoutManager="LinearLayoutManager"
         tools:context="com.chuckerteam.chucker.internal.ui.transaction.TransactionListFragment"
         tools:listitem="@layout/chucker_list_item_transaction" />
 


### PR DESCRIPTION
## :page_facing_up: Context
When the build is created with proguard enabled, the chucker crashes when clicked from the notification.
Issue number : #163 

## :pencil: Changes
Removed **app:layoutManager="LinearLayoutManager"** from chucker_fragment_transaction_list.xml and chucker_fragment_error_list.xml
As the LinearLayoutManager is already set in the kt files for Recyclerview, the app is working as expected after removing LayoutManger from the XML files.

## :pencil: How to test
Normal build with proguard enabled can be created with **-repackageclasses "package"** in the proguard file. This issue is replicable every time.

## :crystal_ball: Next steps
As the LayoutManager is already set in the kt files nothing else is required.
