### PR TITLE
Fix clear action crash when application is dead

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
@@ -10,11 +10,13 @@ internal class ClearDatabaseService : IntentService(CLEAN_DATABASE_SERVICE_NAME)
     override fun onHandleIntent(intent: Intent?) {
         when (intent?.getSerializableExtra(EXTRA_ITEM_TO_CLEAR)) {
             is ClearAction.Transaction -> {
+                RepositoryProvider.initialize(applicationContext)
                 RepositoryProvider.transaction().deleteAllTransactions()
                 NotificationHelper.clearBuffer()
                 NotificationHelper(this).dismissTransactionsNotification()
             }
             is ClearAction.Error -> {
+                RepositoryProvider.initialize(applicationContext)
                 RepositoryProvider.throwable().deleteAllThrowables()
                 NotificationHelper(this).dismissErrorsNotification()
             }


### PR DESCRIPTION
## :page_facing_up: Context
Found a case when Chucker would crash, but since it is incorporated into other apps the dialog with `[App name] stopped` appears and might confuse devs. This happens if the app with Chucker is killed (for example, via swiping from recents screen) and user tries to click `Clear` in Chucker notification. Since the app is killed, so as `RepositoryProvider` and, thus, we get crash, since both `transaction()` and `throwable()` functions use `checkNonNull()`.

## :pencil: Changes
Added call to `initialize()`, so clear action will always have an instance to work with.

## :pencil: How to test
To get crash on current `develop` version get some notifications, kill the app, try to click on `Clear` in network or throwable notifications.