### PR TITLE
Fix/response body

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -192,8 +192,6 @@ class ChuckerInterceptor @JvmOverloads constructor(
                 Log.w(LOG_TAG, "gzip encoded response was too long")
             }
         }
-        // Let's clone the response Buffer in order to don't cause an IllegalStateException: closed
-        //  if others interceptors are manipulating the body (see #192).
         return response.body()?.source()?.buffer()
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -162,7 +162,6 @@ class ChuckerInterceptor @JvmOverloads constructor(
                     transaction.responseImageData = buffer.readByteArray()
                 }
             }
-            transaction.responseContentLength = buffer.size()
         }
     }
 


### PR DESCRIPTION
## :page_facing_up: Context
Fix for #203 
Now we are creating a complete response copy to pass further the chain of interceptors to be sure that Chucker doesn't break anything during processing.

## :pencil: Changes
- Removed redundant response size reassigning (to avoid 0 in size)
- Added `newBuilder()` for response to get a copy of original response.

## :warning: Breaking
Nope