### PR TITLE
CI pipeline optimisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ android:
     - extra-google-m2repository
 
 script:
-   - ./gradlew clean build lint ktlintCheck detekt test
+   - ./gradlew clean ktlintCheck lint detekt build test


### PR DESCRIPTION
## :page_facing_up: Context
Current CI process can be optimised. For example, I am always annoyed when I have to wait till build passes only to find out that ktLint or Detekt finds some issues and fails the whole pipeline.
Since ktLint and Detekt don't require the build result we can put them first in the pipeline to follow `Fail fast` principle and provide contributors faster feedback on their code quality status.
For example, locally ktLint task takes only 4 seconds for me, so it is much better than waiting some time till build finishes.

## :pencil: Changes
Changed the order of commands in Travis CI config.

## :crystal_ball: Next steps
Going to do further process optimisations to speed up builds and do some fine tuning for used tools
