### PR TITLE
Fix for NPE in NotificationHelper

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -107,7 +107,7 @@ internal class NotificationHelper(val context: Context) {
             synchronized(transactionBuffer) {
                 var count = 0
                 (transactionBuffer.size() - 1 downTo 0).forEach { i ->
-                    if (count < BUFFER_SIZE) {
+                    if (count < BUFFER_SIZE && (transactionBuffer.valueAt(i) != null)) {
                         if (count == 0) {
                             builder.setContentText(transactionBuffer.valueAt(i).notificationText)
                         }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -107,11 +107,12 @@ internal class NotificationHelper(val context: Context) {
             synchronized(transactionBuffer) {
                 var count = 0
                 (transactionBuffer.size() - 1 downTo 0).forEach { i ->
-                    if (count < BUFFER_SIZE && (transactionBuffer.valueAt(i) != null)) {
+                    val bufferedTransaction = transactionBuffer.valueAt(i)
+                    if ((bufferedTransaction != null) && count < BUFFER_SIZE) {
                         if (count == 0) {
-                            builder.setContentText(transactionBuffer.valueAt(i).notificationText)
+                            builder.setContentText(bufferedTransaction.notificationText)
                         }
-                        inboxStyle.addLine(transactionBuffer.valueAt(i).notificationText)
+                        inboxStyle.addLine(bufferedTransaction.notificationText)
                     }
                     count++
                 }


### PR DESCRIPTION
## :page_facing_up: Context
Fix, which should protect from issues, like #168 in `NotificationHelper`. Checks for `transaction` in `transactionBuffer` being `null` should protect from cases described in the mentioned issue.

## :pencil: Changes
Add explicit check for `null` value in `transactionBuffer`.