### PR TITLE
Fixing handling of big body payloads

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/SearchHighlightUtil.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/SearchHighlightUtil.kt
@@ -15,7 +15,7 @@ fun String.highlightWithDefinedColors(
     search: String,
     backgroundColor: Int,
     foregroundColor: Int
-): CharSequence {
+): SpannableStringBuilder {
     val startIndexes = indexesOf(this, search)
     return applyColoredSpannable(this, startIndexes, search.length, backgroundColor, foregroundColor)
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
@@ -61,13 +61,13 @@ internal class TransactionBodyAdapter(
                     item.line.clearSpans()
                     item.line = item.line.toString()
                         .highlightWithDefinedColors(newText, backgroundColor, foregroundColor)
-                    notifyItemChanged(index)
+                    notifyItemChanged(index + 1)
                 } else {
                     // Let's clear the spans if we haven't found the query string.
                     val spans = item.line.getSpans(0, item.line.length - 1, Any::class.java)
                     if (spans.isNotEmpty()) {
                         item.line.clearSpans()
-                        notifyItemChanged(index)
+                        notifyItemChanged(index + 1)
                     }
                 }
             }
@@ -80,7 +80,7 @@ internal class TransactionBodyAdapter(
                 val spans = item.line.getSpans(0, item.line.length - 1, Any::class.java)
                 if (spans.isNotEmpty()) {
                     item.line.clearSpans()
-                    notifyItemChanged(index)
+                    notifyItemChanged(index + 1)
                 }
             }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
@@ -1,0 +1,130 @@
+package com.chuckerteam.chucker.internal.ui.transaction
+
+import android.graphics.Bitmap
+import android.text.SpannableStringBuilder
+import android.text.Spanned
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.internal.support.highlightWithDefinedColors
+
+/**
+ * Adapter responsible of showing the content of the Transaction Request/Response body.
+ * We're using a [RecyclerView] to show the content of the body line by line to do not affect
+ * performances when loading big payloads.
+ */
+internal class TransactionBodyAdapter(
+    private val bodyItems: List<TransactionPayloadItem>
+) : RecyclerView.Adapter<TransactionPayloadViewHolder>() {
+
+    override fun onBindViewHolder(holder: TransactionPayloadViewHolder, position: Int) {
+        holder.bind(bodyItems[position])
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TransactionPayloadViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            TYPE_HEADERS -> {
+                val view = inflater.inflate(R.layout.chucker_transaction_item_headers, parent, false)
+                TransactionPayloadViewHolder.HeaderViewHolder(view)
+            }
+            TYPE_BODY_LINE -> {
+                val view = inflater.inflate(R.layout.chucker_transaction_item_body_line, parent, false)
+                TransactionPayloadViewHolder.BodyLineViewHolder(view)
+            }
+            else -> {
+                val view = inflater.inflate(R.layout.chucker_transaction_item_image, parent, false)
+                TransactionPayloadViewHolder.ImageViewHolder(view)
+            }
+        }
+    }
+
+    override fun getItemCount() = bodyItems.size
+
+    override fun getItemViewType(position: Int): Int {
+        return when (bodyItems[position]) {
+            is TransactionPayloadItem.HeaderItem -> TYPE_HEADERS
+            is TransactionPayloadItem.BodyLineItem -> TYPE_BODY_LINE
+            is TransactionPayloadItem.ImageItem -> TYPE_IMAGE
+        }
+    }
+
+    internal fun highlightQueryWithColors(newText: String, backgroundColor: Int, foregroundColor: Int) {
+        bodyItems.filterIsInstance<TransactionPayloadItem.BodyLineItem>()
+            .withIndex()
+            .forEach { (index, item) ->
+                if (newText in item.line) {
+                    item.line.clearSpans()
+                    item.line = item.line.toString()
+                        .highlightWithDefinedColors(newText, backgroundColor, foregroundColor)
+                    notifyItemChanged(index)
+                } else {
+                    // Let's clear the spans if we haven't found the query string.
+                    val spans = item.line.getSpans(0, item.line.length - 1, Any::class.java)
+                    if (spans.isNotEmpty()) {
+                        item.line.clearSpans()
+                        notifyItemChanged(index)
+                    }
+                }
+            }
+    }
+
+    internal fun resetHighlight() {
+        bodyItems.filterIsInstance<TransactionPayloadItem.BodyLineItem>()
+            .withIndex()
+            .forEach { (index, item) ->
+                val spans = item.line.getSpans(0, item.line.length - 1, Any::class.java)
+                if (spans.isNotEmpty()) {
+                    item.line.clearSpans()
+                    notifyItemChanged(index)
+                }
+            }
+    }
+
+    companion object {
+        private const val TYPE_HEADERS = 1
+        private const val TYPE_BODY_LINE = 2
+        private const val TYPE_IMAGE = 3
+    }
+}
+
+internal sealed class TransactionPayloadViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+    abstract fun bind(item: TransactionPayloadItem)
+
+    internal class HeaderViewHolder(view: View) : TransactionPayloadViewHolder(view) {
+        private val headersView: TextView = view.findViewById(R.id.headers)
+        override fun bind(item: TransactionPayloadItem) {
+            if (item is TransactionPayloadItem.HeaderItem) {
+                headersView.text = item.headers
+            }
+        }
+    }
+
+    internal class BodyLineViewHolder(view: View) : TransactionPayloadViewHolder(view) {
+        private val bodyLineView: TextView = view.findViewById(R.id.body_line)
+        override fun bind(item: TransactionPayloadItem) {
+            if (item is TransactionPayloadItem.BodyLineItem) {
+                bodyLineView.text = item.line
+            }
+        }
+    }
+
+    internal class ImageViewHolder(view: View) : TransactionPayloadViewHolder(view) {
+        private val binaryDataView: ImageView = view.findViewById(R.id.binary_data)
+        override fun bind(item: TransactionPayloadItem) {
+            if (item is TransactionPayloadItem.ImageItem) {
+                binaryDataView.setImageBitmap(item.image)
+            }
+        }
+    }
+}
+
+internal sealed class TransactionPayloadItem {
+    internal class HeaderItem(val headers: Spanned) : TransactionPayloadItem()
+    internal class BodyLineItem(var line: SpannableStringBuilder) : TransactionPayloadItem()
+    internal class ImageItem(val image: Bitmap) : TransactionPayloadItem()
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -227,10 +227,9 @@ internal class TransactionPayloadFragment :
             }
 
             // The body could either be an image, binary encoded or plain text.
