### PR TITLE
Fix for wrong class used for extending in ErrorActivity

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
@@ -7,7 +7,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.TextView
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.Observer
 import com.chuckerteam.chucker.R

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
@@ -13,9 +13,10 @@ import androidx.lifecycle.Observer
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
+import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
 import java.text.DateFormat
 
-internal class ErrorActivity : AppCompatActivity() {
+internal class ErrorActivity : BaseChuckerActivity() {
 
     private var throwableId: Long = 0
     private var throwable: RecordedThrowable? = null


### PR DESCRIPTION
## :page_facing_up: Context
`ErrorActivity` should extend `BaseChuckerActivity` as well, since that base class is used for checks whenever the app is in background/foreground and, correspondingly, for firing/not firing pushes.

## :pencil: Changes
Changed only one line in `ErrorActivity` declaration.

## :crystal_ball: Next steps
Consider using `ActivityLifecycleCallbacks` for such cases.