### PR TITLE
Fix HttpHeader serialization when obfuscation is enabled

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpHeader.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpHeader.kt
@@ -1,3 +1,8 @@
 package com.chuckerteam.chucker.internal.data.entity
 
-internal data class HttpHeader(val name: String, val value: String)
+import com.google.gson.annotations.SerializedName
+
+internal data class HttpHeader(
+    @SerializedName("name") val name: String,
+    @SerializedName("value") val value: String
+)


### PR DESCRIPTION
## :camera: Screenshots

## :page_facing_up: Context
I get this exception in `HttpTransaction.setRequestHeaders` when DexGuard is enabled:
```
java.lang.IllegalArgumentException: class o.bwy declares multiple JSON fields named ι
```

Mapping:
```
com.chuckerteam.chucker.api.internal.data.entity.HttpHeader -> o.bwy:
    java.lang.String name -> ι
    java.lang.String value -> Ι
```

## :pencil: Changes
Annotated fields in `HttpHeader` with `@SerializedName` so that Gson would know how to serialize that class when it's obfuscated.

## :paperclip: Related PR

## :no_entry_sign: Breaking

## :hammer_and_wrench: How to test

## :stopwatch: Next steps
