### PR TITLE
Feature/tls info

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -123,6 +123,11 @@ class ChuckerInterceptor @JvmOverloads constructor(
             responseCode = response.code()
             responseMessage = response.message()
 
+            response.handshake()?.let { handshake ->
+                responseTlsVersion = handshake.tlsVersion().javaName()
+                responseCipherSuite = handshake.cipherSuite().javaName()
+            }
+
             responseContentType = response.contentType
             responseContentLength = response.contentLenght
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -33,6 +33,8 @@ internal class HttpTransaction(
     @ColumnInfo(name = "host") var host: String?,
     @ColumnInfo(name = "path") var path: String?,
     @ColumnInfo(name = "scheme") var scheme: String?,
+    @ColumnInfo(name = "responseTlsVersion") var responseTlsVersion: String?,
+    @ColumnInfo(name = "responseCipherSuite") var responseCipherSuite: String?,
     @ColumnInfo(name = "requestContentLength") var requestContentLength: Long?,
     @ColumnInfo(name = "requestContentType") var requestContentType: String?,
     @ColumnInfo(name = "requestHeaders") var requestHeaders: String?,
@@ -60,6 +62,8 @@ internal class HttpTransaction(
         host = null,
         path = null,
         scheme = null,
+        responseTlsVersion = null,
+        responseCipherSuite = null,
         requestContentLength = null,
         requestContentType = null,
         requestHeaders = null,
@@ -243,6 +247,8 @@ internal class HttpTransaction(
             (host == other.host) &&
             (path == other.path) &&
             (scheme == other.scheme) &&
+            (responseTlsVersion == other.responseTlsVersion) &&
+            (responseCipherSuite == other.responseCipherSuite) &&
             (requestContentLength == other.requestContentLength) &&
             (requestContentType == other.requestContentType) &&
             (requestHeaders == other.requestHeaders) &&
@@ -256,6 +262,6 @@ internal class HttpTransaction(
             (responseHeaders == other.responseHeaders) &&
             (responseBody == other.responseBody) &&
             (isResponseBodyPlainText == other.isResponseBodyPlainText) &&
-            responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) != false
+            (responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) != false)
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 
-@Database(entities = [RecordedThrowable::class, HttpTransaction::class], version = 2, exportSchema = false)
+@Database(entities = [RecordedThrowable::class, HttpTransaction::class], version = 3, exportSchema = false)
 internal abstract class ChuckerDatabase : RoomDatabase() {
 
     abstract fun throwableDao(): RecordedThrowableDao

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -7,6 +7,7 @@ import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.constraintlayout.widget.Group
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -21,7 +22,9 @@ internal class TransactionOverviewFragment : Fragment() {
     private lateinit var status: TextView
     private lateinit var response: TextView
     private lateinit var ssl: TextView
+    private lateinit var tlsVersionGroup: Group
     private lateinit var tlsVersion: TextView
+    private lateinit var cipherSuiteGroup: Group
     private lateinit var cipherSuiteVersion: TextView
     private lateinit var requestTime: TextView
     private lateinit var responseTime: TextView
@@ -50,8 +53,10 @@ internal class TransactionOverviewFragment : Fragment() {
                 status = it.findViewById(R.id.chuckerTransactionOverviewStatus)
                 response = it.findViewById(R.id.chuckerTransactionOverviewResponse)
                 ssl = it.findViewById(R.id.chuckerTransactionOverviewSsl)
-                tlsVersion = it.findViewById(R.id.chuckerTransactionOverviewTlsVersion)
-                cipherSuiteVersion = it.findViewById(R.id.chuckerTransactionOverviewTlsChipherSuite)
+                tlsVersionGroup = it.findViewById(R.id.chuckerTransactionOverviewTlsGroup)
+                tlsVersion = it.findViewById(R.id.chuckerTransactionOverviewTlsVersionValue)
+                cipherSuiteGroup = it.findViewById(R.id.chuckerTransactionOverviewCipherSuiteGroup)
+                cipherSuiteVersion = it.findViewById(R.id.chuckerTransactionOverviewTlsChipherSuiteValue)
                 requestTime = it.findViewById(R.id.chuckerTransactionOverviewRequestTime)
                 responseTime = it.findViewById(R.id.chuckerTransactionOverviewResponseTime)
                 duration = it.findViewById(R.id.chuckerTransactionOverviewDuration)
@@ -84,6 +89,13 @@ internal class TransactionOverviewFragment : Fragment() {
                     status.text = transaction?.status?.toString()
                     response.text = transaction?.responseSummaryText
                     ssl.setText(if (transaction?.isSsl == true) R.string.chucker_yes else R.string.chucker_no)
+                    if (transaction?.isSsl == true) {
+                        tlsVersionGroup.visibility = View.VISIBLE
+                        tlsVersion.text = transaction.responseTlsVersion
+
+                        cipherSuiteGroup.visibility = View.VISIBLE
+                        cipherSuiteVersion.text = transaction.responseCipherSuite
+                    }
                     requestTime.text = transaction?.requestDateString
                     responseTime.text = transaction?.responseDateString
                     duration.text = transaction?.durationString

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -88,13 +88,15 @@ internal class TransactionOverviewFragment : Fragment() {
                     protocol.text = transaction?.protocol
                     status.text = transaction?.status?.toString()
                     response.text = transaction?.responseSummaryText
-                    ssl.setText(if (transaction?.isSsl == true) R.string.chucker_yes else R.string.chucker_no)
                     if (transaction?.isSsl == true) {
+                        ssl.setText(R.string.chucker_yes)
                         tlsVersionGroup.visibility = View.VISIBLE
                         tlsVersion.text = transaction.responseTlsVersion
 
                         cipherSuiteGroup.visibility = View.VISIBLE
                         cipherSuiteVersion.text = transaction.responseCipherSuite
+                    } else {
+                        ssl.setText(R.string.chucker_no)
                     }
                     requestTime.text = transaction?.requestDateString
                     responseTime.text = transaction?.responseDateString

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -21,6 +21,8 @@ internal class TransactionOverviewFragment : Fragment() {
     private lateinit var status: TextView
     private lateinit var response: TextView
     private lateinit var ssl: TextView
+    private lateinit var tlsVersion: TextView
+    private lateinit var cipherSuiteVersion: TextView
     private lateinit var requestTime: TextView
     private lateinit var responseTime: TextView
     private lateinit var duration: TextView
@@ -48,6 +50,8 @@ internal class TransactionOverviewFragment : Fragment() {
                 status = it.findViewById(R.id.chuckerTransactionOverviewStatus)
                 response = it.findViewById(R.id.chuckerTransactionOverviewResponse)
                 ssl = it.findViewById(R.id.chuckerTransactionOverviewSsl)
+                tlsVersion = it.findViewById(R.id.chuckerTransactionOverviewTlsVersion)
+                cipherSuiteVersion = it.findViewById(R.id.chuckerTransactionOverviewTlsChipherSuite)
                 requestTime = it.findViewById(R.id.chuckerTransactionOverviewRequestTime)
                 responseTime = it.findViewById(R.id.chuckerTransactionOverviewResponseTime)
                 duration = it.findViewById(R.id.chuckerTransactionOverviewDuration)

--- a/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
@@ -136,6 +136,7 @@
       tools:text="Yes" />
 
     <TextView
+      android:id="@+id/chuckerTransactionOverviewTlsVersion"
       style="@style/Chucker.TextAppearance.Label"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
@@ -145,7 +146,7 @@
       app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewSsl" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewTlsVersion"
+      android:id="@+id/chuckerTransactionOverviewTlsVersionValue"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
@@ -154,24 +155,45 @@
       app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewSsl"
       tools:text="TLS 1.2" />
 
+    <androidx.constraintlayout.widget.Group
+      android:id="@+id/chuckerTransactionOverviewTlsGroup"
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      android:visibility="gone"
+      app:constraint_referenced_ids="chuckerTransactionOverviewTlsVersion,chuckerTransactionOverviewTlsVersionValue"
+      tools:visibility="visible" />
+
     <TextView
+      android:id="@+id/chuckerTransactionOverviewTlsChipherSuite"
       style="@style/Chucker.TextAppearance.Label"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_tls_cipher_suite"
+      android:visibility="gone"
       app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsVersion" />
+      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsVersion"
+      tools:visibility="visible" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewTlsChipherSuite"
+      android:id="@+id/chuckerTransactionOverviewTlsChipherSuiteValue"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
+      android:visibility="gone"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
       app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsVersion"
-      tools:text="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA" />
+      tools:text="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+      tools:visibility="visible" />
+
+    <androidx.constraintlayout.widget.Group
+      android:id="@+id/chuckerTransactionOverviewCipherSuiteGroup"
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      android:visibility="gone"
+      app:constraint_referenced_ids="chuckerTransactionOverviewTlsChipherSuiteValue,chuckerTransactionOverviewTlsChipherSuite"
+      tools:visibility="visible" />
 
     <TextView
       style="@style/Chucker.TextAppearance.Label"
@@ -181,7 +203,7 @@
       android:text="@string/chucker_request_time"
       app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsChipherSuite" />
+      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsChipherSuiteValue" />
 
     <TextView
       android:id="@+id/chuckerTransactionOverviewRequestTime"
@@ -191,7 +213,7 @@
       android:layout_marginTop="@dimen/chucker_base_grid"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsChipherSuite"
+      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsChipherSuiteValue"
       tools:text="05/02/17 11:52:49" />
 
     <TextView

--- a/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
@@ -118,6 +118,7 @@
       style="@style/Chucker.TextAppearance.Label"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:layout_marginTop="@dimen/chucker_base_grid"
       android:text="@string/chucker_ssl"
       app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
@@ -126,6 +127,7 @@
     <TextView
       android:id="@+id/chuckerTransactionOverviewSsl"
       style="@style/Chucker.TextAppearance.Value"
+      android:layout_marginTop="@dimen/chucker_base_grid"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
@@ -137,11 +139,49 @@
       style="@style/Chucker.TextAppearance.Label"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:text="@string/chucker_tls_version"
+      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewSsl" />
+
+    <TextView
+      android:id="@+id/chuckerTransactionOverviewTlsVersion"
+      style="@style/Chucker.TextAppearance.Value"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewSsl"
+      tools:text="TLS 1.2" />
+
+    <TextView
+      style="@style/Chucker.TextAppearance.Label"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:text="@string/chucker_tls_cipher_suite"
+      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsVersion" />
+
+    <TextView
+      android:id="@+id/chuckerTransactionOverviewTlsChipherSuite"
+      style="@style/Chucker.TextAppearance.Value"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsVersion"
+      tools:text="TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA" />
+
+    <TextView
+      style="@style/Chucker.TextAppearance.Label"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
       android:layout_marginTop="@dimen/chucker_base_grid"
       android:text="@string/chucker_request_time"
       app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewSsl" />
+      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsChipherSuite" />
 
     <TextView
       android:id="@+id/chuckerTransactionOverviewRequestTime"
@@ -151,7 +191,7 @@
       android:layout_marginTop="@dimen/chucker_base_grid"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewSsl"
+      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewTlsChipherSuite"
       tools:text="05/02/17 11:52:49" />
 
     <TextView

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="chucker_protocol">Protocol</string>
     <string name="chucker_status">Status</string>
     <string name="chucker_ssl">SSL</string>
+    <string name="chucker_tls_version">TLS version</string>
+    <string name="chucker_tls_cipher_suite">Cipher Suite</string>
     <string name="chucker_request_time">Request time</string>
     <string name="chucker_response_time">Response time</string>
     <string name="chucker_duration">Duration</string>


### PR DESCRIPTION
## :camera: Screenshots
![Screen Shot 2020-02-26 at 12 11 54](https://user-images.githubusercontent.com/13467769/75337030-e34b7a00-5894-11ea-9a0f-e51874c57e90.png)

## :page_facing_up: Context
This update closes #236 

## :pencil: Changes
Updated UI and DB model to show TLS connection info.
For non SSL connections newly added fields are hidden.

## :no_entry_sign: Breaking
Users will have to do a clean install of Chucker due to DB model update. Since it is a debug tool, don't see the reason in writing migrations.
