### PR TITLE
Add instruction for checkbox selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,5 +17,6 @@ about: Suggest an idea for this project
 <!-- Add any other context or screenshots about the feature request here. -->
 
 ## :raising_hand: Do you want to develop this feature yourself?
+<!-- Put an `x` symbol into braces of desired choise. -->
 - [ ] Yes
 - [ ] No


### PR DESCRIPTION
## :page_facing_up: Context
We might have users who have no experience with markdown, so they might have issues with selection in `Do you want to develop this feature yourself`. To address such cases I decided to add some basic instruction.

## :pencil: Changes
Added a comment into the `feature request` template.
