### PR TITLE
Fix/gradle properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,9 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-VERSION_NAME=3.1.0
-# 3*100*100 + 0*100 + 1 => 30001
-VERSION_CODE=30100
+VERSION_NAME=3.1.1
+# 3*100*100 + 1*100 + 1 => 30101
+VERSION_CODE=30101
 GROUP=com.github.chuckerteam.chucker
 
 POM_REPO_NAME=Chucker

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 
 VERSION_NAME=3.1.0
 # 3*100*100 + 0*100 + 1 => 30001


### PR DESCRIPTION
## :page_facing_up: Context
Found out that during 3.1.1 release forgot to update version name. Fixing this.
Also, saw that Chucker doesn't use `parallel` builds. Don't reasons to not use it.

## :pencil: Changes
- Bumped version name.
- Uncommented `org.gradle.parallel=true`

## :crystal_ball: Next steps
Republish 3.1.1 tag from `release` branch with updated info.
