### PR TITLE
Remove stale support-lib-version from gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ buildscript {
         retrofitVersion = '2.6.2'
         roomVersion = '2.1.0'
         viewModelVersion = '2.1.0'
-        supportLibVersion = '1.1.0-rc01'
     }
 
     repositories {


### PR DESCRIPTION
Looks like I accidentally included an unintended line when merging #145 with `develop`. Here the cleanup. Thanks @vbuberen for spotting the issue.