### PR TITLE
Add Action to validate the Gradle Wrapper

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,0 +1,10 @@
+name: Validate Gradle Wrapper
+on: [push, pull_request]
+
+jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
Let's add a simple GH action to validate the Gradle Wrapper just to play on the safe side.