### PR TITLE
Fix "null" prefix in POM name

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -15,7 +15,7 @@ afterEvaluate { proj ->
                     packaging 'aar'
 
                     // Add your description here
-                    name "$group:${proj.name}"
+                    name "${rootProject.group}:${proj.name}"
                     description = POM_DESCRIPTION
                     url siteUrl
 


### PR DESCRIPTION
## :page_facing_up: Context
Current POM on bintray: https://bintray.com/olivierperez/Chucker/download_file?file_path=fr%2Fo80%2Fchucker%2Flibrary%2F2.0.4%2Flibrary-2.0.4.pom contains `  <name>null:library</name>`

## :pencil: Changes
GROUP property value was assigned to root project group but pom was generated from library projects (which have empty groups).

## :paperclip: Related PR
None

## :warning: Breaking
No

## :pencil: How to test
Check `<name>` content in `library(no-op)/build/poms/pom-default.xml` file. Not sure which gradle task exactly creates this file. It needs to be some dependency of `bintrayUpload`.