### PR TITLE
Switch to platform defined HTTP code constants

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -13,6 +13,7 @@ import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 import java.text.DateFormat
+import javax.net.ssl.HttpsURLConnection
 
 internal class TransactionAdapter internal constructor(
     context: Context,
@@ -79,12 +80,12 @@ internal class TransactionAdapter internal constructor(
 
         private fun setStatusColor(holder: ViewHolder, transaction: HttpTransactionTuple) {
             val color: Int = when {
-                transaction.status === HttpTransaction.Status.Failed -> colorError
-                transaction.status === HttpTransaction.Status.Requested -> colorRequested
-                transaction.responseCode == null -> colorDefault
-                transaction.responseCode!! >= SERVER_ERRORS -> color500
-                transaction.responseCode!! >= CLIENT_ERRORS -> color400
-                transaction.responseCode!! >= REDIRECTS -> color300
+                (transaction.status === HttpTransaction.Status.Failed) -> colorError
+                (transaction.status === HttpTransaction.Status.Requested) -> colorRequested
+                (transaction.responseCode == null) -> colorDefault
+                (transaction.responseCode!! >= HttpsURLConnection.HTTP_INTERNAL_ERROR) -> color500
+                (transaction.responseCode!! >= HttpsURLConnection.HTTP_BAD_REQUEST) -> color400
+                (transaction.responseCode!! >= HttpsURLConnection.HTTP_MULT_CHOICE) -> color300
                 else -> colorDefault
             }
             holder.code.setTextColor(color)
@@ -96,7 +97,3 @@ internal class TransactionAdapter internal constructor(
         fun onTransactionClick(transactionId: Long, position: Int)
     }
 }
-
-private const val SERVER_ERRORS = 500
-private const val CLIENT_ERRORS = 400
-private const val REDIRECTS = 300


### PR DESCRIPTION
## :page_facing_up: Context
Currently Chucker uses own constants to check HTTP status codes.
In Android we already have these constants, so why don't we switch to them instead of defining our constants?

## :pencil: Changes
Switched to `HttpsURLConnection` constants for status code checks.
