### PR TITLE
Mask true type of headersToRedact and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ val chuckerInterceptor = ChuckerInterceptor(
         // The max body content length, after this responses will be truncated.
         maxContentLength = 250000L,
         // List of headers to obfuscate in the Chucker UI
-        headersToRedact = listOf("Auth-Token"))
+        headersToRedact = setOf("Auth-Token"))
 
 // Don't forget to plug the ChuckerInterceptor inside the OkHttpClient
 val client = OkHttpClient.Builder()

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -35,10 +35,11 @@ class ChuckerInterceptor @JvmOverloads constructor(
     private val context: Context,
     private val collector: ChuckerCollector = ChuckerCollector(context),
     private val maxContentLength: Long = 250000L,
-    private val headersToRedact: MutableSet<String> = mutableSetOf()
+    headersToRedact: Set<String> = emptySet()
 ) : Interceptor {
 
     private val io: IOUtils = IOUtils(context)
+    private val headersToRedact: MutableSet<String> = headersToRedact.toMutableSet()
 
     fun redactHeader(name: String) = apply {
         headersToRedact.add(name)

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -30,7 +30,7 @@ class HttpBinClient(
         context = context,
         collector = collector,
         maxContentLength = 250000L,
-        headersToRedact = emptySet()
+        headersToRedact = emptySet<String>()
     )
 
     private val httpClient =

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -29,7 +29,8 @@ class HttpBinClient(
     private val chuckerInterceptor = ChuckerInterceptor(
         context = context,
         collector = collector,
-        maxContentLength = 250000L
+        maxContentLength = 250000L,
+        headersToRedact = emptySet()
     )
 
     private val httpClient =


### PR DESCRIPTION
## :page_facing_up: Context
When using ```ChuckerInterceptor```, you are forced to used a ```MutableSet``` for ```headersToRedact``` parameter.
It is better to mask the true type of ```headersToRedact```  and expose a simple ```Set```.

## :pencil: Changes
I change ```ChuckerInterceptor``` to accept a simple ```Set```.
I also upgrade *README* which was correct for this parameter.
