### PR TITLE
Fix for Empty Response Body and 0 Content Lenght

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -1,21 +1,17 @@
 package com.chuckerteam.chucker.api
 
 import android.content.Context
-import android.util.Log
-import com.chuckerteam.chucker.api.Chucker.LOG_TAG
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.support.IOUtils
 import com.chuckerteam.chucker.internal.support.hasBody
 import java.io.IOException
 import java.nio.charset.Charset
-import java.nio.charset.UnsupportedCharsetException
 import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody
 import okio.Buffer
-import okio.BufferedSource
 import okio.GzipSource
 
 /**

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -158,7 +158,9 @@ class ChuckerInterceptor @JvmOverloads constructor(
         } else {
             transaction.isResponseBodyPlainText = false
 
-            val isImageContentType = (transaction.responseContentType?.contains(CONTENT_TYPE_IMAGE, ignoreCase = true) == true)
+            val isImageContentType =
+                (contentType?.toString()?.contains(CONTENT_TYPE_IMAGE, ignoreCase = true) == true)
+
             if (isImageContentType && buffer.size() < MAX_BLOB_SIZE) {
                 transaction.responseImageData = buffer.readByteArray()
             }

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -143,7 +143,7 @@ class ChuckerInterceptor @JvmOverloads constructor(
         source.request(Long.MAX_VALUE) // Buffer the entire body.
         var buffer = source.buffer()
 
-        if (CONTENT_ENCODING_GZIP.equals(response.headers()[CONTENT_ENCODING], ignoreCase = true)) {
+        if (io.bodyIsGzipped(response.headers()[CONTENT_ENCODING])) {
             GzipSource(buffer.clone()).use { gzippedResponseBody ->
                 buffer = Buffer()
                 buffer.writeAll(gzippedResponseBody)
@@ -181,7 +181,6 @@ class ChuckerInterceptor @JvmOverloads constructor(
 
         private const val MAX_BLOB_SIZE = 1000_000L
 
-        private const val CONTENT_ENCODING_GZIP = "gzip"
         private const val CONTENT_TYPE_IMAGE = "image"
         private const val CONTENT_ENCODING = "Content-Encoding"
     }

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -158,7 +158,7 @@ class ChuckerInterceptor @JvmOverloads constructor(
         } else {
             transaction.isResponseBodyPlainText = false
 
-            val isImageContentType = (transaction.responseContentType?.contains(CONTENT_TYPE_IMAGE) == true)
+            val isImageContentType = (transaction.responseContentType?.contains(CONTENT_TYPE_IMAGE, ignoreCase = true) == true)
             if (isImageContentType && buffer.size() < MAX_BLOB_SIZE) {
                 transaction.responseImageData = buffer.readByteArray()
             }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
@@ -67,5 +67,9 @@ internal class IOUtils(private val context: Context) {
             contentEncoding.equals("identity", ignoreCase = true) ||
             contentEncoding.equals("gzip", ignoreCase = true)
 
-    fun bodyIsGzipped(contentEncoding: String?) = contentEncoding?.equals("gzip", ignoreCase = true) ?: false
+    fun bodyIsGzipped(contentEncoding: String?) = CONTENT_ENCODING_GZIP.equals(contentEncoding, ignoreCase = true)
+
+    private companion object {
+        const val CONTENT_ENCODING_GZIP = "gzip"
+    }
 }

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -36,8 +36,8 @@ class HttpBinClient(
     private val httpClient =
         OkHttpClient.Builder()
             // Add a ChuckerInterceptor instance to your OkHttp client
-            .addInterceptor(chuckerInterceptor)
             .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
+            .addInterceptor(chuckerInterceptor)
             .build()
 
     private val api: HttpBinApi by lazy {

--- a/sample/src/main/res/xml/network_security_config.xml
+++ b/sample/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>

--- a/sample/src/main/res/xml/network_security_config.xml
+++ b/sample/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<network-security-config>
-    <debug-overrides>
-        <trust-anchors>
-            <!-- Trust user added CAs while debuggable only -->
-            <certificates src="user" />
-        </trust-anchors>
-    </debug-overrides>
-</network-security-config>


### PR DESCRIPTION
Fixes a bug introduce by me in #198, when implementing clone of the `okio.Buffer` from the HTTP Response.

Looks like the problem on our end what that we were using `ChuckerInterceptor` as first interceptors, so the Sample App showed valid results. Switching order of the interceptors showed that responses are `null` and the approach followed for the `.clone()` was not correct. I reimplemented it following the `HttpLoggingInterceptor` body.

# How to test

Remove the fix I applied on `ChuckerInterceptor` and keep only the changes I applied in the sample app. It should break and show `null` in the response body.

Fixes #203
Closes #205 