### PR TITLE
Do not refresh transaction when it is not being affected.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         materialComponentsVersion = '1.1.0-rc02'
         roomVersion = '2.2.3'
         lifecycleVersion = '2.2.0'
+        androidXCore = '2.1.0'
 
         // Publishing
         androidMavenGradleVersion = '2.1'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
+    testImplementation "androidx.arch.core:core-testing:$androidXCore"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -245,6 +245,6 @@ internal class HttpTransaction(
             (responseHeaders == other.responseHeaders) &&
             (responseBody == other.responseBody) &&
             (isResponseBodyPlainText == other.isResponseBodyPlainText) &&
-            responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) == true
+            responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) != false
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -214,4 +214,43 @@ internal class HttpTransaction(
         scheme = url.scheme()
         return this
     }
+
+    // Not relying on 'equals' because comparison be long due to request and response sizes
+    // and it would be unwise to do this every time 'equals' is called.
+    @Suppress("ComplexMethod")
+    fun hasTheSameContent(other: HttpTransaction?): Boolean {
+        if (this === other) return true
+        if (other == null) return false
+
+        if (id != other.id) return false
+        if (requestDate != other.requestDate) return false
+        if (responseDate != other.responseDate) return false
+        if (tookMs != other.tookMs) return false
+        if (protocol != other.protocol) return false
+        if (method != other.method) return false
+        if (url != other.url) return false
+        if (host != other.host) return false
+        if (path != other.path) return false
+        if (scheme != other.scheme) return false
+        if (requestContentLength != other.requestContentLength) return false
+        if (requestContentType != other.requestContentType) return false
+        if (requestHeaders != other.requestHeaders) return false
+        if (requestBody != other.requestBody) return false
+        if (isRequestBodyPlainText != other.isRequestBodyPlainText) return false
+        if (responseCode != other.responseCode) return false
+        if (responseMessage != other.responseMessage) return false
+        if (error != other.error) return false
+        if (responseContentLength != other.responseContentLength) return false
+        if (responseContentType != other.responseContentType) return false
+        if (responseHeaders != other.responseHeaders) return false
+        if (responseBody != other.responseBody) return false
+        if (isResponseBodyPlainText != other.isResponseBodyPlainText) return false
+        val thisImageData = responseImageData
+        if (thisImageData != null) {
+            val otherImageData = other.responseImageData ?: return false
+            if (!thisImageData.contentEquals(otherImageData)) return false
+        } else if (other.responseImageData != null) return false
+
+        return true
+    }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -222,35 +222,29 @@ internal class HttpTransaction(
         if (this === other) return true
         if (other == null) return false
 
-        if (id != other.id) return false
-        if (requestDate != other.requestDate) return false
-        if (responseDate != other.responseDate) return false
-        if (tookMs != other.tookMs) return false
-        if (protocol != other.protocol) return false
-        if (method != other.method) return false
-        if (url != other.url) return false
-        if (host != other.host) return false
-        if (path != other.path) return false
-        if (scheme != other.scheme) return false
-        if (requestContentLength != other.requestContentLength) return false
-        if (requestContentType != other.requestContentType) return false
-        if (requestHeaders != other.requestHeaders) return false
-        if (requestBody != other.requestBody) return false
-        if (isRequestBodyPlainText != other.isRequestBodyPlainText) return false
-        if (responseCode != other.responseCode) return false
-        if (responseMessage != other.responseMessage) return false
-        if (error != other.error) return false
-        if (responseContentLength != other.responseContentLength) return false
-        if (responseContentType != other.responseContentType) return false
-        if (responseHeaders != other.responseHeaders) return false
-        if (responseBody != other.responseBody) return false
-        if (isResponseBodyPlainText != other.isResponseBodyPlainText) return false
-        val thisImageData = responseImageData
-        if (thisImageData != null) {
-            val otherImageData = other.responseImageData ?: return false
-            if (!thisImageData.contentEquals(otherImageData)) return false
-        } else if (other.responseImageData != null) return false
-
-        return true
+        return id == other.id &&
+            requestDate == other.requestDate &&
+            responseDate == other.responseDate &&
+            tookMs == other.tookMs &&
+            protocol == other.protocol &&
+            method == other.method &&
+            url == other.url &&
+            host == other.host &&
+            path == other.path &&
+            scheme == other.scheme &&
+            requestContentLength == other.requestContentLength &&
+            requestContentType == other.requestContentType &&
+            requestHeaders == other.requestHeaders &&
+            requestBody == other.requestBody &&
+            isRequestBodyPlainText == other.isRequestBodyPlainText &&
+            responseCode == other.responseCode &&
+            responseMessage == other.responseMessage &&
+            error == other.error &&
+            responseContentLength == other.responseContentLength &&
+            responseContentType == other.responseContentType &&
+            responseHeaders == other.responseHeaders &&
+            responseBody == other.responseBody &&
+            isResponseBodyPlainText == other.isResponseBodyPlainText &&
+            responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) == true
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -222,29 +222,29 @@ internal class HttpTransaction(
         if (this === other) return true
         if (other == null) return false
 
-        return id == other.id &&
-            requestDate == other.requestDate &&
-            responseDate == other.responseDate &&
-            tookMs == other.tookMs &&
-            protocol == other.protocol &&
-            method == other.method &&
-            url == other.url &&
-            host == other.host &&
-            path == other.path &&
-            scheme == other.scheme &&
-            requestContentLength == other.requestContentLength &&
-            requestContentType == other.requestContentType &&
-            requestHeaders == other.requestHeaders &&
-            requestBody == other.requestBody &&
-            isRequestBodyPlainText == other.isRequestBodyPlainText &&
-            responseCode == other.responseCode &&
-            responseMessage == other.responseMessage &&
-            error == other.error &&
-            responseContentLength == other.responseContentLength &&
-            responseContentType == other.responseContentType &&
-            responseHeaders == other.responseHeaders &&
-            responseBody == other.responseBody &&
-            isResponseBodyPlainText == other.isResponseBodyPlainText &&
+        return (id == other.id) &&
+            (requestDate == other.requestDate) &&
+            (responseDate == other.responseDate) &&
+            (tookMs == other.tookMs) &&
+            (protocol == other.protocol) &&
+            (method == other.method) &&
+            (url == other.url) &&
+            (host == other.host) &&
+            (path == other.path) &&
+            (scheme == other.scheme) &&
+            (requestContentLength == other.requestContentLength) &&
+            (requestContentType == other.requestContentType) &&
+            (requestHeaders == other.requestHeaders) &&
+            (requestBody == other.requestBody) &&
+            (isRequestBodyPlainText == other.isRequestBodyPlainText) &&
+            (responseCode == other.responseCode) &&
+            (responseMessage == other.responseMessage) &&
+            (error == other.error) &&
+            (responseContentLength == other.responseContentLength) &&
+            (responseContentType == other.responseContentType) &&
+            (responseHeaders == other.responseHeaders) &&
+            (responseBody == other.responseBody) &&
+            (isResponseBodyPlainText == other.isResponseBodyPlainText) &&
             responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) == true
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
+import com.chuckerteam.chucker.internal.support.distinctUntilChanged
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
@@ -19,7 +20,7 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
     }
 
     override fun getTransaction(transactionId: Long): LiveData<HttpTransaction> {
-        return transcationDao.getById(transactionId)
+        return transcationDao.getById(transactionId).distinctUntilChanged { old, new -> old.hasTheSameContent(new) }
     }
 
     override fun getSortedTransactionTuples(): LiveData<List<HttpTransactionTuple>> {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableDatabaseRepository.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
+import com.chuckerteam.chucker.internal.support.distinctUntilChanged
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
@@ -14,7 +15,7 @@ internal class RecordedThrowableDatabaseRepository(
     private val executor: Executor = Executors.newSingleThreadExecutor()
 
     override fun getRecordedThrowable(id: Long): LiveData<RecordedThrowable> {
-        return database.throwableDao().getById(id)
+        return database.throwableDao().getById(id).distinctUntilChanged()
     }
 
     override fun deleteAllThrowables() {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/LiveDataUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/LiveDataUtils.kt
@@ -1,0 +1,34 @@
+package com.chuckerteam.chucker.internal.support
+
+import android.annotation.SuppressLint
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
+import java.util.concurrent.Executor
+
+// Unlike built-in extension operation is performed on a provided thread pool.
+// This is needed in our case since we compare requests and responses which can be big
+// and result in frame drops.
+internal fun <T> LiveData<T>.distinctUntilChanged(
+    executor: Executor = ioExecutor(),
+    areEqual: (old: T, new: T) -> Boolean = { old, new -> old == new }
+): LiveData<T> {
+    val distinctMediator = MediatorLiveData<T>()
+    var old = uninitializedToken
+    distinctMediator.addSource(this) { new ->
+        executor.execute {
+            @Suppress("UNCHECKED_CAST")
+            if (old === uninitializedToken || !areEqual(old as T, new)) {
+                old = new
+                distinctMediator.postValue(new)
+            }
+        }
+    }
+    return distinctMediator
+}
+
+private val uninitializedToken: Any? = Any()
+
+// It is lesser evil than providing a custom executor.
+@SuppressLint("RestrictedApi")
+private fun ioExecutor() = ArchTaskExecutor.getIOThreadExecutor()

--- a/library/src/test/java/com/chuckerteam/chucker/TestUtils.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/TestUtils.kt
@@ -1,5 +1,7 @@
 package com.chuckerteam.chucker
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
 import java.io.File
 import okio.Buffer
 import okio.Okio
@@ -7,5 +9,39 @@ import okio.Okio
 fun getResourceFile(file: String): Buffer {
     return Buffer().apply {
         writeAll(Okio.buffer(Okio.source(File("./src/test/resources/$file"))))
+    }
+}
+
+fun <T> LiveData<T>.test(test: LiveDataRecord<T>.() -> Unit) {
+    val observer = RecordingObserver<T>()
+    observeForever(observer)
+    LiveDataRecord(observer).test()
+    removeObserver(observer)
+    observer.records.clear()
+}
+
+class LiveDataRecord<T> internal constructor(
+    private val observer: RecordingObserver<T>
+) {
+    fun expectData(): T {
+        if (observer.records.isEmpty()) {
+            throw AssertionError("Expected data but was empty.")
+        }
+        return observer.records.removeAt(0)
+    }
+
+    fun expectNoData() {
+        if (observer.records.isNotEmpty()) {
+            val data = observer.records[0]
+            throw AssertionError("Expected no data but was $data.")
+        }
+    }
+}
+
+internal class RecordingObserver<T> : Observer<T> {
+    val records = mutableListOf<T>()
+
+    override fun onChanged(data: T) {
+        records += data
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
@@ -1,0 +1,88 @@
+package com.chuckerteam.chucker.internal.support
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.distinctUntilChanged
+import com.chuckerteam.chucker.test
+import junit.framework.TestCase.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class LiveDataDistinctUntilChangedTest {
+    @get:Rule val instantExecutorRule = InstantTaskExecutorRule()
+
+    @Test
+    fun initialUpstreamData_isEmittedDownstream() {
+        val upstream = MutableLiveData<Any?>(null)
+
+        upstream.distinctUntilChanged().test {
+            assertEquals(null, expectData())
+        }
+    }
+
+    @Test
+    fun emptyUpstream_isNotEmittedDownstream() {
+        val upstream = MutableLiveData<Any?>()
+
+        upstream.distinctUntilChanged().test {
+            expectNoData()
+        }
+    }
+
+    @Test
+    fun newDistinctData_isEmittedDownstream() {
+        val upstream = MutableLiveData<Int?>()
+
+        upstream.distinctUntilChanged().test {
+            upstream.value = 1
+            assertEquals(1, expectData())
+
+            upstream.value = 2
+            assertEquals(2, expectData())
+
+            upstream.value = null
+            assertEquals(null, expectData())
+
+            upstream.value = 2
+            assertEquals(2, expectData())
+        }
+    }
+
+    @Test
+    fun newIndistinctData_isNotEmittedDownstream() {
+        val upstream = MutableLiveData<String?>()
+
+        upstream.distinctUntilChanged().test {
+            upstream.value = null
+            assertEquals(null, expectData())
+
+            upstream.value = null
+            expectNoData()
+
+            upstream.value = ""
+            assertEquals("", expectData())
+
+            upstream.value = ""
+            expectNoData()
+        }
+    }
+
+    @Test
+    fun customFunction_canBeUsedToDistinguishData() {
+        val upstream = MutableLiveData<Pair<Int, String>>()
+
+        upstream.distinctUntilChanged { old, new -> old.first == new.first }.test {
+            upstream.value = 1 to ""
+            assertEquals(1 to "", expectData())
+
+            upstream.value = 1 to "a"
+            expectNoData()
+
+            upstream.value = 2 to "b"
+            assertEquals(2 to "b", expectData())
+
+            upstream.value = 3 to "b"
+            assertEquals(3 to "b", expectData())
+        }
+    }
+}


### PR DESCRIPTION
## :page_facing_up: Context
There is an open issue. #244

## :pencil: Changes
DB queries which observe entities by their IDs now check beforehand is something changed before emitting data downstream.

This cannot be done on DB level as SQL emissions happen whenever table is changed (https://sqlite.org/lang_createtrigger.html).

One unpleasant change is custom `distinctUntilChanged()` `LiveData` extensions that accepts an executor on which it performs computation. It is needed as in our case data that is being compared can have long comparison computation (requests and responses), which would result in dropped frames.

Ideally `Flow` or Rx would be used to avoid this `LiveData` restriction.

## :paperclip: Related PR
Not blocking but there will be conflicts with https://github.com/ChuckerTeam/chucker/pull/233 due to `LiveData` extensions. I would suggest merging this one first becuase I introduced here a test wrapper for `LivedData`, that can be used in #233 as well.

## :no_entry_sign: Breaking
No.

## :hammer_and_wrench: How to test
Perform requests that are delayed so you can observe the effects of #244. Best way would be to either enqueue bunch of delayed requests or add a delay interceptor to the sample client. While requests are running open any transaction and observe it. Its tabs should not flash.

## :stopwatch: Next steps
No.

Closes #244. 