### PR TITLE
Minor code cleanup

### DIFF
--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -11,7 +11,7 @@ object Chucker {
     const val SCREEN_HTTP = 1
     const val SCREEN_ERROR = 2
 
-    const val isOp = false
+    val isOp = false
 
     @JvmStatic
     fun getLaunchIntent(context: Context, screen: Int): Intent {

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -11,20 +11,24 @@ object Chucker {
     const val SCREEN_HTTP = 1
     const val SCREEN_ERROR = 2
 
-    val isOp = false
+    const val isOp = false
 
+    @JvmStatic
     fun getLaunchIntent(context: Context, screen: Int): Intent {
         return Intent()
     }
 
+    @JvmStatic
     fun registerDefaultCrashHandler(collector: ChuckerCollector) {
         // Empty method for the library-no-op artifact
     }
 
+    @JvmStatic
     fun dismissTransactionsNotification(context: Context) {
         // Empty method for the library-no-op artifact
     }
 
+    @JvmStatic
     fun dismissErrorsNotification(context: Context) {
         // Empty method for the library-no-op artifact
     }

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -13,19 +13,19 @@ object Chucker {
 
     val isOp = false
 
-    @JvmStatic fun getLaunchIntent(context: Context, screen: Int): Intent {
+    fun getLaunchIntent(context: Context, screen: Int): Intent {
         return Intent()
     }
 
-    @JvmStatic fun registerDefaultCrashHandler(collector: ChuckerCollector) {
+    fun registerDefaultCrashHandler(collector: ChuckerCollector) {
         // Empty method for the library-no-op artifact
     }
 
-    @JvmStatic fun dismissTransactionsNotification(context: Context) {
+    fun dismissTransactionsNotification(context: Context) {
         // Empty method for the library-no-op artifact
     }
 
-    @JvmStatic fun dismissErrorsNotification(context: Context) {
+    fun dismissErrorsNotification(context: Context) {
         // Empty method for the library-no-op artifact
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -24,7 +24,6 @@ object Chucker {
      * @param screen The [Screen] to display: SCREEN_HTTP or SCREEN_ERROR.
      * @return An Intent for the main Chucker Activity that can be started with [Context.startActivity].
      */
-    @JvmStatic
     fun getLaunchIntent(context: Context, @Screen screen: Int): Intent {
         return Intent(context, MainActivity::class.java)
             .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -37,7 +36,6 @@ object Chucker {
      *
      * @param collector the ChuckerCollector
      */
-    @JvmStatic
     fun registerDefaultCrashHandler(collector: ChuckerCollector) {
         Thread.setDefaultUncaughtExceptionHandler(ChuckerCrashHandler(collector))
     }
@@ -45,7 +43,6 @@ object Chucker {
     /**
      * Method to dismiss the Chucker notification of HTTP Transactions
      */
-    @JvmStatic
     fun dismissTransactionsNotification(context: Context) {
         NotificationHelper(context).dismissTransactionsNotification()
     }
@@ -53,7 +50,6 @@ object Chucker {
     /**
      * Method to dismiss the Chucker notification of Uncaught Errors.
      */
-    @JvmStatic
     fun dismissErrorsNotification(context: Context) {
         NotificationHelper(context).dismissErrorsNotification()
     }

--- a/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -12,11 +12,14 @@ import com.chuckerteam.chucker.internal.ui.MainActivity
  */
 object Chucker {
 
+    const val SCREEN_HTTP = 1
+    const val SCREEN_ERROR = 2
+
     /**
      * Check if this instance is the operation one or no-op.
      * @return `true` if this is the operation instance.
      */
-    val isOp = true
+    const val isOp = true
 
     /**
      * Get an Intent to launch the Chucker UI directly.
@@ -24,6 +27,7 @@ object Chucker {
      * @param screen The [Screen] to display: SCREEN_HTTP or SCREEN_ERROR.
      * @return An Intent for the main Chucker Activity that can be started with [Context.startActivity].
      */
+    @JvmStatic
     fun getLaunchIntent(context: Context, @Screen screen: Int): Intent {
         return Intent(context, MainActivity::class.java)
             .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -36,6 +40,7 @@ object Chucker {
      *
      * @param collector the ChuckerCollector
      */
+    @JvmStatic
     fun registerDefaultCrashHandler(collector: ChuckerCollector) {
         Thread.setDefaultUncaughtExceptionHandler(ChuckerCrashHandler(collector))
     }
@@ -43,6 +48,7 @@ object Chucker {
     /**
      * Method to dismiss the Chucker notification of HTTP Transactions
      */
+    @JvmStatic
     fun dismissTransactionsNotification(context: Context) {
         NotificationHelper(context).dismissTransactionsNotification()
     }
@@ -50,12 +56,10 @@ object Chucker {
     /**
      * Method to dismiss the Chucker notification of Uncaught Errors.
      */
+    @JvmStatic
     fun dismissErrorsNotification(context: Context) {
         NotificationHelper(context).dismissErrorsNotification()
     }
-
-    const val SCREEN_HTTP = 1
-    const val SCREEN_ERROR = 2
 
     /**
      * Annotation used to specify which screen of Chucker should be launched.

--- a/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -19,7 +19,7 @@ object Chucker {
      * Check if this instance is the operation one or no-op.
      * @return `true` if this is the operation instance.
      */
-    const val isOp = true
+    val isOp = true
 
     /**
      * Get an Intent to launch the Chucker UI directly.

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -60,11 +60,11 @@ class ChuckerInterceptor @JvmOverloads constructor(
             requestContentLength = requestBody?.contentLength() ?: 0L
         }
 
-        val encodingIsSupported = io.bodyHasSupportedEncoding(request.headers().get("Content-Encoding"))
+        val encodingIsSupported = io.bodyHasSupportedEncoding(request.headers().get(CONTENT_ENCODING))
         transaction.isRequestBodyPlainText = encodingIsSupported
 
         if (requestBody != null && encodingIsSupported) {
-            val source = io.getNativeSource(Buffer(), io.bodyIsGzipped(request.headers().get("Content-Encoding")))
+            val source = io.getNativeSource(Buffer(), io.bodyIsGzipped(request.headers().get(CONTENT_ENCODING)))
             val buffer = source.buffer()
             requestBody.writeTo(buffer)
             var charset: Charset = UTF8
@@ -110,7 +110,7 @@ class ChuckerInterceptor @JvmOverloads constructor(
             setResponseHeaders(filterHeaders(response.headers()))
         }
 
-        val responseEncodingIsSupported = io.bodyHasSupportedEncoding(response.headers().get("Content-Encoding"))
+        val responseEncodingIsSupported = io.bodyHasSupportedEncoding(response.headers().get(CONTENT_ENCODING))
         transaction.isResponseBodyPlainText = responseEncodingIsSupported
 
         if (response.hasBody() && responseEncodingIsSupported) {
@@ -169,7 +169,7 @@ class ChuckerInterceptor @JvmOverloads constructor(
      */
     @Throws(IOException::class)
     private fun getNativeSource(response: Response): BufferedSource {
-        if (io.bodyIsGzipped(response.headers().get("Content-Encoding"))) {
+        if (io.bodyIsGzipped(response.headers().get(CONTENT_ENCODING))) {
             val source = response.peekBody(maxContentLength).source()
             if (source.buffer().size() < maxContentLength) {
                 return io.getNativeSource(source, true)
@@ -182,5 +182,6 @@ class ChuckerInterceptor @JvmOverloads constructor(
 
     companion object {
         private val UTF8 = Charset.forName("UTF-8")
+        private val CONTENT_ENCODING = "Content-Encoding"
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -114,7 +114,7 @@ internal class HttpTransaction(
             return when (status) {
                 Status.Failed -> error
                 Status.Requested -> null
-                else -> "${responseCode.toString()} $responseMessage"
+                else -> "$responseCode $responseMessage"
             }
         }
 
@@ -123,7 +123,7 @@ internal class HttpTransaction(
             return when (status) {
                 Status.Failed -> " ! ! !  $method $path"
                 Status.Requested -> " . . .  $method $path"
-                else -> "${responseCode.toString()} $method $path"
+                else -> "$responseCode $method $path"
             }
         }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -114,7 +114,7 @@ internal class HttpTransaction(
             return when (status) {
                 Status.Failed -> error
                 Status.Requested -> null
-                else -> responseCode.toString() + " " + responseMessage
+                else -> "${responseCode.toString()} $responseMessage"
             }
         }
 
@@ -123,12 +123,12 @@ internal class HttpTransaction(
             return when (status) {
                 Status.Failed -> " ! ! !  $method $path"
                 Status.Requested -> " . . .  $method $path"
-                else -> responseCode.toString() + " " + method + " " + path
+                else -> "${responseCode.toString()} $method $path"
             }
         }
 
     val isSsl: Boolean
-        get() = scheme?.toLowerCase() == "https"
+        get() = scheme.equals("https", ignoreCase = true)
 
     val responseImageBitmap: Bitmap?
         get() {
@@ -187,9 +187,9 @@ internal class HttpTransaction(
 
     private fun formatBody(body: String, contentType: String?): String {
         return when {
-            contentType != null && contentType.toLowerCase().contains("json") ->
+            contentType != null && contentType.contains("json", ignoreCase = true) ->
                 FormatUtils.formatJson(body)
-            contentType != null && contentType.toLowerCase().contains("xml") ->
+            contentType != null && contentType.contains("xml", ignoreCase = true) ->
                 FormatUtils.formatXml(body)
             else -> body
         }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -21,7 +21,7 @@ internal class HttpTransactionTuple(
     @ColumnInfo(name = "responseContentLength") var responseContentLength: Long?,
     @ColumnInfo(name = "error") var error: String?
 ) {
-    val isSsl: Boolean get() = scheme?.toLowerCase() == "https"
+    val isSsl: Boolean get() = scheme.equals("https", ignoreCase = true)
 
     val status: HttpTransaction.Status
         get() = when {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProvider.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProvider.kt
@@ -13,13 +13,13 @@ internal object RepositoryProvider {
     private var transactionRepository: HttpTransactionRepository? = null
     private var throwableRepository: RecordedThrowableRepository? = null
 
-    @JvmStatic fun transaction(): HttpTransactionRepository {
+    fun transaction(): HttpTransactionRepository {
         return checkNotNull(transactionRepository) {
             "You can't access the transaction repository if you don't initialize it!"
         }
     }
 
-    @JvmStatic fun throwable(): RecordedThrowableRepository {
+    fun throwable(): RecordedThrowableRepository {
         return checkNotNull(throwableRepository) {
             "You can't access the throwable repository if you don't initialize it!"
         }
@@ -28,7 +28,6 @@ internal object RepositoryProvider {
     /**
      * Idempotent method. Must be called before accessing the repositories.
      */
-    @JvmStatic
     fun initialize(context: Context) {
         if (transactionRepository == null || throwableRepository == null) {
             val db = ChuckerDatabase.create(context)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
@@ -14,8 +14,8 @@ internal abstract class ChuckerDatabase : RoomDatabase() {
     abstract fun transactionDao(): HttpTransactionDao
 
     companion object {
-        private val OLD_DB_NAME = "chuck.db"
-        private val DB_NAME = "chucker.db"
+        private const val OLD_DB_NAME = "chuck.db"
+        private const val DB_NAME = "chucker.db"
 
         fun create(context: Context): ChuckerDatabase {
             // We eventually delete the old DB if a previous version of Chuck/Chucker was used.


### PR DESCRIPTION
## :page_facing_up: Context
Most of the code is already migrated to Kotlin, which means we don't need `@JvmStatic` annotated functions anymore. Since this annotation generates additional methods during compilation, I believe Chucker should get rid of it.
Also, some code parts 

## :pencil: Changes
- Removed @JvmStatic annotations almost everywhere (a few usages left)
- Used String interpolation in a few places to support switching to unified code style across the project
- Added a few `const` keywords in database `companion object`

## :crystal_ball: Next steps
Remove other `@JvmStatic` annotations when Kotlinification of `FormatUtils` class will be merged into `develop`
