### PR TITLE
Fix for redundant toolbar collapsing

### DIFF
--- a/library/src/main/res/layout/chucker_activity_transaction.xml
+++ b/library/src/main/res/layout/chucker_activity_transaction.xml
@@ -33,13 +33,13 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            app:layout_scrollFlags="scroll|enterAlways|snap"
             app:popupTheme="@style/Chucker.Theme" >
 
             <TextView
                 android:id="@+id/toolbar_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/chucker_doub_grid"
                 style="@style/Chucker.TextAppearance.TransactionTitle"
                 tools:text="Title"/>
 

--- a/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
@@ -10,9 +10,10 @@
 
     <ProgressBar
         android:id="@+id/progress_loading_transaction"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:indeterminate="true"
+        android:layout_gravity="center"
         android:layout_margin="@dimen/chucker_doub_grid"
         android:visibility="visible" />
 


### PR DESCRIPTION
## :camera: Screenshots
| Before | After |
| --- | --- |
|![toolbar_before](https://user-images.githubusercontent.com/13467769/73213069-388e5180-4158-11ea-9d87-828d2d58ad0c.gif) |![toolbar_after](https://user-images.githubusercontent.com/13467769/73213081-3b894200-4158-11ea-9e35-11bf7a9addee.gif) |

## :page_facing_up: Context
Both in Chuck and Chucker I was always seeing the same bug where switching from `Overview` to `Response` tab made the toolbar collapse. Scrolling the content won't return the toolbar and user has to do a downwards scroll on `TabLayout` to bring the toolbar back. I believe that for this screen there is no need in toolbar hiding, so remove scroll flags from it.

## :pencil: Changes
- Removed scroll flags from `Toolbar` in `TransactionActivity`
- Fixed the position of `ProgressBar` in `Response` tab.