### PR TITLE
Added ability to iterate through search results in response pane

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -57,6 +57,9 @@ internal class TransactionPayloadFragment :
     private var backgroundSpanColor: Int = Color.YELLOW
     private var foregroundSpanColor: Int = Color.RED
 
+    private var highlightBackgroundSpanColor: Int = Color.BLUE
+    private var hightlightForegroundSpanColor: Int = Color.WHITE
+
     private var type: Int = 0
 
     private lateinit var viewModel: TransactionViewModel
@@ -140,6 +143,8 @@ internal class TransactionPayloadFragment :
         super.onAttach(context)
         backgroundSpanColor = ContextCompat.getColor(context, R.color.chucker_background_span_color)
         foregroundSpanColor = ContextCompat.getColor(context, R.color.chucker_foreground_span_color)
+        highlightBackgroundSpanColor = ContextCompat.getColor(context, R.color.chucker_highlight_background_span_color)
+        hightlightForegroundSpanColor = ContextCompat.getColor(context, R.color.chucker_highlight_foreground_span_color)
     }
 
     @RequiresApi(Build.VERSION_CODES.KITKAT)
@@ -174,7 +179,14 @@ internal class TransactionPayloadFragment :
         }
     }
 
-    override fun onQueryTextSubmit(query: String): Boolean = false
+    override fun onQueryTextSubmit(query: String): Boolean {
+        val adapter = (transactionContentList.adapter as TransactionBodyAdapter)
+        if (adapter.hasSearchResults()) {
+            adapter.goToNextHighlightLine(backgroundSpanColor, foregroundSpanColor, highlightBackgroundSpanColor, hightlightForegroundSpanColor)
+            return true
+        }
+        return false
+    }
 
     override fun onQueryTextChange(newText: String): Boolean {
         val adapter = (transactionContentList.adapter as TransactionBodyAdapter)
@@ -248,7 +260,7 @@ internal class TransactionPayloadFragment :
             val recyclerView: RecyclerView? = fragment.view?.findViewById(R.id.transaction_content)
             progressBar?.visibility = View.INVISIBLE
             recyclerView?.visibility = View.VISIBLE
-            recyclerView?.adapter = TransactionBodyAdapter(result)
+            recyclerView?.adapter = TransactionBodyAdapter(result, recyclerView?.layoutManager!!, recyclerView.context)
         }
     }
 

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -21,4 +21,7 @@
 
     <color name="chucker_background_span_color">#ffffff00</color>
     <color name="chucker_foreground_span_color">#ffff0000</color>
+
+    <color name="chucker_highlight_background_span_color">#ff0000ff</color>
+    <color name="chucker_highlight_foreground_span_color">#ffffffff</color>
 </resources>


### PR DESCRIPTION
This uses the  IME search action button as the method for iterating through search resultt

## :camera: Screenshots
Video here:
![iterate](https://user-images.githubusercontent.com/801410/72778812-d3be7e80-3bce-11ea-9058-318cc20cec52.gif)




## :page_facing_up: Context
*Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an extarnal link?*
I was looking for an easy way to iterate between multiple search results in long json responses viewed through Chucker.

## :pencil: Changes
*Which code did you change? How?*
The transaction adapter/fragment code. Added a few mutable variables to keep track of state, open to any suggestions for clean up, I was just getting something easy in for my purposes.

## :paperclip: Related PR
*PR that blocks this one, or the ones blocked by this PR*

## :warning: Breaking
*Is there something breaking in the API? Any class or method signature changed?*
None that I could spot, the search IME action button was previously unused.
## :pencil: How to test
*Is there a special case to test your changes?*
Just follow the video example
## :crystal_ball: Next steps
*Do we have to plan something else after the merge?*
None currently, thanks!