### PR TITLE
Hide library resources

### DIFF
--- a/library/src/main/res/values/public.xml
+++ b/library/src/main/res/values/public.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- ~This file should make other resources private during build -->
+<!-- This file should make other resources private during build -->
 <resources>
   <public />
 </resources>

--- a/library/src/main/res/values/public.xml
+++ b/library/src/main/res/values/public.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- ~This file should make other resources private during build -->
+<resources>
+  <public />
+</resources>


### PR DESCRIPTION
## :camera: Screenshots
Before:
<img width="431" alt="Screen Shot 2020-01-16 at 21 59 33" src="https://user-images.githubusercontent.com/13467769/72563184-cabf6b80-38b5-11ea-9e93-ec5dc317cf8a.png">
After:
<img width="180" alt="Screen Shot 2020-01-16 at 23 04 53" src="https://user-images.githubusercontent.com/13467769/72563194-ceeb8900-38b5-11ea-817c-073bf760579f.png">

## :page_facing_up: Context
After fixing visibility for internal classes I decided to also try to make all the resources we have (like strings, drawables, values, etc.) private, so users won't see them in autocomplete suggestions.
According to https://developer.android.com/studio/projects/android-library#PrivateResources
all we need to do is to create some public resource (might be even empty), so others are marked as private in final `aar`.
Unfortunately, this approach won't work when the library added as module, like we have in sample app, so wasn't able to check locally.

## :pencil: Changes
Added a single resource marked as public.

## :warning: Breaking
Nothing wrong expected.

## :pencil: How to test
Try to get snapshot from Jitpack as `com.github.ChuckerTeam:Chucker:fix~hide_resources-SNAPSHOT` and try to check autocomplete in the app using this dependency.
