### PR TITLE
Fix an issue with negative request/response sizes displayed.

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -196,7 +196,7 @@ internal class HttpTransaction(
     }
 
     private fun formatBytes(bytes: Long): String {
-        return FormatUtils.formatByteCount(bytes, true)
+        return FormatUtils.formatByteCount(bytes.coerceAtLeast(0), true)
     }
 
     fun getFormattedRequestBody(): String {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -34,8 +34,8 @@ internal class HttpTransactionTuple(
 
     val totalSizeString: String
         get() {
-            val reqBytes = requestContentLength ?: 0
-            val resBytes = responseContentLength ?: 0
+            val reqBytes = requestContentLength?.coerceAtLeast(0) ?: 0
+            val resBytes = responseContentLength?.coerceAtLeast(0) ?: 0
             return formatBytes(reqBytes + resBytes)
         }
 


### PR DESCRIPTION
## :camera: Screenshots
*Show us what you've changed, we love images.*

![Screenshot_1581268679](https://user-images.githubusercontent.com/30936061/74109654-768e6b00-4b85-11ea-8d08-e73977bcf9da.png)
![Screenshot_1581269196](https://user-images.githubusercontent.com/30936061/74109657-7c844c00-4b85-11ea-90a9-6679212cbf82.png)

## :page_facing_up: Context
*Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an extarnal link?*

I introduced a bug with one of the previous PRs.

## :pencil: Changes
*Which code did you change? How?*

I modified the response/request length on the UI level to display at lest `0` as a minimum value.

## :warning: Breaking
*Is there something breaking in the API? Any class or method signature changed?*

No.

## :pencil: How to test
*Is there a special case to test your changes?*

Run the sample app. Requests and responses should display `0 B` instead of `-1 B` for some of the responses.

## :crystal_ball: Next steps
*Do we have to plan something else after the merge?*

No.
