### PR TITLE
Visibility fix for internal members

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion rootProject.compileSdkVersion
 
     compileOptions {
-        kotlinOptions.freeCompilerArgs += ['-module-name', "com.github.ChuckerTeam.Chucker.library-no-op"]
+        kotlinOptions.freeCompilerArgs += ['-module-name', "com.github.ChuckerTeam.Chucker.library"]
     }
 
     defaultConfig {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ChuckerCrashHandler.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ChuckerCrashHandler.kt
@@ -2,7 +2,7 @@ package com.chuckerteam.chucker.internal.support
 
 import com.chuckerteam.chucker.api.ChuckerCollector
 
-class ChuckerCrashHandler(private val collector: ChuckerCollector) : Thread.UncaughtExceptionHandler {
+internal class ChuckerCrashHandler(private val collector: ChuckerCollector) : Thread.UncaughtExceptionHandler {
 
     private val defaultHandler: Thread.UncaughtExceptionHandler? = Thread.getDefaultUncaughtExceptionHandler()
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
@@ -51,7 +51,7 @@ internal object FormatUtils {
 
     fun formatJson(json: String): String {
         return try {
-            val je =  JsonParser.parseString(json)
+            val je = JsonParser.parseString(json)
             JsonConverter.instance.toJson(je)
         } catch (e: JsonParseException) {
             json

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
@@ -51,7 +51,7 @@ internal object FormatUtils {
 
     fun formatJson(json: String): String {
         return try {
-            val je = JsonParser().parse(json)
+            val je =  JsonParser.parseString(json)
             JsonConverter.instance.toJson(je)
         } catch (e: JsonParseException) {
             json

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
@@ -13,7 +13,7 @@ import okio.Okio
 private const val PREFIX_SIZE = 64L
 private const val CODE_POINT_SIZE = 16
 
-class IOUtils(private val context: Context) {
+internal class IOUtils(private val context: Context) {
 
     /**
      * Returns true if the body in question probably contains human readable text. Uses a small sample
@@ -63,8 +63,7 @@ class IOUtils(private val context: Context) {
     }
 
     fun bodyHasSupportedEncoding(contentEncoding: String?) =
-        contentEncoding == null ||
-            contentEncoding.isEmpty() ||
+            contentEncoding.isNullOrEmpty() ||
             contentEncoding.equals("identity", ignoreCase = true) ||
             contentEncoding.equals("gzip", ignoreCase = true)
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
@@ -63,7 +63,7 @@ internal class IOUtils(private val context: Context) {
     }
 
     fun bodyHasSupportedEncoding(contentEncoding: String?) =
-            contentEncoding.isNullOrEmpty() ||
+        contentEncoding.isNullOrEmpty() ||
             contentEncoding.equals("identity", ignoreCase = true) ||
             contentEncoding.equals("gzip", ignoreCase = true)
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/LiveDataUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/LiveDataUtils.kt
@@ -3,7 +3,7 @@ package com.chuckerteam.chucker.internal.support
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 
-fun <T> LiveData<T>.observeOnce(observer: Observer<T>) {
+internal fun <T> LiveData<T>.observeOnce(observer: Observer<T>) {
     observeForever(object : Observer<T> {
         override fun onChanged(t: T?) {
             observer.onChanged(t)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -16,7 +16,8 @@ import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
 import java.util.HashSet
 
-class NotificationHelper(val context: Context) {
+internal class NotificationHelper(val context: Context) {
+
     companion object {
         private const val CHANNEL_ID = "chucker"
         private const val TRANSACTION_NOTIFICATION_ID = 1138
@@ -65,7 +66,7 @@ class NotificationHelper(val context: Context) {
         }
     }
 
-    internal fun show(transaction: HttpTransaction) {
+    fun show(transaction: HttpTransaction) {
         addToBuffer(transaction)
         if (!BaseChuckerActivity.isInForeground) {
             val builder =
@@ -109,7 +110,7 @@ class NotificationHelper(val context: Context) {
         }
     }
 
-    internal fun show(throwable: RecordedThrowable) {
+    fun show(throwable: RecordedThrowable) {
         if (!BaseChuckerActivity.isInForeground) {
             val builder =
                 NotificationCompat.Builder(context, CHANNEL_ID)
@@ -144,11 +145,11 @@ class NotificationHelper(val context: Context) {
             return NotificationCompat.Action(R.drawable.chucker_ic_delete_white_24dp, clearTitle, intent)
         }
 
-    internal fun dismissTransactionsNotification() {
+    fun dismissTransactionsNotification() {
         notificationManager.cancel(TRANSACTION_NOTIFICATION_ID)
     }
 
-    internal fun dismissErrorsNotification() {
+    fun dismissErrorsNotification() {
         notificationManager.cancel(ERROR_NOTIFICATION_ID)
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
@@ -10,7 +10,7 @@ import okhttp3.Response
 const val HTTP_CONTINUE = 100
 
 /** Returns true if the response must have a (possibly 0-length) body. See RFC 7231.  */
-fun Response.hasBody(): Boolean {
+internal fun Response.hasBody(): Boolean {
     // HEAD requests never yield a body regardless of the response headers.
     if (this.request().method() == "HEAD") {
         return false
@@ -29,12 +29,12 @@ fun Response.hasBody(): Boolean {
     return this.contentLenght != -1L || this.isChunked
 }
 
-val Response.contentLenght: Long
+internal val Response.contentLenght: Long
     get() {
         return this.header("Content-Length")?.toLongOrNull() ?: -1
     }
 
-val Response.isChunked: Boolean
+internal val Response.isChunked: Boolean
     get() {
         return this.header("Transfer-Encoding").equals("chunked", ignoreCase = true)
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/SearchHighlightUtil.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/SearchHighlightUtil.kt
@@ -11,7 +11,7 @@ import android.text.style.UnderlineSpan
  *
  * @param search the text to highlight
  */
-fun String.highlightWithDefinedColors(
+internal fun String.highlightWithDefinedColors(
     search: String,
     backgroundColor: Int,
     foregroundColor: Int

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/BaseChuckerActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/BaseChuckerActivity.kt
@@ -19,7 +19,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 
-abstract class BaseChuckerActivity : AppCompatActivity() {
+internal abstract class BaseChuckerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -27,7 +27,7 @@ import com.chuckerteam.chucker.internal.ui.transaction.TransactionActivity
 import com.chuckerteam.chucker.internal.ui.transaction.TransactionAdapter
 import com.google.android.material.tabs.TabLayout
 
-class MainActivity :
+internal class MainActivity :
     BaseChuckerActivity(),
     TransactionAdapter.TransactionClickListListener,
     ErrorAdapter.ErrorClickListListener {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -32,7 +32,7 @@ import com.chuckerteam.chucker.internal.support.FormatUtils.getShareText
 import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
 import com.google.android.material.tabs.TabLayout
 
-class TransactionActivity : BaseChuckerActivity() {
+internal class TransactionActivity : BaseChuckerActivity() {
 
     private lateinit var title: TextView
     private lateinit var viewModel: TransactionViewModel
@@ -116,13 +116,10 @@ class TransactionActivity : BaseChuckerActivity() {
         private const val EXTRA_TRANSACTION_ID = "transaction_id"
         private var selectedTabPosition = 0
 
-        @JvmStatic
         fun start(context: Context, transactionId: Long) {
-            context.startActivity(
-                Intent(context, TransactionActivity::class.java).apply {
-                    putExtra(EXTRA_TRANSACTION_ID, transactionId)
-                }
-            )
+            val intent = Intent(context, TransactionActivity::class.java)
+            intent.putExtra(EXTRA_TRANSACTION_ID, transactionId)
+            context.startActivity(intent)
         }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -27,7 +27,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProviders
 import com.chuckerteam.chucker.R
 
-class TransactionOverviewFragment : Fragment() {
+internal class TransactionOverviewFragment : Fragment() {
 
     private lateinit var url: TextView
     private lateinit var method: TextView


### PR DESCRIPTION
## :page_facing_up: Context
Fix for #179 

## :pencil: Changes
- Updated visibility modifiers
- Changed fun for starting TransactionActivity, since after merging PR with `ViewModel` this fun was reverted to state before #137 
- Fixed typo, which appeared after #146 
- Replaced deprecated calls for JsonParser
