### PR TITLE
Update Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,26 +4,26 @@ about: Create a report to help us improve
 
 ---
 
-## :loudspeaker: Describe the bug
-*A clear and concise description of what the bug is.*
+## :writing_hand: Describe the bug
+<!-- A clear and concise description of what the bug is. -->
 
-## :bomb: To Reproduce
-*Steps to reproduce the behavior:*
+## :bomb: Steps to reproduce
+<!-- How we can reproduce the behavior: -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-### :wrench: Expected behavior
-*A clear and concise description of what you expected to happen.*
+## :wrench: Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
 ## :camera: Screenshots
-*If applicable, add screenshots to help explain your problem.*
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-## :iphone: Smartphone
- - Device: *e.g. Nexus 6P*
- - OS: *e.g. 7.1.1*
- - Lib version: *e.g. 2.0.2*
+## :iphone: Tech info
+ - Device: <!-- e.g. Nexus 6P -->
+ - OS: <!-- e.g. 7.1.1 -->
+ - Chucker version: <!-- e.g. 3.1.2 -->
 
 ## :page_facing_up: Additional context
-*Add any other context about the problem here.*
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 
 ---
 
-## :warning: Is your feature request related to a problem? Please describe.
+## :warning: Is your feature request related to a problem? Please describe
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ## :bulb: Describe the solution you'd like

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,17 +5,17 @@ about: Suggest an idea for this project
 ---
 
 ## :warning: Is your feature request related to a problem? Please describe.
-*A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]*
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
-## :dart: Describe the solution you'd like
-*A clear and concise description of what you want to happen.*
+## :bulb: Describe the solution you'd like
+<!-- A clear and concise description of what you want to happen. -->
 
 ## :bar_chart: Describe alternatives you've considered
-*A clear and concise description of any alternative solutions or features you've considered.*
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 ## :page_facing_up: Additional context
-*Add any other context or screenshots about the feature request here.*
+<!-- Add any other context or screenshots about the feature request here. -->
 
-## :pencil: Do you want to develop this feature yourself?
+## :raising_hand: Do you want to develop this feature yourself?
 - [ ] Yes
 - [X] No

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,4 +18,4 @@ about: Suggest an idea for this project
 
 ## :raising_hand: Do you want to develop this feature yourself?
 - [ ] Yes
-- [X] No
+- [ ] No

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,20 +1,20 @@
 ## :camera: Screenshots
-*Show us what you've changed, we love images.*
+<!-- Show us what you've changed, we love images. -->
 
 ## :page_facing_up: Context
-*Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an extarnal link?*
+<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
 
 ## :pencil: Changes
-*Which code did you change? How?*
+<!-- Which code did you change? How? -->
 
 ## :paperclip: Related PR
-*PR that blocks this one, or the ones blocked by this PR*
+<!-- PR that blocks this one, or the ones blocked by this PR -->
 
-## :warning: Breaking
-*Is there something breaking in the API? Any class or method signature changed?*
+## :no_entry_sign: Breaking
+<!-- Is there something breaking the API? Any class or method signature changed? -->
 
-## :pencil: How to test
-*Is there a special case to test your changes?*
+## :hammer_and_wrench: How to test
+<!-- Is there a special case to test your changes? -->
 
-## :crystal_ball: Next steps
-*Do we have to plan something else after the merge?*
+## :stopwatch: Next steps
+<!-- Do we have to plan something else after the merge? -->


### PR DESCRIPTION
## :camera: Screenshots
| Bug | PR |
| --- | --- |
| ![bug](https://user-images.githubusercontent.com/13467769/74149662-f6ade280-4c10-11ea-8b5c-def39c5685c9.png) | ![feature_request](https://user-images.githubusercontent.com/13467769/74149666-f877a600-4c10-11ea-9a26-561b2fcc34db.png)
| PR |
|![PR](https://user-images.githubusercontent.com/13467769/74149667-f9103c80-4c10-11ea-864e-ea489c1ae06c.png)|

## :page_facing_up: Context
Wanted to just fix the typo in PR template, but ended up with updates to issues templates as well.
Now text in templates is marked as comment, so it won't appear in the message after editing.

## :pencil: Changes
- Fixed typo in `external` word in PR template.
- Switched to comments instead of regular text in all templates.
- Updated some emojis 😄 
