### PR TITLE
Fix for curl command

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
@@ -145,7 +145,7 @@ internal object FormatUtils {
 
     fun getShareCurlCommand(transaction: HttpTransaction): String {
         var compressed = false
-        var curlCmd = "curl -X $transaction.method"
+        var curlCmd = "curl -X ${transaction.method}"
         val headers = transaction.getParsedRequestHeaders()
 
         headers?.forEach { header ->
@@ -154,13 +154,13 @@ internal object FormatUtils {
             ) {
                 compressed = true
             }
-            curlCmd += " -H \"$header.name: $header.value\""
+            curlCmd += " -H \"${header.name}: ${header.value}\""
         }
 
         val requestBody = transaction.requestBody
         if (!requestBody.isNullOrEmpty()) {
             // try to keep to a single line and use a subshell to preserve any line breaks
-            curlCmd += " --data $'$requestBody.replace(\"\\n\", \"\\\\n\")'"
+            curlCmd += " --data $'${requestBody.replace("\n", "\\n")}'"
         }
         curlCmd += (if (compressed) " --compressed " else " ") + transaction.url
         return curlCmd


### PR DESCRIPTION
## :camera: Screenshots
| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/13467769/73309368-c2a6ea80-422a-11ea-944c-25d4bf2c192f.png) | ![After](https://user-images.githubusercontent.com/13467769/73309373-c5094480-422a-11ea-8c3f-d07ed242ab72.png) |
<img width="332" alt="Screen Shot 2020-01-28 at 23 54 20" src="https://user-images.githubusercontent.com/13467769/73309420-d9e5d800-422a-11ea-9249-3682eff0242f.png">
<img width="366" alt="Screen Shot 2020-01-28 at 23 56 24" src="https://user-images.githubusercontent.com/13467769/73309423-dbaf9b80-422a-11ea-9212-5caa66b8e046.png">
<img width="483" alt="Screen Shot 2020-01-28 at 23 56 31" src="https://user-images.githubusercontent.com/13467769/73309430-e1a57c80-422a-11ea-936c-ad1f5ffda16a.png">

## :page_facing_up: Context
It seems that in `3.1.0` and `3.1.1` respectively we have a bug with generated curl share command.
It happens due to incorrect string interpolation usage (see attached screenshots).

## :pencil: Changes
- Added curly braces into all required calls in `getShareCurlCommand()`
