### PR TITLE
Fix R8 minification crash on TransactionViewModel creation.

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
@@ -27,6 +27,7 @@ internal class TransactionViewModel(private val transactionId: Long) : ViewModel
 internal class TransactionViewModelFactory(private val transactionId: Long = 0L) :
     ViewModelProvider.Factory {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-        return modelClass.getConstructor(Long::class.java).newInstance(transactionId)
+        require(modelClass == TransactionViewModel::class.java) { "Cannot create $modelClass" }
+        return TransactionViewModel(transactionId) as T
     }
 }


### PR DESCRIPTION
## :page_facing_up: Context
*Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an extarnal link?*
https://github.com/ChuckerTeam/chucker/issues/217

## :pencil: Changes
*Which code did you change? How?*
`TransactionViewModelFactory` uses now ViewModel's constructor instead of obtaining it via reflection.

## :warning: Breaking
*Is there something breaking in the API? Any class or method signature changed?*
No. Only internal API changes.

## :pencil: How to test
*Is there a special case to test your changes?*
Run a sample app that is minified with R8 in full mode. It will crash when one wants to open Chucker.

## :crystal_ball: Next steps
*Do we have to plan something else after the merge?*
No.
