### PR TITLE
Headers redaction refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ It is intended for **use during development**, and not in release builds or othe
 You can redact headers that contain sensitive information by calling `redactHeader(String)` on the `ChuckerInterceptor`.
 
 ```kotlin
-interceptor.redactHeader("Auth-Token");
-interceptor.redactHeader("User-Session");
+interceptor.redactHeader("Auth-Token", "User-Session");
 ```
 
 ## Migrating 🚗

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -41,6 +41,7 @@ class ChuckerInterceptor @JvmOverloads constructor(
     private val io: IOUtils = IOUtils(context)
     private val headersToRedact: MutableSet<String> = headersToRedact.toMutableSet()
 
+    /** Adds [headerName] into [headersToRedact] */
     fun redactHeader(vararg headerName: String) {
         headersToRedact.addAll(headerName)
     }

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -29,7 +29,7 @@ private const val MAX_BLOB_SIZE = 1000_000L
  * before they are truncated. Warning: setting this value too high may cause unexpected
  * results.
  * @param headersToRedact Set of headers that you want to redact. They will be replaced
- * with a `**` in the ChuckerUI.
+ * with a `**` in the Chucker UI.
  */
 class ChuckerInterceptor @JvmOverloads constructor(
     private val context: Context,

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -28,7 +28,7 @@ private const val MAX_BLOB_SIZE = 1000_000L
  * @param maxContentLength The maximum length for request and response content
  * before they are truncated. Warning: setting this value too high may cause unexpected
  * results.
- * @param headersToRedact Set of headers that you want to redact. They will be replaced
+ * @param headersToRedact a [Set] of headers that you want to redact. They will be replaced
  * with a `**` in the Chucker UI.
  */
 class ChuckerInterceptor @JvmOverloads constructor(

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -28,8 +28,8 @@ private const val MAX_BLOB_SIZE = 1000_000L
  * @param maxContentLength The maximum length for request and response content
  * before they are truncated. Warning: setting this value too high may cause unexpected
  * results.
- * @param headersToRedact List of headers that you want to redact. They will be not be shown in
- * the ChuckerUI but will be replaced with a `**`.
+ * @param headersToRedact Set of headers that you want to redact. They will be replaced
+ * with a `**` in the ChuckerUI.
  */
 class ChuckerInterceptor @JvmOverloads constructor(
     private val context: Context,
@@ -41,8 +41,8 @@ class ChuckerInterceptor @JvmOverloads constructor(
     private val io: IOUtils = IOUtils(context)
     private val headersToRedact: MutableSet<String> = headersToRedact.toMutableSet()
 
-    fun redactHeader(name: String) = apply {
-        headersToRedact.add(name)
+    fun redactHeader(vararg headerName: String) {
+        headersToRedact.addAll(headerName)
     }
 
     @Throws(IOException::class)

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -158,7 +158,7 @@ class ChuckerInterceptor @JvmOverloads constructor(
     private fun filterHeaders(headers: Headers): Headers {
         val builder = headers.newBuilder()
         for (name in headers.names()) {
-            if (name in headersToRedact) {
+            if (headersToRedact.any { userHeader -> userHeader.equals(name, ignoreCase = true) }) {
                 builder.set(name, "**")
             }
         }


### PR DESCRIPTION
## :page_facing_up: Context
After merging #181 I decided to review some of the code, which works with headers and simplify it a little bit both in terms of usage and code quality.
During this work I found out that comparison of headers in `filterHeaders` was case-sensitive, while [the official HTTP standard](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) states that header field names are case-insensitive. So, it means that the library had a bug, which I also fixed here.

## :pencil: Changes
- Changed parameter type in `redactHeader()` function to accept `vararg` (note, that nothing changes for existing users).
- Replaced headers comparison with case-insensitive alternative
- Updated Readme and `ChuckerInterceptor` documentation to match changes.

## :warning: Breaking
No