-            if (type == TYPE_RESPONSE && transaction.responseImageBitmap != null) {
-                transaction.responseImageBitmap?.let {
-                    result.add(TransactionPayloadItem.ImageItem(it))
-                }
+            val responseBitmap = transaction.responseImageBitmap
+            if (type == TYPE_RESPONSE && responseBitmap != null) {
+                result.add(TransactionPayloadItem.ImageItem(responseBitmap))
             } else if (!isBodyPlainText) {
                 fragment.context?.getString(R.string.chucker_body_omitted)?.let {
                     result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -19,19 +19,18 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.graphics.Bitmap
 import android.graphics.Color
 import android.net.Uri
 import android.os.AsyncTask
 import android.os.Build
 import android.os.Bundle
+import android.text.SpannableStringBuilder
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
+import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.SearchView
@@ -40,9 +39,9 @@ import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
+import androidx.recyclerview.widget.RecyclerView
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
-import com.chuckerteam.chucker.internal.support.highlightWithDefinedColors
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
@@ -52,17 +51,16 @@ private const val GET_FILE_FOR_SAVING_REQUEST_CODE: Int = 43
 internal class TransactionPayloadFragment :
     Fragment(), SearchView.OnQueryTextListener {
 
-    private lateinit var headers: TextView
-    private lateinit var body: TextView
-    private lateinit var binaryData: ImageView
+    private lateinit var progressLoading: ProgressBar
+    private lateinit var transactionContentList: RecyclerView
 
     private var backgroundSpanColor: Int = Color.YELLOW
     private var foregroundSpanColor: Int = Color.RED
 
     private var type: Int = 0
+
     private lateinit var viewModel: TransactionViewModel
-    private var originalBody: String? = null
-    private var uiLoaderTask: UiLoaderTask? = null
+    private var payloadLoaderTask: PayloadLoaderTask? = null
     private var fileSaverTask: FileSaverTask? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -78,9 +76,9 @@ internal class TransactionPayloadFragment :
         savedInstanceState: Bundle?
     ): View? =
         inflater.inflate(R.layout.chucker_fragment_transaction_payload, container, false).apply {
-            headers = findViewById(R.id.headers)
-            body = findViewById(R.id.body)
-            binaryData = findViewById(R.id.binaryData)
+            transactionContentList = findViewById(R.id.transaction_content)
+            transactionContentList.isNestedScrollingEnabled = false
+            progressLoading = findViewById(R.id.progress_loading_transaction)
         }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -88,44 +86,49 @@ internal class TransactionPayloadFragment :
         viewModel.transaction.observe(
             this,
             Observer { transaction ->
-                UiLoaderTask(this).execute(Pair(type, transaction))
+                PayloadLoaderTask(this).execute(Pair(type, transaction))
             }
         )
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        uiLoaderTask?.cancel(true)
+        payloadLoaderTask?.cancel(true)
         fileSaverTask?.cancel(true)
     }
 
     @SuppressLint("NewApi")
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        if ((type == TYPE_RESPONSE || type == TYPE_REQUEST)) {
-            if (body.text.isNotEmpty()) {
-                val searchMenuItem = menu.findItem(R.id.search)
-                searchMenuItem.isVisible = true
-                val searchView = searchMenuItem.actionView as SearchView
-                searchView.setOnQueryTextListener(this)
-                searchView.setIconifiedByDefault(true)
-            }
+        val transaction = viewModel.transaction.value
 
-            val transaction = viewModel.transaction.value
-            val showSaveMenuItem = when {
-                // SAF is not available on pre-Kit Kat so let's hide the icon.
-                (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) -> false
-                (type == TYPE_REQUEST && 0L == (transaction?.requestContentLength ?: 0L)) -> false
-                (type == TYPE_RESPONSE && 0L == (transaction?.responseContentLength ?: 0L)) -> false
-                else -> true
-            }
+        val showSearchIcon = when {
+            (type == TYPE_REQUEST && true == transaction?.isRequestBodyPlainText) -> true
+            (type == TYPE_RESPONSE && true == transaction?.isResponseBodyPlainText) -> true
+            else -> false
+        }
 
-            if (showSaveMenuItem) {
-                menu.findItem(R.id.save_body).apply {
-                    isVisible = true
-                    setOnMenuItemClickListener {
-                        viewBodyExternally()
-                        true
-                    }
+        if (showSearchIcon) {
+            val searchMenuItem = menu.findItem(R.id.search)
+            searchMenuItem.isVisible = true
+            val searchView = searchMenuItem.actionView as SearchView
+            searchView.setOnQueryTextListener(this)
+            searchView.setIconifiedByDefault(true)
+        }
+
+        val showSaveMenuItem = when {
+            // SAF is not available on pre-Kit Kat so let's hide the icon.
+            (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) -> false
+            (type == TYPE_REQUEST && 0L == (transaction?.requestContentLength ?: 0L)) -> false
+            (type == TYPE_RESPONSE && 0L == (transaction?.responseContentLength ?: 0L)) -> false
+            else -> true
+        }
+
+        if (showSaveMenuItem) {
+            menu.findItem(R.id.save_body).apply {
+                isVisible = true
+                setOnMenuItemClickListener {
+                    viewBodyExternally()
+                    true
                 }
             }
         }
@@ -137,26 +140,6 @@ internal class TransactionPayloadFragment :
         super.onAttach(context)
         backgroundSpanColor = ContextCompat.getColor(context, R.color.chucker_background_span_color)
         foregroundSpanColor = ContextCompat.getColor(context, R.color.chucker_foreground_span_color)
-    }
-
-    private fun setBody(headersString: String, bodyString: String?, isPlainText: Boolean, image: Bitmap?) {
-        uiLoaderTask = null
-        headers.visibility = if (headersString.isEmpty()) View.GONE else View.VISIBLE
-        headers.text = HtmlCompat.fromHtml(headersString, HtmlCompat.FROM_HTML_MODE_LEGACY)
-        val isImageData = image != null
-        if (!isPlainText && !isImageData) {
-            body.text = context?.getString(R.string.chucker_body_omitted)
-        } else if (!isImageData) {
-            body.text = bodyString
-        }
-        if (image != null) {
-            binaryData.visibility = View.VISIBLE
-            binaryData.setImageBitmap(image)
-        } else {
-            binaryData.visibility = View.GONE
-        }
-        originalBody = body.text.toString()
-        activity?.invalidateOptionsMenu()
     }
 
     @RequiresApi(Build.VERSION_CODES.KITKAT)
@@ -194,41 +177,83 @@ internal class TransactionPayloadFragment :
     override fun onQueryTextSubmit(query: String): Boolean = false
 
     override fun onQueryTextChange(newText: String): Boolean {
+        val adapter = (transactionContentList.adapter as TransactionBodyAdapter)
         if (newText.isNotBlank()) {
-            body.text = originalBody?.highlightWithDefinedColors(newText, backgroundSpanColor, foregroundSpanColor)
+            adapter.highlightQueryWithColors(newText, backgroundSpanColor, foregroundSpanColor)
         } else {
-            body.text = originalBody
+            adapter.resetHighlight()
         }
         return true
     }
 
-    private class UiLoaderTask(val fragment: TransactionPayloadFragment) :
-        AsyncTask<Pair<Int, HttpTransaction>, Unit, UiPayload>() {
+    /**
+     * Async task responsible of loading in the background the content of the HTTP request/response.
+     */
+    class PayloadLoaderTask(private val fragment: TransactionPayloadFragment) :
+        AsyncTask<Pair<Int, HttpTransaction>, Unit, List<TransactionPayloadItem>>() {
 
-        override fun doInBackground(vararg params: Pair<Int, HttpTransaction>): UiPayload {
-            val (type, transaction) = params[0]
-            return if (type == TYPE_REQUEST) {
-                UiPayload(
-                    transaction.getRequestHeadersString(true),
-                    transaction.getFormattedRequestBody(),
-                    transaction.isRequestBodyPlainText
-                )
-            } else {
-                UiPayload(
-                    transaction.getResponseHeadersString(true),
-                    transaction.getFormattedResponseBody(),
-                    transaction.isResponseBodyPlainText,
-                    transaction.responseImageBitmap
-                )
-            }
+        override fun onPreExecute() {
+            val progressBar: ProgressBar? = fragment.view?.findViewById(R.id.progress_loading_transaction)
+            val recyclerView: RecyclerView? = fragment.view?.findViewById(R.id.transaction_content)
+            progressBar?.visibility = View.VISIBLE
+            recyclerView?.visibility = View.INVISIBLE
         }
 
-        override fun onPostExecute(result: UiPayload) = with(result) {
-            fragment.setBody(headersString, bodyString, isPlainText, image)
+        @Suppress("ComplexMethod")
+        override fun doInBackground(vararg params: Pair<Int, HttpTransaction>): List<TransactionPayloadItem> {
+            val (type, transaction) = params[0]
+            val result = mutableListOf<TransactionPayloadItem>()
+
+            val headersString: String
+            val isBodyPlainText: Boolean
+            val bodyString: String
+
+            if (type == TYPE_REQUEST) {
+                headersString = transaction.getRequestHeadersString(true)
+                isBodyPlainText = transaction.isRequestBodyPlainText
+                bodyString = transaction.getFormattedRequestBody()
+            } else {
+                headersString = transaction.getResponseHeadersString(true)
+                isBodyPlainText = transaction.isResponseBodyPlainText
+                bodyString = transaction.getFormattedResponseBody()
+            }
+
+            if (headersString.isNotBlank()) {
+                result.add(
+                    TransactionPayloadItem.HeaderItem(
+                        HtmlCompat.fromHtml(headersString, HtmlCompat.FROM_HTML_MODE_LEGACY)
+                    )
+                )
+            }
+
+            // The body could either be an image, binary encoded or plain text.
+            if (type == TYPE_RESPONSE && transaction.responseImageBitmap != null) {
+                transaction.responseImageBitmap?.let {
+                    result.add(TransactionPayloadItem.ImageItem(it))
+                }
+            } else if (!isBodyPlainText) {
+                fragment.context?.getString(R.string.chucker_body_omitted)?.let {
+                    result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
+                }
+            } else {
+                bodyString.lines().forEach {
+                    result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
+                }
+            }
+
+            return result
+        }
+
+        override fun onPostExecute(result: List<TransactionPayloadItem>) {
+            val progressBar: ProgressBar? = fragment.view?.findViewById(R.id.progress_loading_transaction)
+            val recyclerView: RecyclerView? = fragment.view?.findViewById(R.id.transaction_content)
+            progressBar?.visibility = View.INVISIBLE
+            recyclerView?.visibility = View.VISIBLE
+            recyclerView?.adapter = TransactionBodyAdapter(result)
         }
     }
 
-    private class FileSaverTask(val fragment: TransactionPayloadFragment) :
+    class FileSaverTask(val fragment: TransactionPayloadFragment) :
         AsyncTask<Triple<Int, Uri, HttpTransaction>, Unit, Boolean>() {
 
         @Suppress("NestedBlockDepth")
@@ -271,13 +296,6 @@ internal class TransactionPayloadFragment :
             Toast.makeText(fragment.context, toastMessageId, Toast.LENGTH_SHORT).show()
         }
     }
-
-    private data class UiPayload(
-        val headersString: String,
-        val bodyString: String?,
-        val isPlainText: Boolean,
-        val image: Bitmap? = null
-    )
 
     companion object {
         private const val ARG_TYPE = "type"

--- a/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
@@ -1,52 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
- ~ Copyright (C) 2017 Jeff Gilfelt.
- ~
- ~ Licensed under the Apache License, Version 2.0 (the "License");
- ~ you may not use this file except in compliance with the License.
- ~ You may obtain a copy of the License at
- ~
- ~      http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~ Unless required by applicable law or agreed to in writing, software
- ~ distributed under the License is distributed on an "AS IS" BASIS,
- ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- ~ See the License for the specific language governing permissions and
- ~ limitations under the License.
- -->
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:scrollbars="vertical"
+    android:animateLayoutChanges="true"
     android:layoutDirection="ltr"
     tools:context="com.chuckerteam.chucker.internal.ui.transaction.TransactionPayloadFragment">
 
-    <LinearLayout
+    <ProgressBar
+        android:id="@+id/progress_loading_transaction"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp"
-        android:orientation="vertical" >
+        android:indeterminate="true"
+        android:layout_margin="@dimen/chucker_doub_grid"
+        android:visibility="visible" />
 
-        <TextView
-            android:id="@+id/headers"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textIsSelectable="true"/>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/transaction_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbars="vertical"
+        android:visibility="invisible"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/chucker_octa_grid"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
-        <TextView
-            android:id="@+id/body"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:typeface="monospace"
-            android:textIsSelectable="true"/>
-
-        <ImageView
-            android:id="@+id/binaryData"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            />
-
-    </LinearLayout>
-
-</androidx.core.widget.NestedScrollView>
+</FrameLayout>

--- a/library/src/main/res/layout/chucker_transaction_item_body_line.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_body_line.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/body_line"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textIsSelectable="true"
+    android:minLines="1"
+    android:gravity="left"
+    android:layout_marginHorizontal="16dp"
+    android:typeface="monospace" />

--- a/library/src/main/res/layout/chucker_transaction_item_body_line.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_body_line.xml
@@ -5,6 +5,6 @@
     android:layout_height="wrap_content"
     android:textIsSelectable="true"
     android:minLines="1"
-    android:gravity="left"
+    android:gravity="left|start"
     android:layout_marginHorizontal="16dp"
     android:typeface="monospace" />

--- a/library/src/main/res/layout/chucker_transaction_item_headers.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_headers.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/headers"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp"
+    android:textIsSelectable="true" />

--- a/library/src/main/res/layout/chucker_transaction_item_image.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_image.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/binary_data"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp"
+    android:contentDescription="@string/chucker_binary_data" />

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -3,6 +3,8 @@
     <dimen name="chucker_half_grid">4dp</dimen>
     <dimen name="chucker_base_grid">8dp</dimen>
     <dimen name="chucker_doub_grid">16dp</dimen>
+    <dimen name="chucker_quad_grid">32dp</dimen>
+    <dimen name="chucker_octa_grid">64dp</dimen>
 
     <dimen name="chucker_item_size">56dp</dimen>
 </resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -60,4 +60,5 @@
     <string name="chucker_clear_error_confirmation">Do you want to clear complete errors history?</string>
     <string name="chucker_check_readme"><a href="https://github.com/ChuckerTeam/chucker/blob/develop/README.md#configure-">Check the setup instructions on GitHub</a></string>
     <string name="chucker_setup">Setup</string>
+    <string name="chucker_binary_data">binary data</string>
 </resources>


### PR DESCRIPTION
Currently Chucker UI hangs when the HTTP request/response body is too
big. The issue is caused by having to put a bunch of text inside a
single TextView.

This commit refactors the request/response body screen to use a
RecyclerView to load single lines. In this way the UI is much smoother
and the experience is generally better.

## :camera: GIF
![bigpayload](https://user-images.githubusercontent.com/3001957/71679634-4b477d80-2d88-11ea-8716-ce3b6c60f6a0.gif)

## :page_facing_up: Context
Fixes #82

## :warning: Breaking
Only changes inside `.internal` so no breaking changes on the API.
On the other hand there are a couple of drawbacks:

- Text in the body is selectable only line by line.
- Search in the body works only line by line.
- Response/Request screen are not inside a `NestedScrollView` anymore (as this had major performance drawbacks) 

## :pencil: How to test
Ideally we should extend the sample app with a single call to https://data.cityofnewyork.us/api/views/kku6-nxdu/rows.json or to another big JSON api.
