### PR TITLE
WIP: Hide library resources

### DIFF
--- a/library/src/main/res/values/public.xml
+++ b/library/src/main/res/values/public.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ~This file should make other resources private during build -->
+<resources>
+  <public />
+</resources>


### PR DESCRIPTION
## :camera: Screenshots
*Show us what you've changed, we love images.*

## :page_facing_up: Context
After fixing visibility for internal classes I decided to also try to make all the resources we have (like strings) private, so users won't see them in autocomplete suggestions.
According to https://developer.android.com/studio/projects/android-library#PrivateResources
all we need to do is to create some public resource (might be even empty), so others are marked as private in final `aar`. 
Unfortunately, this approach won't work when the library added as module, like we have in sample app, so wasn't able to check locally.

## :pencil: Changes
Added a resource marked as public.

## :warning: Breaking
*Is there something breaking in the API? Any class or method signature changed?*