### PR TITLE
Fix for version name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,11 +14,11 @@ org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 
-VERSION_NAME=3.1.0
-# 3*100*100 + 0*100 + 1 => 30001
-VERSION_CODE=30100
+VERSION_NAME=3.1.1
+# 3*100*100 + 1*100 + 1 => 30101
+VERSION_CODE=30101
 GROUP=com.github.chuckerteam.chucker
 
 POM_REPO_NAME=Chucker

--- a/library/src/main/res/layout/chucker_activity_transaction.xml
+++ b/library/src/main/res/layout/chucker_activity_transaction.xml
@@ -33,13 +33,13 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
-            app:layout_scrollFlags="scroll|enterAlways|snap"
             app:popupTheme="@style/Chucker.Theme" >
 
             <TextView
                 android:id="@+id/toolbar_title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/chucker_doub_grid"
                 style="@style/Chucker.TextAppearance.TransactionTitle"
                 tools:text="Title"/>
 

--- a/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
@@ -10,9 +10,10 @@
 
     <ProgressBar
         android:id="@+id/progress_loading_transaction"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:indeterminate="true"
+        android:layout_gravity="center"
         android:layout_margin="@dimen/chucker_doub_grid"
         android:visibility="visible" />
 


### PR DESCRIPTION
## :page_facing_up: Context
During 3.1.1 release preparation version name and code weren't updated. 
This PR resolves that issue, so the tag 3.1.1 can be recreated with proper versions.

## :pencil: Changes
- Updated `gradle.properties` #211
- Minor fix for collapsing toolbar issue #210 

## :crystal_ball: Next steps
Recreate tag `3.1.1` and republish it.