### PR TITLE
Switch views to ViewBinding

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,6 +21,10 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
+    viewBinding {
+        enabled = true
+    }
 }
 
 dokka {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/RecordedThrowable.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/RecordedThrowable.kt
@@ -5,7 +5,6 @@ import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
 import com.chuckerteam.chucker.internal.support.FormatUtils
-import java.text.DateFormat
 
 /**
  * Represent a Throwable that was fired from an App.
@@ -28,10 +27,4 @@ internal data class RecordedThrowable(
         this.message = throwable.message
         this.content = FormatUtils.formatThrowable(throwable)
     }
-
-    val formattedDate: String
-        get() {
-            return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
-                .format(this.date)
-        }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/RecordedThrowable.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/RecordedThrowable.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.Ignore
 import androidx.room.PrimaryKey
 import com.chuckerteam.chucker.internal.support.FormatUtils
+import java.text.DateFormat
 
 /**
  * Represent a Throwable that was fired from an App.
@@ -27,4 +28,10 @@ internal data class RecordedThrowable(
         this.message = throwable.message
         this.content = FormatUtils.formatThrowable(throwable)
     }
+
+    val formattedDate: String
+        get() {
+            return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
+                .format(this.date)
+        }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/RecordedThrowableTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/RecordedThrowableTuple.kt
@@ -1,6 +1,7 @@
 package com.chuckerteam.chucker.internal.data.entity
 
 import androidx.room.ColumnInfo
+import java.text.DateFormat
 
 /**
  * A subset of [RecordedThrowable] to perform faster Read operations on the Repository.
@@ -12,4 +13,10 @@ internal data class RecordedThrowableTuple(
     @ColumnInfo(name = "date") var date: Long?,
     @ColumnInfo(name = "clazz") var clazz: String?,
     @ColumnInfo(name = "message") var message: String?
-)
+) {
+    val formattedDate: String
+        get() {
+            return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
+                .format(this.date)
+        }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/RecordedThrowableTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/RecordedThrowableTuple.kt
@@ -1,7 +1,6 @@
 package com.chuckerteam.chucker.internal.data.entity
 
 import androidx.room.ColumnInfo
-import java.text.DateFormat
 
 /**
  * A subset of [RecordedThrowable] to perform faster Read operations on the Repository.
@@ -13,10 +12,4 @@ internal data class RecordedThrowableTuple(
     @ColumnInfo(name = "date") var date: Long?,
     @ColumnInfo(name = "clazz") var clazz: String?,
     @ColumnInfo(name = "message") var message: String?
-) {
-    val formattedDate: String
-        get() {
-            return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
-                .format(this.date)
-        }
-}
+)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -5,16 +5,10 @@ import android.os.Bundle
 import androidx.lifecycle.ViewModelProvider
 import com.chuckerteam.chucker.api.Chucker
 import com.chuckerteam.chucker.databinding.ChuckerActivityMainBinding
-import com.chuckerteam.chucker.internal.ui.error.ErrorActivity
-import com.chuckerteam.chucker.internal.ui.error.ErrorAdapter
-import com.chuckerteam.chucker.internal.ui.transaction.TransactionActivity
-import com.chuckerteam.chucker.internal.ui.transaction.TransactionAdapter
 import com.google.android.material.tabs.TabLayout
 
 internal class MainActivity :
-    BaseChuckerActivity(),
-    TransactionAdapter.TransactionClickListListener,
-    ErrorAdapter.ErrorClickListListener {
+    BaseChuckerActivity() {
 
     private lateinit var viewModel: MainViewModel
     private lateinit var binding: ChuckerActivityMainBinding
@@ -66,14 +60,6 @@ internal class MainActivity :
         } else {
             HomePageAdapter.SCREEN_ERROR_INDEX
         }
-    }
-
-    override fun onErrorClick(throwableId: Long, position: Int) {
-        ErrorActivity.start(this, throwableId)
-    }
-
-    override fun onTransactionClick(transactionId: Long, position: Int) {
-        TransactionActivity.start(this, transactionId)
     }
 
     companion object {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -2,11 +2,9 @@ package com.chuckerteam.chucker.internal.ui
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.appcompat.widget.Toolbar
 import androidx.lifecycle.ViewModelProvider
-import androidx.viewpager.widget.ViewPager
-import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.api.Chucker
+import com.chuckerteam.chucker.databinding.ChuckerActivityMainBinding
 import com.chuckerteam.chucker.internal.ui.error.ErrorActivity
 import com.chuckerteam.chucker.internal.ui.error.ErrorAdapter
 import com.chuckerteam.chucker.internal.ui.transaction.TransactionActivity
@@ -19,37 +17,36 @@ internal class MainActivity :
     ErrorAdapter.ErrorClickListListener {
 
     private lateinit var viewModel: MainViewModel
-    private lateinit var viewPager: ViewPager
+    private lateinit var binding: ChuckerActivityMainBinding
 
     private val applicationName: CharSequence
         get() = applicationInfo.loadLabel(packageManager)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.chucker_activity_main)
-
-        val toolbar = findViewById<Toolbar>(R.id.chuckerTransactionToolbar)
-        setSupportActionBar(toolbar)
-        toolbar.subtitle = applicationName
-
+        binding = ChuckerActivityMainBinding.inflate(layoutInflater)
         viewModel = ViewModelProvider(this).get(MainViewModel::class.java)
 
-        viewPager = findViewById(R.id.chuckerMainViewPager)
-        viewPager.adapter = HomePageAdapter(this, supportFragmentManager)
-
-        val tabLayout = findViewById<TabLayout>(R.id.chuckerMainTabLayout)
-        tabLayout.setupWithViewPager(viewPager)
-
-        viewPager.addOnPageChangeListener(object : TabLayout.TabLayoutOnPageChangeListener(tabLayout) {
-            override fun onPageSelected(position: Int) {
-                super.onPageSelected(position)
-                if (position == 0) {
-                    Chucker.dismissTransactionsNotification(this@MainActivity)
-                } else {
-                    Chucker.dismissErrorsNotification(this@MainActivity)
+        with(binding) {
+            setContentView(root)
+            setSupportActionBar(chuckerTransactionToolbar)
+            chuckerTransactionToolbar.subtitle = applicationName
+            chuckerMainViewPager.adapter = HomePageAdapter(this@MainActivity, supportFragmentManager)
+            chuckerMainTabLayout.setupWithViewPager(chuckerMainViewPager)
+            chuckerMainViewPager.addOnPageChangeListener(
+                object : TabLayout.TabLayoutOnPageChangeListener(chuckerMainTabLayout) {
+                    override fun onPageSelected(position: Int) {
+                        super.onPageSelected(position)
+                        if (position == 0) {
+                            Chucker.dismissTransactionsNotification(this@MainActivity)
+                        } else {
+                            Chucker.dismissErrorsNotification(this@MainActivity)
+                        }
+                    }
                 }
-            }
-        })
+            )
+        }
+
         consumeIntent(intent)
     }
 
@@ -64,10 +61,10 @@ internal class MainActivity :
     private fun consumeIntent(intent: Intent) {
         // Get the screen to show, by default => HTTP
         val screenToShow = intent.getIntExtra(EXTRA_SCREEN, Chucker.SCREEN_HTTP)
-        if (screenToShow == Chucker.SCREEN_HTTP) {
-            viewPager.currentItem = HomePageAdapter.SCREEN_HTTP_INDEX
+        binding.chuckerMainViewPager.currentItem = if (screenToShow == Chucker.SCREEN_HTTP) {
+            HomePageAdapter.SCREEN_HTTP_INDEX
         } else {
-            viewPager.currentItem = HomePageAdapter.SCREEN_ERROR_INDEX
+            HomePageAdapter.SCREEN_ERROR_INDEX
         }
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -31,7 +31,7 @@ internal class MainActivity :
                 object : TabLayout.TabLayoutOnPageChangeListener(tabLayout) {
                     override fun onPageSelected(position: Int) {
                         super.onPageSelected(position)
-                        if (position == 0) {
+                        if (position == HomePageAdapter.SCREEN_HTTP_INDEX) {
                             Chucker.dismissTransactionsNotification(this@MainActivity)
                         } else {
                             Chucker.dismissErrorsNotification(this@MainActivity)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -11,24 +11,24 @@ internal class MainActivity :
     BaseChuckerActivity() {
 
     private lateinit var viewModel: MainViewModel
-    private lateinit var binding: ChuckerActivityMainBinding
+    private lateinit var mainBinding: ChuckerActivityMainBinding
 
     private val applicationName: CharSequence
         get() = applicationInfo.loadLabel(packageManager)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ChuckerActivityMainBinding.inflate(layoutInflater)
+        mainBinding = ChuckerActivityMainBinding.inflate(layoutInflater)
         viewModel = ViewModelProvider(this).get(MainViewModel::class.java)
 
-        with(binding) {
+        with(mainBinding) {
             setContentView(root)
-            setSupportActionBar(chuckerTransactionToolbar)
-            chuckerTransactionToolbar.subtitle = applicationName
-            chuckerMainViewPager.adapter = HomePageAdapter(this@MainActivity, supportFragmentManager)
-            chuckerMainTabLayout.setupWithViewPager(chuckerMainViewPager)
-            chuckerMainViewPager.addOnPageChangeListener(
-                object : TabLayout.TabLayoutOnPageChangeListener(chuckerMainTabLayout) {
+            setSupportActionBar(toolbar)
+            toolbar.subtitle = applicationName
+            viewPager.adapter = HomePageAdapter(this@MainActivity, supportFragmentManager)
+            tabLayout.setupWithViewPager(viewPager)
+            viewPager.addOnPageChangeListener(
+                object : TabLayout.TabLayoutOnPageChangeListener(tabLayout) {
                     override fun onPageSelected(position: Int) {
                         super.onPageSelected(position)
                         if (position == 0) {
@@ -55,7 +55,7 @@ internal class MainActivity :
     private fun consumeIntent(intent: Intent) {
         // Get the screen to show, by default => HTTP
         val screenToShow = intent.getIntExtra(EXTRA_SCREEN, Chucker.SCREEN_HTTP)
-        binding.chuckerMainViewPager.currentItem = if (screenToShow == Chucker.SCREEN_HTTP) {
+        mainBinding.viewPager.currentItem = if (screenToShow == Chucker.SCREEN_HTTP) {
             HomePageAdapter.SCREEN_HTTP_INDEX
         } else {
             HomePageAdapter.SCREEN_ERROR_INDEX

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
@@ -17,7 +17,7 @@ import java.text.DateFormat
 
 internal class ErrorActivity : BaseChuckerActivity() {
 
-    private lateinit var binding: ChuckerActivityErrorBinding
+    private lateinit var errorBinding: ChuckerActivityErrorBinding
 
     private var throwableId: Long = 0
     private var throwable: RecordedThrowable? = null
@@ -25,13 +25,13 @@ internal class ErrorActivity : BaseChuckerActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        binding = ChuckerActivityErrorBinding.inflate(layoutInflater)
+        errorBinding = ChuckerActivityErrorBinding.inflate(layoutInflater)
         throwableId = intent.getLongExtra(EXTRA_THROWABLE_ID, 0)
 
-        with(binding) {
+        with(errorBinding) {
             setContentView(root)
-            setSupportActionBar(chuckerErrorToolbar)
-            chuckerErrorActivityItem.chuckerItemErrorDate.visibility = View.GONE
+            setSupportActionBar(toolbar)
+            errorItem.date.visibility = View.GONE
         }
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
@@ -86,12 +86,12 @@ internal class ErrorActivity : BaseChuckerActivity() {
     }
 
     private fun populateUI(throwable: RecordedThrowable) {
-        binding.apply {
-            chuckerErrorToolbarTitle.text = throwable.formattedDate
-            chuckerErrorActivityItem.chuckerItemErrorTag.text = throwable.tag
-            chuckerErrorActivityItem.chuckerItemErrorClazz.text = throwable.clazz
-            chuckerErrorActivityItem.chuckerItemErrorMessage.text = throwable.message
-            chuckerErrorStacktrace.text = throwable.content
+        errorBinding.apply {
+            toolbarTitle.text = throwable.formattedDate
+            errorItem.tag.text = throwable.tag
+            errorItem.clazz.text = throwable.clazz
+            errorItem.message.text = throwable.message
+            errorStacktrace.text = throwable.content
         }
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
@@ -13,7 +13,6 @@ import com.chuckerteam.chucker.databinding.ChuckerActivityErrorBinding
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
-import java.text.DateFormat
 
 internal class ErrorActivity : BaseChuckerActivity() {
 
@@ -105,10 +104,4 @@ internal class ErrorActivity : BaseChuckerActivity() {
             context.startActivity(intent)
         }
     }
-
-    private val RecordedThrowable.formattedDate: String
-        get() {
-            return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
-                .format(this.date)
-        }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
@@ -13,6 +13,7 @@ import com.chuckerteam.chucker.databinding.ChuckerActivityErrorBinding
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
+import java.text.DateFormat
 
 internal class ErrorActivity : BaseChuckerActivity() {
 
@@ -93,6 +94,12 @@ internal class ErrorActivity : BaseChuckerActivity() {
             chuckerErrorStacktrace.text = throwable.content
         }
     }
+
+    private val RecordedThrowable.formattedDate: String
+        get() {
+            return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
+                .format(this.date)
+        }
 
     companion object {
         private const val MIME_TYPE = "text/plain"

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorActivity.kt
@@ -6,10 +6,10 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import android.widget.TextView
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.Observer
 import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.databinding.ChuckerActivityErrorBinding
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
@@ -17,31 +17,23 @@ import java.text.DateFormat
 
 internal class ErrorActivity : BaseChuckerActivity() {
 
+    private lateinit var binding: ChuckerActivityErrorBinding
+
     private var throwableId: Long = 0
     private var throwable: RecordedThrowable? = null
 
-    private lateinit var title: TextView
-    private lateinit var tag: TextView
-    private lateinit var clazz: TextView
-    private lateinit var message: TextView
-    private lateinit var date: TextView
-    private lateinit var stacktrace: TextView
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.chucker_activity_error)
-        setSupportActionBar(findViewById(R.id.chuckerErrorToolbar))
-        supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        title = findViewById(R.id.chuckerErrorToolbarTitle)
-        tag = findViewById(R.id.chuckerItemErrorTag)
-        clazz = findViewById(R.id.chuckerItemErrorClazz)
-        message = findViewById(R.id.chuckerItemErrorMessage)
-        date = findViewById(R.id.chuckerItemErrorDate)
-        stacktrace = findViewById(R.id.chuckerErrorStacktrace)
-        date.visibility = View.GONE
-
+        binding = ChuckerActivityErrorBinding.inflate(layoutInflater)
         throwableId = intent.getLongExtra(EXTRA_THROWABLE_ID, 0)
+
+        with(binding) {
+            setContentView(root)
+            setSupportActionBar(chuckerErrorToolbar)
+            chuckerErrorActivityItem.chuckerItemErrorDate.visibility = View.GONE
+        }
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
     override fun onResume() {
@@ -94,11 +86,13 @@ internal class ErrorActivity : BaseChuckerActivity() {
     }
 
     private fun populateUI(throwable: RecordedThrowable) {
-        title.text = throwable.formattedDate
-        tag.text = throwable.tag
-        clazz.text = throwable.clazz
-        message.text = throwable.message
-        stacktrace.text = throwable.content
+        binding.apply {
+            chuckerErrorToolbarTitle.text = throwable.formattedDate
+            chuckerErrorActivityItem.chuckerItemErrorTag.text = throwable.tag
+            chuckerErrorActivityItem.chuckerItemErrorClazz.text = throwable.clazz
+            chuckerErrorActivityItem.chuckerItemErrorMessage.text = throwable.message
+            chuckerErrorStacktrace.text = throwable.content
+        }
     }
 
     companion object {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.chuckerteam.chucker.databinding.ChuckerListItemErrorBinding
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple
+import java.text.DateFormat
 
 internal class ErrorAdapter(
     val listener: ErrorClickListListener
@@ -48,7 +49,8 @@ internal class ErrorAdapter(
             chuckerItemErrorTag.text = throwable.tag
             chuckerItemErrorClazz.text = throwable.clazz
             chuckerItemErrorMessage.text = throwable.message
-            chuckerItemErrorDate.text = throwable.formattedDate
+            chuckerItemErrorDate.text = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
+                .format(throwable.date)
         }
 
         override fun onClick(v: View) {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.databinding.ChuckerListItemErrorBinding
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple
 import java.text.DateFormat
 
@@ -16,10 +17,8 @@ internal class ErrorAdapter(
     private var data: List<RecordedThrowableTuple> = listOf()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ErrorViewHolder {
-        val view =
-            LayoutInflater.from(parent.context)
-                .inflate(R.layout.chucker_list_item_error, parent, false)
-        return ErrorViewHolder(view)
+        val viewBinding = ChuckerListItemErrorBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ErrorViewHolder(viewBinding)
     }
 
     override fun onBindViewHolder(holder: ErrorViewHolder, position: Int) {
@@ -37,25 +36,22 @@ internal class ErrorAdapter(
     }
 
     inner class ErrorViewHolder(
-        itemView: View
-    ) : RecyclerView.ViewHolder(itemView), View.OnClickListener {
+        private val itemBinding: ChuckerListItemErrorBinding
+    ) : RecyclerView.ViewHolder(itemBinding.root), View.OnClickListener {
 
-        private val tagView: TextView = itemView.findViewById(R.id.chuckerItemErrorTag)
-        private val clazzView: TextView = itemView.findViewById(R.id.chuckerItemErrorClazz)
-        private val messageView: TextView = itemView.findViewById(R.id.chuckerItemErrorMessage)
-        private val dateView: TextView = itemView.findViewById(R.id.chuckerItemErrorDate)
         private var throwableId: Long? = null
 
         init {
             itemView.setOnClickListener(this)
         }
 
-        internal fun bind(throwable: RecordedThrowableTuple) = with(throwable) {
-            throwableId = id
-            tagView.text = tag
-            clazzView.text = clazz
-            messageView.text = message
-            dateView.text = formattedDate
+        internal fun bind(throwable: RecordedThrowableTuple) = with(itemBinding) {
+            throwableId = throwable.id
+
+            chuckerItemErrorTag.text = throwable.tag
+            chuckerItemErrorClazz.text = throwable.clazz
+            chuckerItemErrorMessage.text = throwable.message
+            chuckerItemErrorDate.text = throwable.formattedDate
         }
 
         override fun onClick(v: View) {
@@ -64,12 +60,6 @@ internal class ErrorAdapter(
             }
         }
     }
-
-    private val RecordedThrowableTuple.formattedDate: String
-        get() {
-            return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
-                .format(this.date)
-        }
 
     interface ErrorClickListListener {
         fun onErrorClick(throwableId: Long, position: Int)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorAdapter.kt
@@ -46,10 +46,10 @@ internal class ErrorAdapter(
         internal fun bind(throwable: RecordedThrowableTuple) = with(itemBinding) {
             throwableId = throwable.id
 
-            chuckerItemErrorTag.text = throwable.tag
-            chuckerItemErrorClazz.text = throwable.clazz
-            chuckerItemErrorMessage.text = throwable.message
-            chuckerItemErrorDate.text = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
+            tag.text = throwable.tag
+            clazz.text = throwable.clazz
+            message.text = throwable.message
+            date.text = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
                 .format(throwable.date)
         }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorAdapter.kt
@@ -3,12 +3,9 @@ package com.chuckerteam.chucker.internal.ui.error
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerListItemErrorBinding
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple
-import java.text.DateFormat
 
 internal class ErrorAdapter(
     val listener: ErrorClickListListener

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorListFragment.kt
@@ -1,6 +1,5 @@
 package com.chuckerteam.chucker.internal.ui.error
 
-import android.content.Context
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
@@ -9,23 +8,20 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.DividerItemDecoration.VERTICAL
-import androidx.recyclerview.widget.RecyclerView
 import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.databinding.ChuckerFragmentErrorListBinding
 import com.chuckerteam.chucker.internal.ui.MainViewModel
 
-internal class ErrorListFragment : Fragment() {
+internal class ErrorListFragment : Fragment(), ErrorAdapter.ErrorClickListListener {
 
     private lateinit var viewModel: MainViewModel
-    private lateinit var adapter: ErrorAdapter
-    private lateinit var listener: ErrorAdapter.ErrorClickListListener
-    private lateinit var tutorialView: View
+    private lateinit var errorsBinding: ChuckerFragmentErrorListBinding
+    private lateinit var errorsAdapter: ErrorAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -34,15 +30,19 @@ internal class ErrorListFragment : Fragment() {
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.chucker_fragment_error_list, container, false).apply {
-            tutorialView = findViewById(R.id.chuckerErrorsTutorialView)
-            findViewById<TextView>(R.id.chuckerErrorsTutorialLink).movementMethod = LinkMovementMethod.getInstance()
+        errorsBinding = ChuckerFragmentErrorListBinding.inflate(inflater, container, false)
 
-            val recyclerView = findViewById<RecyclerView>(R.id.chuckerErrorsRecyclerView)
-            recyclerView.addItemDecoration(DividerItemDecoration(context, VERTICAL))
-            adapter = ErrorAdapter(listener)
-            recyclerView.adapter = adapter
+        errorsAdapter = ErrorAdapter(this)
+
+        with(errorsBinding) {
+            chuckerErrorsTutorialLink.movementMethod = LinkMovementMethod.getInstance()
+            chuckerErrorsRecyclerView.apply {
+                addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+                adapter = errorsAdapter
+            }
         }
+
+        return errorsBinding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -50,23 +50,14 @@ internal class ErrorListFragment : Fragment() {
         viewModel.errors.observe(
             viewLifecycleOwner,
             Observer { errors ->
-                adapter.setData(errors)
-                tutorialView.visibility = if (errors.isNullOrEmpty()) {
+                errorsAdapter.setData(errors)
+                errorsBinding.chuckerErrorsTutorialView.visibility = if (errors.isNullOrEmpty()) {
                     View.VISIBLE
                 } else {
                     View.GONE
                 }
             }
         )
-    }
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-
-        require(context is ErrorAdapter.ErrorClickListListener) {
-            "Context must implement the listener."
-        }
-        listener = context
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -96,5 +87,9 @@ internal class ErrorListFragment : Fragment() {
 
     companion object {
         fun newInstance() = ErrorListFragment()
+    }
+
+    override fun onErrorClick(throwableId: Long, position: Int) {
+        ErrorActivity.start(requireActivity(), throwableId)
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/error/ErrorListFragment.kt
@@ -35,8 +35,8 @@ internal class ErrorListFragment : Fragment(), ErrorAdapter.ErrorClickListListen
         errorsAdapter = ErrorAdapter(this)
 
         with(errorsBinding) {
-            chuckerErrorsTutorialLink.movementMethod = LinkMovementMethod.getInstance()
-            chuckerErrorsRecyclerView.apply {
+            tutorialLink.movementMethod = LinkMovementMethod.getInstance()
+            errorsRecyclerView.apply {
                 addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
                 adapter = errorsAdapter
             }
@@ -51,7 +51,7 @@ internal class ErrorListFragment : Fragment(), ErrorAdapter.ErrorClickListListen
             viewLifecycleOwner,
             Observer { errors ->
                 errorsAdapter.setData(errors)
-                errorsBinding.chuckerErrorsTutorialView.visibility = if (errors.isNullOrEmpty()) {
+                errorsBinding.tutorialView.visibility = if (errors.isNullOrEmpty()) {
                     View.VISIBLE
                 } else {
                     View.GONE

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -18,11 +18,11 @@ import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
 internal class TransactionActivity : BaseChuckerActivity() {
 
     private lateinit var viewModel: TransactionViewModel
-    private lateinit var binding: ChuckerActivityTransactionBinding
+    private lateinit var transactionBinding: ChuckerActivityTransactionBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ChuckerActivityTransactionBinding.inflate(layoutInflater)
+        transactionBinding = ChuckerActivityTransactionBinding.inflate(layoutInflater)
 
         val transactionId = intent.getLongExtra(EXTRA_TRANSACTION_ID, 0)
 
@@ -31,11 +31,11 @@ internal class TransactionActivity : BaseChuckerActivity() {
         viewModel = ViewModelProvider(this, TransactionViewModelFactory(transactionId))
             .get(TransactionViewModel::class.java)
 
-        with(binding) {
+        with(transactionBinding) {
             setContentView(root)
-            setSupportActionBar(chuckerTransactionToolbar)
-            setupViewPager(chuckerTransactionViewPager)
-            chuckerTransactionTabLayout.setupWithViewPager(chuckerTransactionViewPager)
+            setSupportActionBar(toolbar)
+            setupViewPager(viewPager)
+            tabLayout.setupWithViewPager(viewPager)
         }
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
@@ -45,7 +45,7 @@ internal class TransactionActivity : BaseChuckerActivity() {
         super.onResume()
         viewModel.transactionTitle.observe(
             this,
-            Observer { binding.chuckerTransactionToolbarTitle.text = it }
+            Observer { transactionBinding.toolbarTitle.text = it }
         )
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -5,26 +5,24 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
-import android.widget.TextView
-import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager
 import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.databinding.ChuckerActivityTransactionBinding
 import com.chuckerteam.chucker.internal.support.FormatUtils.getShareCurlCommand
 import com.chuckerteam.chucker.internal.support.FormatUtils.getShareText
 import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
-import com.google.android.material.tabs.TabLayout
 
 internal class TransactionActivity : BaseChuckerActivity() {
 
-    private lateinit var title: TextView
     private lateinit var viewModel: TransactionViewModel
+    private lateinit var binding: ChuckerActivityTransactionBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.chucker_activity_transaction)
+        binding = ChuckerActivityTransactionBinding.inflate(layoutInflater)
 
         val transactionId = intent.getLongExtra(EXTRA_TRANSACTION_ID, 0)
 
@@ -33,23 +31,21 @@ internal class TransactionActivity : BaseChuckerActivity() {
         viewModel = ViewModelProvider(this, TransactionViewModelFactory(transactionId))
             .get(TransactionViewModel::class.java)
 
-        val toolbar = findViewById<Toolbar>(R.id.chuckerTransactionToolbar)
-        setSupportActionBar(toolbar)
-        title = findViewById(R.id.chuckerTransactionToolbarTitle)
+        with(binding) {
+            setContentView(root)
+            setSupportActionBar(chuckerTransactionToolbar)
+            setupViewPager(chuckerTransactionViewPager)
+            chuckerTransactionTabLayout.setupWithViewPager(chuckerTransactionViewPager)
+        }
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-
-        findViewById<ViewPager>(R.id.chuckerTransactionViewPager)?.let { viewPager ->
-            setupViewPager(viewPager)
-            findViewById<TabLayout>(R.id.chuckerTransactionTabLayout).setupWithViewPager(viewPager)
-        }
     }
 
     override fun onResume() {
         super.onResume()
         viewModel.transactionTitle.observe(
             this,
-            Observer { title.text = it }
+            Observer { binding.chuckerTransactionToolbarTitle.text = it }
         )
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -57,23 +57,22 @@ internal class TransactionAdapter internal constructor(
             transactionId = transaction.id
 
             itemBinding.apply {
-                chuckerTransactionItemPath.text =
-                    "${transaction.method} ${transaction.getFormattedPath(encode = false)}"
-                chuckerTransactionItemHost.text = transaction.host
-                chuckerTransactionItemTimeStart.text = DateFormat.getTimeInstance().format(transaction.requestDate)
-                chuckerTransactionItemSsl.visibility = if (transaction.isSsl) View.VISIBLE else View.GONE
+                path.text = "${transaction.method} ${transaction.getFormattedPath(encode = false)}"
+                host.text = transaction.host
+                timeStart.text = DateFormat.getTimeInstance().format(transaction.requestDate)
+                ssl.visibility = if (transaction.isSsl) View.VISIBLE else View.GONE
 
                 if (transaction.status === HttpTransaction.Status.Complete) {
-                    chuckerTransactionItemCode.text = transaction.responseCode.toString()
-                    chuckerTransactionItemDuration.text = transaction.durationString
-                    chuckerTransactionItemSize.text = transaction.totalSizeString
+                    code.text = transaction.responseCode.toString()
+                    duration.text = transaction.durationString
+                    size.text = transaction.totalSizeString
                 } else {
-                    chuckerTransactionItemCode.text = ""
-                    chuckerTransactionItemDuration.text = ""
-                    chuckerTransactionItemSize.text = ""
+                    code.text = ""
+                    duration.text = ""
+                    size.text = ""
                 }
                 if (transaction.status === HttpTransaction.Status.Failed) {
-                    chuckerTransactionItemCode.text = "!!!"
+                    code.text = "!!!"
                 }
             }
 
@@ -96,8 +95,8 @@ internal class TransactionAdapter internal constructor(
                 (transaction.responseCode!! >= HttpsURLConnection.HTTP_MULT_CHOICE) -> color300
                 else -> colorDefault
             }
-            itemBinding.chuckerTransactionItemCode.setTextColor(color)
-            itemBinding.chuckerTransactionItemPath.setTextColor(color)
+            itemBinding.code.setTextColor(color)
+            itemBinding.path.setTextColor(color)
         }
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -76,7 +76,7 @@ internal class TransactionAdapter internal constructor(
                 }
             }
 
-            setStatusColor(this.itemBinding, transaction)
+            setStatusColor(transaction)
         }
 
         override fun onClick(v: View?) {
@@ -85,7 +85,7 @@ internal class TransactionAdapter internal constructor(
             }
         }
 
-        private fun setStatusColor(itemBinding: ChuckerListItemTransactionBinding, transaction: HttpTransactionTuple) {
+        private fun setStatusColor(transaction: HttpTransactionTuple) {
             val color: Int = when {
                 (transaction.status === HttpTransaction.Status.Failed) -> colorError
                 (transaction.status === HttpTransaction.Status.Requested) -> colorRequested

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
@@ -42,8 +42,8 @@ internal class TransactionListFragment :
 
         transactionsAdapter = TransactionAdapter(requireContext(), this)
         with(transactionsBinding) {
-            chuckerTransactionsLink.movementMethod = LinkMovementMethod.getInstance()
-            chuckerTransactionsRecyclerView.apply {
+            tutorialLink.movementMethod = LinkMovementMethod.getInstance()
+            transactionsRecyclerView.apply {
                 addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
                 adapter = transactionsAdapter
             }
@@ -58,7 +58,7 @@ internal class TransactionListFragment :
             viewLifecycleOwner,
             Observer { transactionTuples ->
                 transactionsAdapter.setData(transactionTuples)
-                transactionsBinding.chuckerTransactionsTutorialView.visibility =
+                transactionsBinding.tutorialView.visibility =
                     if (transactionTuples.isEmpty()) View.VISIBLE else View.GONE
             }
         )

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
@@ -8,15 +8,14 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DividerItemDecoration
-import androidx.recyclerview.widget.RecyclerView
 import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionListBinding
 import com.chuckerteam.chucker.internal.ui.MainViewModel
 
 internal class TransactionListFragment :
@@ -25,8 +24,8 @@ internal class TransactionListFragment :
     TransactionAdapter.TransactionClickListListener {
 
     private lateinit var viewModel: MainViewModel
-    private lateinit var adapter: TransactionAdapter
-    private lateinit var tutorialView: View
+    private lateinit var transactionsBinding: ChuckerFragmentTransactionListBinding
+    private lateinit var transactionsAdapter: TransactionAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -39,19 +38,18 @@ internal class TransactionListFragment :
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view = inflater.inflate(R.layout.chucker_fragment_transaction_list, container, false)
-        tutorialView = view.findViewById(R.id.chuckerTransactionsTutorialView)
-        view.findViewById<TextView>(R.id.chuckerTransactionsLink).movementMethod = LinkMovementMethod.getInstance()
+        transactionsBinding = ChuckerFragmentTransactionListBinding.inflate(inflater, container, false)
 
-        val recyclerView = view.findViewById<RecyclerView>(R.id.chuckerTransactionsRecyclerView)
-        val context = view.context
-        recyclerView.addItemDecoration(
-            DividerItemDecoration(context, DividerItemDecoration.VERTICAL)
-        )
-        adapter = TransactionAdapter(context, this)
-        recyclerView.adapter = adapter
+        transactionsAdapter = TransactionAdapter(requireContext(), this)
+        with(transactionsBinding) {
+            chuckerTransactionsLink.movementMethod = LinkMovementMethod.getInstance()
+            chuckerTransactionsRecyclerView.apply {
+                addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
+                adapter = transactionsAdapter
+            }
+        }
 
-        return view
+        return transactionsBinding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -59,8 +57,9 @@ internal class TransactionListFragment :
         viewModel.transactions.observe(
             viewLifecycleOwner,
             Observer { transactionTuples ->
-                adapter.setData(transactionTuples)
-                tutorialView.visibility = if (transactionTuples.isEmpty()) View.VISIBLE else View.GONE
+                transactionsAdapter.setData(transactionTuples)
+                transactionsBinding.chuckerTransactionsTutorialView.visibility =
+                    if (transactionTuples.isEmpty()) View.VISIBLE else View.GONE
             }
         )
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -64,7 +64,19 @@ internal class TransactionOverviewFragment : Fragment() {
             protocol.text = transaction?.protocol
             status.text = transaction?.status.toString()
             response.text = transaction?.responseSummaryText
-            ssl.setText(if (transaction?.isSsl == true) R.string.chucker_yes else R.string.chucker_no)
+            when (transaction?.isSsl) {
+                null -> {
+                    sslGroup.visibility = View.GONE
+                }
+                true -> {
+                    sslGroup.visibility = View.VISIBLE
+                    sslValue.setText(R.string.chucker_yes)
+                }
+                else -> {
+                    sslGroup.visibility = View.VISIBLE
+                    sslValue.setText(R.string.chucker_no)
+                }
+            }
             if (transaction?.responseTlsVersion != null) {
                 tlsVersionValue.text = transaction.responseTlsVersion
                 tlsGroup.visibility = View.VISIBLE

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -6,27 +6,16 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionOverviewBinding
 import com.chuckerteam.chucker.internal.support.combineLatest
 
 internal class TransactionOverviewFragment : Fragment() {
 
-    private lateinit var url: TextView
-    private lateinit var method: TextView
-    private lateinit var protocol: TextView
-    private lateinit var status: TextView
-    private lateinit var response: TextView
-    private lateinit var ssl: TextView
-    private lateinit var requestTime: TextView
-    private lateinit var responseTime: TextView
-    private lateinit var duration: TextView
-    private lateinit var requestSize: TextView
-    private lateinit var responseSize: TextView
-    private lateinit var totalSize: TextView
+    private lateinit var overviewBinding: ChuckerFragmentTransactionOverviewBinding
     private lateinit var viewModel: TransactionViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -39,22 +28,10 @@ internal class TransactionOverviewFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? =
-        inflater.inflate(R.layout.chucker_fragment_transaction_overview, container, false)
-            .also {
-                url = it.findViewById(R.id.chuckerTransactionOverviewUrl)
-                method = it.findViewById(R.id.chuckerTransactionOverviewMethod)
-                protocol = it.findViewById(R.id.chuckerTransactionOverviewProtocol)
-                status = it.findViewById(R.id.chuckerTransactionOverviewStatus)
-                response = it.findViewById(R.id.chuckerTransactionOverviewResponse)
-                ssl = it.findViewById(R.id.chuckerTransactionOverviewSsl)
-                requestTime = it.findViewById(R.id.chuckerTransactionOverviewRequestTime)
-                responseTime = it.findViewById(R.id.chuckerTransactionOverviewResponseTime)
-                duration = it.findViewById(R.id.chuckerTransactionOverviewDuration)
-                requestSize = it.findViewById(R.id.chuckerTransactionOverviewRequestSize)
-                responseSize = it.findViewById(R.id.chuckerTransactionOverviewResponseSize)
-                totalSize = it.findViewById(R.id.chuckerTransactionOverviewTotalSize)
-            }
+    ): View? {
+        overviewBinding = ChuckerFragmentTransactionOverviewBinding.inflate(inflater, container, false)
+        return overviewBinding.root
+    }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.findItem(R.id.save_body).isVisible = false
@@ -74,18 +51,22 @@ internal class TransactionOverviewFragment : Fragment() {
             .observe(
                 viewLifecycleOwner,
                 Observer { (transaction, encodeUrl) ->
-                    url.text = transaction?.getFormattedUrl(encodeUrl)
-                    method.text = transaction?.method
-                    protocol.text = transaction?.protocol
-                    status.text = transaction?.status?.toString()
-                    response.text = transaction?.responseSummaryText
-                    ssl.setText(if (transaction?.isSsl == true) R.string.chucker_yes else R.string.chucker_no)
-                    requestTime.text = transaction?.requestDateString
-                    responseTime.text = transaction?.responseDateString
-                    duration.text = transaction?.durationString
-                    requestSize.text = transaction?.requestSizeString
-                    responseSize.text = transaction?.responseSizeString
-                    totalSize.text = transaction?.totalSizeString
+                    with(overviewBinding) {
+                        chuckerTransactionOverviewUrl.text = transaction?.getFormattedUrl(encodeUrl)
+                        chuckerTransactionOverviewMethod.text = transaction?.method
+                        chuckerTransactionOverviewProtocol.text = transaction?.protocol
+                        chuckerTransactionOverviewStatus.text = transaction?.status.toString()
+                        chuckerTransactionOverviewResponse.text = transaction?.responseSummaryText
+                        chuckerTransactionOverviewSsl.setText(
+                            if (transaction?.isSsl == true) R.string.chucker_yes else R.string.chucker_no
+                        )
+                        chuckerTransactionOverviewRequestTime.text = transaction?.requestDateString
+                        chuckerTransactionOverviewResponseTime.text = transaction?.responseDateString
+                        chuckerTransactionOverviewDuration.text = transaction?.durationString
+                        chuckerTransactionOverviewRequestSize.text = transaction?.requestSizeString
+                        chuckerTransactionOverviewResponseSize.text = transaction?.responseSizeString
+                        chuckerTransactionOverviewTotalSize.text = transaction?.totalSizeString
+                    }
                 }
             )
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionOverviewBinding
+import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.support.combineLatest
 
 internal class TransactionOverviewFragment : Fragment() {
@@ -51,23 +52,27 @@ internal class TransactionOverviewFragment : Fragment() {
             .observe(
                 viewLifecycleOwner,
                 Observer { (transaction, encodeUrl) ->
-                    with(overviewBinding) {
-                        chuckerTransactionOverviewUrl.text = transaction?.getFormattedUrl(encodeUrl)
-                        chuckerTransactionOverviewMethod.text = transaction?.method
-                        chuckerTransactionOverviewProtocol.text = transaction?.protocol
-                        chuckerTransactionOverviewStatus.text = transaction?.status.toString()
-                        chuckerTransactionOverviewResponse.text = transaction?.responseSummaryText
-                        chuckerTransactionOverviewSsl.setText(
-                            if (transaction?.isSsl == true) R.string.chucker_yes else R.string.chucker_no
-                        )
-                        chuckerTransactionOverviewRequestTime.text = transaction?.requestDateString
-                        chuckerTransactionOverviewResponseTime.text = transaction?.responseDateString
-                        chuckerTransactionOverviewDuration.text = transaction?.durationString
-                        chuckerTransactionOverviewRequestSize.text = transaction?.requestSizeString
-                        chuckerTransactionOverviewResponseSize.text = transaction?.responseSizeString
-                        chuckerTransactionOverviewTotalSize.text = transaction?.totalSizeString
-                    }
+                    populateUI(transaction, encodeUrl)
                 }
             )
+    }
+
+    private fun populateUI(transaction: HttpTransaction?, encodeUrl: Boolean) {
+        with(overviewBinding) {
+            chuckerTransactionOverviewUrl.text = transaction?.getFormattedUrl(encodeUrl)
+            chuckerTransactionOverviewMethod.text = transaction?.method
+            chuckerTransactionOverviewProtocol.text = transaction?.protocol
+            chuckerTransactionOverviewStatus.text = transaction?.status.toString()
+            chuckerTransactionOverviewResponse.text = transaction?.responseSummaryText
+            chuckerTransactionOverviewSsl.setText(
+                if (transaction?.isSsl == true) R.string.chucker_yes else R.string.chucker_no
+            )
+            chuckerTransactionOverviewRequestTime.text = transaction?.requestDateString
+            chuckerTransactionOverviewResponseTime.text = transaction?.responseDateString
+            chuckerTransactionOverviewDuration.text = transaction?.durationString
+            chuckerTransactionOverviewRequestSize.text = transaction?.requestSizeString
+            chuckerTransactionOverviewResponseSize.text = transaction?.responseSizeString
+            chuckerTransactionOverviewTotalSize.text = transaction?.totalSizeString
+        }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -59,20 +59,20 @@ internal class TransactionOverviewFragment : Fragment() {
 
     private fun populateUI(transaction: HttpTransaction?, encodeUrl: Boolean) {
         with(overviewBinding) {
-            chuckerTransactionOverviewUrl.text = transaction?.getFormattedUrl(encodeUrl)
-            chuckerTransactionOverviewMethod.text = transaction?.method
-            chuckerTransactionOverviewProtocol.text = transaction?.protocol
-            chuckerTransactionOverviewStatus.text = transaction?.status.toString()
-            chuckerTransactionOverviewResponse.text = transaction?.responseSummaryText
-            chuckerTransactionOverviewSsl.setText(
+            url.text = transaction?.getFormattedUrl(encodeUrl)
+            method.text = transaction?.method
+            protocol.text = transaction?.protocol
+            status.text = transaction?.status.toString()
+            response.text = transaction?.responseSummaryText
+            ssl.setText(
                 if (transaction?.isSsl == true) R.string.chucker_yes else R.string.chucker_no
             )
-            chuckerTransactionOverviewRequestTime.text = transaction?.requestDateString
-            chuckerTransactionOverviewResponseTime.text = transaction?.responseDateString
-            chuckerTransactionOverviewDuration.text = transaction?.durationString
-            chuckerTransactionOverviewRequestSize.text = transaction?.requestSizeString
-            chuckerTransactionOverviewResponseSize.text = transaction?.responseSizeString
-            chuckerTransactionOverviewTotalSize.text = transaction?.totalSizeString
+            requestTime.text = transaction?.requestDateString
+            responseTime.text = transaction?.responseDateString
+            duration.text = transaction?.durationString
+            requestSize.text = transaction?.requestSizeString
+            responseSize.text = transaction?.responseSizeString
+            totalSize.text = transaction?.totalSizeString
         }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
@@ -96,31 +96,31 @@ internal sealed class TransactionPayloadViewHolder(view: View) : RecyclerView.Vi
     abstract fun bind(item: TransactionPayloadItem)
 
     internal class HeaderViewHolder(
-        private val itemBinding: ChuckerTransactionItemHeadersBinding
-    ) : TransactionPayloadViewHolder(itemBinding.root) {
+        private val headerBinding: ChuckerTransactionItemHeadersBinding
+    ) : TransactionPayloadViewHolder(headerBinding.root) {
         override fun bind(item: TransactionPayloadItem) {
             if (item is TransactionPayloadItem.HeaderItem) {
-                itemBinding.chuckerTransactionResponseHeaders.text = item.headers
+                headerBinding.responseHeaders.text = item.headers
             }
         }
     }
 
     internal class BodyLineViewHolder(
-        private val itemBinding: ChuckerTransactionItemBodyLineBinding
-    ) : TransactionPayloadViewHolder(itemBinding.root) {
+        private val bodyBinding: ChuckerTransactionItemBodyLineBinding
+    ) : TransactionPayloadViewHolder(bodyBinding.root) {
         override fun bind(item: TransactionPayloadItem) {
             if (item is TransactionPayloadItem.BodyLineItem) {
-                itemBinding.chuckerTransactionResponseBodyLine.text = item.line
+                bodyBinding.bodyLine.text = item.line
             }
         }
     }
 
     internal class ImageViewHolder(
-        private val itemBinding: ChuckerTransactionItemImageBinding
-    ) : TransactionPayloadViewHolder(itemBinding.root) {
+        private val imageBinding: ChuckerTransactionItemImageBinding
+    ) : TransactionPayloadViewHolder(imageBinding.root) {
         override fun bind(item: TransactionPayloadItem) {
             if (item is TransactionPayloadItem.ImageItem) {
-                itemBinding.chuckerTransactionResponseBinaryData.setImageBitmap(item.image)
+                imageBinding.binaryData.setImageBitmap(item.image)
             }
         }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
@@ -6,10 +6,10 @@ import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.databinding.ChuckerTransactionItemBodyLineBinding
+import com.chuckerteam.chucker.databinding.ChuckerTransactionItemHeadersBinding
+import com.chuckerteam.chucker.databinding.ChuckerTransactionItemImageBinding
 import com.chuckerteam.chucker.internal.support.highlightWithDefinedColors
 
 /**
@@ -29,16 +29,16 @@ internal class TransactionBodyAdapter(
         val inflater = LayoutInflater.from(parent.context)
         return when (viewType) {
             TYPE_HEADERS -> {
-                val view = inflater.inflate(R.layout.chucker_transaction_item_headers, parent, false)
-                TransactionPayloadViewHolder.HeaderViewHolder(view)
+                val headersItemBinding = ChuckerTransactionItemHeadersBinding.inflate(inflater, parent, false)
+                TransactionPayloadViewHolder.HeaderViewHolder(headersItemBinding)
             }
             TYPE_BODY_LINE -> {
-                val view = inflater.inflate(R.layout.chucker_transaction_item_body_line, parent, false)
-                TransactionPayloadViewHolder.BodyLineViewHolder(view)
+                val bodyItemBinding = ChuckerTransactionItemBodyLineBinding.inflate(inflater, parent, false)
+                TransactionPayloadViewHolder.BodyLineViewHolder(bodyItemBinding)
             }
             else -> {
-                val view = inflater.inflate(R.layout.chucker_transaction_item_image, parent, false)
-                TransactionPayloadViewHolder.ImageViewHolder(view)
+                val imageItemBinding = ChuckerTransactionItemImageBinding.inflate(inflater, parent, false)
+                TransactionPayloadViewHolder.ImageViewHolder(imageItemBinding)
             }
         }
     }
@@ -95,29 +95,32 @@ internal class TransactionBodyAdapter(
 internal sealed class TransactionPayloadViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     abstract fun bind(item: TransactionPayloadItem)
 
-    internal class HeaderViewHolder(view: View) : TransactionPayloadViewHolder(view) {
-        private val headersView: TextView = view.findViewById(R.id.chuckerTransactionResponseHeaders)
+    internal class HeaderViewHolder(
+        private val itemBinding: ChuckerTransactionItemHeadersBinding
+    ) : TransactionPayloadViewHolder(itemBinding.root) {
         override fun bind(item: TransactionPayloadItem) {
             if (item is TransactionPayloadItem.HeaderItem) {
-                headersView.text = item.headers
+                itemBinding.chuckerTransactionResponseHeaders.text = item.headers
             }
         }
     }
 
-    internal class BodyLineViewHolder(view: View) : TransactionPayloadViewHolder(view) {
-        private val bodyLineView: TextView = view.findViewById(R.id.chuckerTransactionResponseBodyLine)
+    internal class BodyLineViewHolder(
+        private val itemBinding: ChuckerTransactionItemBodyLineBinding
+    ) : TransactionPayloadViewHolder(itemBinding.root) {
         override fun bind(item: TransactionPayloadItem) {
             if (item is TransactionPayloadItem.BodyLineItem) {
-                bodyLineView.text = item.line
+                itemBinding.chuckerTransactionResponseBodyLine.text = item.line
             }
         }
     }
 
-    internal class ImageViewHolder(view: View) : TransactionPayloadViewHolder(view) {
-        private val binaryDataView: ImageView = view.findViewById(R.id.chuckerTransactionResponseBinaryData)
+    internal class ImageViewHolder(
+        private val itemBinding: ChuckerTransactionItemImageBinding
+    ) : TransactionPayloadViewHolder(itemBinding.root) {
         override fun bind(item: TransactionPayloadItem) {
             if (item is TransactionPayloadItem.ImageItem) {
-                binaryDataView.setImageBitmap(item.image)
+                itemBinding.chuckerTransactionResponseBinaryData.setImageBitmap(item.image)
             }
         }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -15,7 +15,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.SearchView
@@ -24,8 +23,8 @@ import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
-import androidx.recyclerview.widget.RecyclerView
 import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionPayloadBinding
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
@@ -36,8 +35,7 @@ private const val GET_FILE_FOR_SAVING_REQUEST_CODE: Int = 43
 internal class TransactionPayloadFragment :
     Fragment(), SearchView.OnQueryTextListener {
 
-    private lateinit var progressLoading: ProgressBar
-    private lateinit var transactionContentList: RecyclerView
+    private lateinit var payloadBinding: ChuckerFragmentTransactionPayloadBinding
 
     private var backgroundSpanColor: Int = Color.YELLOW
     private var foregroundSpanColor: Int = Color.RED
@@ -59,12 +57,10 @@ internal class TransactionPayloadFragment :
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? =
-        inflater.inflate(R.layout.chucker_fragment_transaction_payload, container, false).apply {
-            transactionContentList = findViewById(R.id.chuckerTransactionResponseRecyclerView)
-            transactionContentList.isNestedScrollingEnabled = false
-            progressLoading = findViewById(R.id.chuckerTransactionLoadingProgress)
-        }
+    ): View? {
+        payloadBinding = ChuckerFragmentTransactionPayloadBinding.inflate(inflater, container, false)
+        return payloadBinding.root
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -169,7 +165,7 @@ internal class TransactionPayloadFragment :
     override fun onQueryTextSubmit(query: String): Boolean = false
 
     override fun onQueryTextChange(newText: String): Boolean {
-        val adapter = (transactionContentList.adapter as TransactionBodyAdapter)
+        val adapter = (payloadBinding.chuckerTransactionResponseRecyclerView.adapter as TransactionBodyAdapter)
         if (newText.isNotBlank()) {
             adapter.highlightQueryWithColors(newText, backgroundSpanColor, foregroundSpanColor)
         } else {
@@ -185,10 +181,10 @@ internal class TransactionPayloadFragment :
         AsyncTask<Pair<Int, HttpTransaction>, Unit, List<TransactionPayloadItem>>() {
 
         override fun onPreExecute() {
-            val progressBar: ProgressBar? = fragment.view?.findViewById(R.id.chuckerTransactionLoadingProgress)
-            val recyclerView: RecyclerView? = fragment.view?.findViewById(R.id.chuckerTransactionResponseRecyclerView)
-            progressBar?.visibility = View.VISIBLE
-            recyclerView?.visibility = View.INVISIBLE
+            fragment.payloadBinding.apply {
+                chuckerTransactionLoadingProgress.visibility = View.VISIBLE
+                chuckerTransactionResponseRecyclerView.visibility = View.INVISIBLE
+            }
         }
 
         @Suppress("ComplexMethod")
@@ -236,11 +232,11 @@ internal class TransactionPayloadFragment :
         }
 
         override fun onPostExecute(result: List<TransactionPayloadItem>) {
-            val progressBar: ProgressBar? = fragment.view?.findViewById(R.id.chuckerTransactionLoadingProgress)
-            val recyclerView: RecyclerView? = fragment.view?.findViewById(R.id.chuckerTransactionResponseRecyclerView)
-            progressBar?.visibility = View.INVISIBLE
-            recyclerView?.visibility = View.VISIBLE
-            recyclerView?.adapter = TransactionBodyAdapter(result)
+            fragment.payloadBinding.apply {
+                chuckerTransactionLoadingProgress.visibility = View.INVISIBLE
+                chuckerTransactionResponseRecyclerView.visibility = View.VISIBLE
+                chuckerTransactionResponseRecyclerView.adapter = TransactionBodyAdapter(result)
+            }
         }
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -165,7 +165,7 @@ internal class TransactionPayloadFragment :
     override fun onQueryTextSubmit(query: String): Boolean = false
 
     override fun onQueryTextChange(newText: String): Boolean {
-        val adapter = (payloadBinding.chuckerTransactionResponseRecyclerView.adapter as TransactionBodyAdapter)
+        val adapter = (payloadBinding.responseRecyclerView.adapter as TransactionBodyAdapter)
         if (newText.isNotBlank()) {
             adapter.highlightQueryWithColors(newText, backgroundSpanColor, foregroundSpanColor)
         } else {
@@ -182,8 +182,8 @@ internal class TransactionPayloadFragment :
 
         override fun onPreExecute() {
             fragment.payloadBinding.apply {
-                chuckerTransactionLoadingProgress.visibility = View.VISIBLE
-                chuckerTransactionResponseRecyclerView.visibility = View.INVISIBLE
+                loadingProgress.visibility = View.VISIBLE
+                responseRecyclerView.visibility = View.INVISIBLE
             }
         }
 
@@ -233,9 +233,9 @@ internal class TransactionPayloadFragment :
 
         override fun onPostExecute(result: List<TransactionPayloadItem>) {
             fragment.payloadBinding.apply {
-                chuckerTransactionLoadingProgress.visibility = View.INVISIBLE
-                chuckerTransactionResponseRecyclerView.visibility = View.VISIBLE
-                chuckerTransactionResponseRecyclerView.adapter = TransactionBodyAdapter(result)
+                loadingProgress.visibility = View.INVISIBLE
+                responseRecyclerView.visibility = View.VISIBLE
+                responseRecyclerView.adapter = TransactionBodyAdapter(result)
             }
         }
     }

--- a/library/src/main/res/layout/chucker_activity_error.xml
+++ b/library/src/main/res/layout/chucker_activity_error.xml
@@ -12,14 +12,14 @@
         android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
 
         <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/chuckerErrorToolbar"
+            android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:layout_scrollFlags="scroll|enterAlways|snap"
             app:popupTheme="@style/Chucker.Theme">
 
             <TextView
-                android:id="@+id/chuckerErrorToolbarTitle"
+                android:id="@+id/toolbarTitle"
                 style="@style/Chucker.TextAppearance.TransactionTitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -28,7 +28,7 @@
         </com.google.android.material.appbar.MaterialToolbar>
 
         <include
-          android:id="@+id/chuckerErrorActivityItem"
+          android:id="@+id/errorItem"
           layout="@layout/chucker_list_item_error" />
 
     </com.google.android.material.appbar.AppBarLayout>
@@ -39,7 +39,7 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <TextView
-            android:id="@+id/chuckerErrorStacktrace"
+            android:id="@+id/errorStacktrace"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="@dimen/chucker_doub_grid"

--- a/library/src/main/res/layout/chucker_activity_error.xml
+++ b/library/src/main/res/layout/chucker_activity_error.xml
@@ -27,7 +27,9 @@
 
         </com.google.android.material.appbar.MaterialToolbar>
 
-        <include layout="@layout/chucker_list_item_error" />
+        <include
+          android:id="@+id/chuckerErrorActivityItem"
+          layout="@layout/chucker_list_item_error" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/library/src/main/res/layout/chucker_activity_main.xml
+++ b/library/src/main/res/layout/chucker_activity_main.xml
@@ -11,13 +11,13 @@
         android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
 
         <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/chuckerTransactionToolbar"
+            android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:popupTheme="@style/Chucker.Theme" />
 
         <com.google.android.material.tabs.TabLayout
-                android:id="@+id/chuckerMainTabLayout"
+                android:id="@+id/tabLayout"
                 style="@style/Widget.MaterialComponents.TabLayout.PrimarySurface"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
@@ -25,7 +25,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.viewpager.widget.ViewPager
-        android:id="@+id/chuckerMainViewPager"
+        android:id="@+id/viewPager"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 

--- a/library/src/main/res/layout/chucker_activity_transaction.xml
+++ b/library/src/main/res/layout/chucker_activity_transaction.xml
@@ -12,13 +12,13 @@
         android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar">
 
         <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/chuckerTransactionToolbar"
+            android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             app:popupTheme="@style/Chucker.Theme" >
 
             <TextView
-                android:id="@+id/chuckerTransactionToolbarTitle"
+                android:id="@+id/toolbarTitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/chucker_doub_grid"
@@ -28,7 +28,7 @@
         </com.google.android.material.appbar.MaterialToolbar>
 
         <com.google.android.material.tabs.TabLayout
-            android:id="@+id/chuckerTransactionTabLayout"
+            android:id="@+id/tabLayout"
             style="@style/Widget.MaterialComponents.TabLayout.PrimarySurface"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
@@ -36,7 +36,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.viewpager.widget.ViewPager
-        android:id="@+id/chuckerTransactionViewPager"
+        android:id="@+id/viewPager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />

--- a/library/src/main/res/layout/chucker_fragment_error_list.xml
+++ b/library/src/main/res/layout/chucker_fragment_error_list.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/chuckerErrorsRecyclerView"
+        android:id="@+id/errorsRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
@@ -14,7 +14,7 @@
         tools:listitem="@layout/chucker_list_item_error" />
 
     <LinearLayout
-        android:id="@+id/chuckerErrorsTutorialView"
+        android:id="@+id/tutorialView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_margin="@dimen/chucker_doub_grid"
@@ -36,7 +36,7 @@
             android:text="@string/chucker_errors_tutorial" />
 
         <TextView
-            android:id="@+id/chuckerErrorsTutorialLink"
+            android:id="@+id/tutorialLink"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/chucker_base_grid"

--- a/library/src/main/res/layout/chucker_fragment_transaction_list.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_list.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/chuckerTransactionsRecyclerView"
+        android:id="@+id/transactionsRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
@@ -15,7 +15,7 @@
         tools:listitem="@layout/chucker_list_item_transaction" />
 
     <LinearLayout
-        android:id="@+id/chuckerTransactionsTutorialView"
+        android:id="@+id/tutorialView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_margin="@dimen/chucker_doub_grid"
@@ -37,7 +37,7 @@
             android:text="@string/chucker_network_tutorial" />
 
         <TextView
-            android:id="@+id/chuckerTransactionsLink"
+            android:id="@+id/tutorialLink"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/chucker_base_grid"

--- a/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
@@ -115,6 +115,7 @@
       tools:text="200 OK" />
 
     <TextView
+      android:id="@+id/ssl"
       style="@style/Chucker.TextAppearance.Label"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
@@ -125,7 +126,7 @@
       app:layout_constraintTop_toBottomOf="@id/response" />
 
     <TextView
-      android:id="@+id/ssl"
+      android:id="@+id/sslValue"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_marginTop="@dimen/chucker_base_grid"
       android:layout_width="0dp"
@@ -135,6 +136,14 @@
       app:layout_constraintTop_toBottomOf="@id/response"
       tools:text="Yes" />
 
+    <androidx.constraintlayout.widget.Group
+      android:id="@+id/sslGroup"
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      app:constraint_referenced_ids="sslValue,ssl"
+      tools:layout_editor_absoluteX="16dp"
+      tools:layout_editor_absoluteY="16dp" />
+
     <TextView
       android:id="@+id/tlsVersion"
       style="@style/Chucker.TextAppearance.Label"
@@ -143,7 +152,7 @@
       android:text="@string/chucker_tls_version"
       app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/ssl" />
+      app:layout_constraintTop_toBottomOf="@id/sslValue" />
 
     <TextView
       android:id="@+id/tlsVersionValue"
@@ -152,7 +161,7 @@
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintStart_toStartOf="@id/overviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/ssl"
+      app:layout_constraintTop_toBottomOf="@id/sslValue"
       tools:text="TLS 1.2" />
 
     <androidx.constraintlayout.widget.Group

--- a/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
@@ -11,7 +11,7 @@
     android:padding="@dimen/chucker_doub_grid">
 
     <androidx.constraintlayout.widget.Guideline
-      android:id="@+id/chuckerTransactionOverviewGuideline"
+      android:id="@+id/overviewGuideline"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:orientation="vertical"
@@ -23,18 +23,18 @@
       android:layout_height="wrap_content"
       android:gravity="start"
       android:text="@string/chucker_url"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewUrl"
+      android:id="@+id/url"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:gravity="start"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
       app:layout_constraintTop_toTopOf="parent"
       tools:text="https://example.com/path/to/resource?here=might_be_really_long" />
 
@@ -43,18 +43,18 @@
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_method"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewUrl" />
+      app:layout_constraintTop_toBottomOf="@id/url" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewMethod"
+      android:id="@+id/method"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@+id/chuckerTransactionOverviewUrl"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@+id/url"
       tools:text="GET" />
 
     <TextView
@@ -62,18 +62,18 @@
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_protocol"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewMethod" />
+      app:layout_constraintTop_toBottomOf="@id/method" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewProtocol"
+      android:id="@+id/protocol"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewMethod"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/method"
       tools:text="HTTP/1.1" />
 
     <TextView
@@ -81,18 +81,18 @@
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_status"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewProtocol" />
+      app:layout_constraintTop_toBottomOf="@id/protocol" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewStatus"
+      android:id="@+id/status"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewProtocol"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/protocol"
       tools:text="Complete" />
 
     <TextView
@@ -100,18 +100,18 @@
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_response"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewStatus" />
+      app:layout_constraintTop_toBottomOf="@id/status" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewResponse"
+      android:id="@+id/response"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewStatus"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/status"
       tools:text="200 OK" />
 
     <TextView
@@ -119,18 +119,18 @@
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_ssl"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewResponse" />
+      app:layout_constraintTop_toBottomOf="@id/response" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewSsl"
+      android:id="@+id/ssl"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewResponse"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/response"
       tools:text="Yes" />
 
     <TextView
@@ -139,19 +139,19 @@
       android:layout_height="wrap_content"
       android:layout_marginTop="@dimen/chucker_base_grid"
       android:text="@string/chucker_request_time"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewSsl" />
+      app:layout_constraintTop_toBottomOf="@id/ssl" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewRequestTime"
+      android:id="@+id/requestTime"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:layout_marginTop="@dimen/chucker_base_grid"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewSsl"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/ssl"
       tools:text="05/02/17 11:52:49" />
 
     <TextView
@@ -159,18 +159,18 @@
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_response_time"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewRequestTime" />
+      app:layout_constraintTop_toBottomOf="@id/requestTime" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewResponseTime"
+      android:id="@+id/responseTime"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewRequestTime"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/requestTime"
       tools:text="05/02/17 11:52:49" />
 
     <TextView
@@ -178,18 +178,18 @@
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_duration"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewResponseTime" />
+      app:layout_constraintTop_toBottomOf="@id/responseTime" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewDuration"
+      android:id="@+id/duration"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewResponseTime"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/responseTime"
       tools:text="405 ms" />
 
     <TextView
@@ -198,19 +198,19 @@
       android:layout_height="wrap_content"
       android:layout_marginTop="@dimen/chucker_base_grid"
       android:text="@string/chucker_request_size"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewDuration" />
+      app:layout_constraintTop_toBottomOf="@id/duration" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewRequestSize"
+      android:id="@+id/requestSize"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:layout_marginTop="@dimen/chucker_base_grid"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewDuration"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/duration"
       tools:text="53 KB" />
 
     <TextView
@@ -218,18 +218,18 @@
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_response_size"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewRequestSize" />
+      app:layout_constraintTop_toBottomOf="@id/requestSize" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewResponseSize"
+      android:id="@+id/responseSize"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewRequestSize"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/requestSize"
       tools:text="148 KB" />
 
     <TextView
@@ -237,18 +237,18 @@
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:text="@string/chucker_total_size"
-      app:layout_constraintEnd_toStartOf="@id/chuckerTransactionOverviewGuideline"
+      app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewResponseSize" />
+      app:layout_constraintTop_toBottomOf="@id/responseSize" />
 
     <TextView
-      android:id="@+id/chuckerTransactionOverviewTotalSize"
+      android:id="@+id/totalSize"
       style="@style/Chucker.TextAppearance.Value"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/chuckerTransactionOverviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/chuckerTransactionOverviewResponseSize"
+      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+      app:layout_constraintTop_toBottomOf="@id/responseSize"
       tools:text="201 KB" />
 
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
@@ -8,7 +8,7 @@
     tools:context="com.chuckerteam.chucker.internal.ui.transaction.TransactionPayloadFragment">
 
     <ProgressBar
-        android:id="@+id/chuckerTransactionLoadingProgress"
+        android:id="@+id/loadingProgress"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:indeterminate="true"
@@ -17,7 +17,7 @@
         android:visibility="visible" />
 
     <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/chuckerTransactionResponseRecyclerView"
+        android:id="@+id/responseRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"

--- a/library/src/main/res/layout/chucker_list_item_error.xml
+++ b/library/src/main/res/layout/chucker_list_item_error.xml
@@ -8,7 +8,7 @@
     android:padding="8dp">
 
     <TextView
-        android:id="@+id/chuckerItemErrorClazz"
+        android:id="@+id/clazz"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="2dp"
@@ -16,20 +16,20 @@
         tools:text="java.lang.RuntimeException" />
 
     <TextView
-        android:id="@+id/chuckerItemErrorTag"
+        android:id="@+id/tag"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:textAppearance="@style/Chucker.TextAppearance.Label"
         tools:text="A given tag" />
 
     <TextView
-        android:id="@+id/chuckerItemErrorMessage"
+        android:id="@+id/message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         tools:text="Something gone wrong!" />
 
     <TextView
-        android:id="@+id/chuckerItemErrorDate"
+        android:id="@+id/date"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="right|end"

--- a/library/src/main/res/layout/chucker_list_item_transaction.xml
+++ b/library/src/main/res/layout/chucker_list_item_transaction.xml
@@ -8,14 +8,14 @@
     android:padding="@dimen/chucker_base_grid">
 
     <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/chuckerTransactionItemGuideline"
+        android:id="@+id/guideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.5" />
 
     <TextView
-        android:id="@+id/chuckerTransactionItemCode"
+        android:id="@+id/code"
         android:layout_width="@dimen/chucker_item_size"
         android:layout_height="wrap_content"
         android:gravity="center"
@@ -26,66 +26,66 @@
         tools:text="200" />
 
     <TextView
-        android:id="@+id/chuckerTransactionItemPath"
+        android:id="@+id/path"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:textAppearance="@style/Chucker.TextAppearance.ListItem"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/chuckerTransactionItemCode"
+        app:layout_constraintStart_toEndOf="@+id/code"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="GET /path/to/some/resource?goes=here" />
 
     <TextView
-        android:id="@+id/chuckerTransactionItemHost"
+        android:id="@+id/host"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/chucker_half_grid"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/chuckerTransactionItemSsl"
-        app:layout_constraintTop_toBottomOf="@+id/chuckerTransactionItemPath"
+        app:layout_constraintStart_toEndOf="@+id/ssl"
+        app:layout_constraintTop_toBottomOf="@+id/path"
         app:layout_goneMarginStart="0dp"
         app:layout_goneMarginTop="@dimen/chucker_doub_grid"
         tools:text="example.com" />
 
     <ImageView
-        android:id="@+id/chuckerTransactionItemSsl"
+        android:id="@+id/ssl"
         android:layout_width="@dimen/chucker_doub_grid"
         android:layout_height="@dimen/chucker_doub_grid"
         android:contentDescription="@string/chucker_ssl"
         android:src="@drawable/chucker_ic_https_primary"
         android:tint="@color/chucker_color_primary"
         android:visibility="gone"
-        app:layout_constraintStart_toStartOf="@+id/chuckerTransactionItemPath"
-        app:layout_constraintTop_toTopOf="@+id/chuckerTransactionItemHost"
-        app:layout_constraintBottom_toBottomOf="@id/chuckerTransactionItemHost"
+        app:layout_constraintStart_toStartOf="@+id/path"
+        app:layout_constraintTop_toTopOf="@+id/host"
+        app:layout_constraintBottom_toBottomOf="@id/host"
         tools:visibility="visible" />
 
     <TextView
-        android:id="@+id/chuckerTransactionItemTimeStart"
+        android:id="@+id/timeStart"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toStartOf="@+id/chuckerTransactionItemDuration"
-        app:layout_constraintStart_toStartOf="@+id/chuckerTransactionItemPath"
-        app:layout_constraintTop_toBottomOf="@+id/chuckerTransactionItemHost"
+        app:layout_constraintEnd_toStartOf="@+id/duration"
+        app:layout_constraintStart_toStartOf="@+id/path"
+        app:layout_constraintTop_toBottomOf="@+id/host"
         tools:text="18:29:07 PM" />
 
     <TextView
-        android:id="@+id/chuckerTransactionItemDuration"
+        android:id="@+id/duration"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="start"
-        app:layout_constraintEnd_toStartOf="@+id/chuckerTransactionItemSize"
-        app:layout_constraintStart_toEndOf="@+id/chuckerTransactionItemGuideline"
-        app:layout_constraintTop_toTopOf="@+id/chuckerTransactionItemTimeStart"
+        app:layout_constraintEnd_toStartOf="@+id/size"
+        app:layout_constraintStart_toEndOf="@+id/guideline"
+        app:layout_constraintTop_toTopOf="@+id/timeStart"
         tools:text="8023 ms" />
 
     <TextView
-        android:id="@+id/chuckerTransactionItemSize"
+        android:id="@+id/size"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="end"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/chuckerTransactionItemDuration"
-        app:layout_constraintTop_toTopOf="@+id/chuckerTransactionItemDuration"
+        app:layout_constraintStart_toEndOf="@+id/duration"
+        app:layout_constraintTop_toTopOf="@+id/duration"
         tools:text="16.45 KB" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/layout/chucker_transaction_item_body_line.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_body_line.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/chuckerTransactionResponseBodyLine"
+    android:id="@+id/bodyLine"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:textIsSelectable="true"

--- a/library/src/main/res/layout/chucker_transaction_item_headers.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_headers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/chuckerTransactionResponseHeaders"
+    android:id="@+id/responseHeaders"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/chucker_doub_grid"

--- a/library/src/main/res/layout/chucker_transaction_item_image.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_image.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/chuckerTransactionResponseBinaryData"
+    android:id="@+id/binaryData"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/chucker_doub_grid"

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="chucker_share_error_content"><![CDATA[Date: %1$s\nException: %2$s\nTag: %3$s\nMessage: %4$s\n\n%5$s]]></string>
     <string name="chucker_clear_http_confirmation">Do you want to clear complete network calls history?</string>
     <string name="chucker_clear_error_confirmation">Do you want to clear complete errors history?</string>
-    <string name="chucker_check_readme"><a href="chucker_https://github.com/ChuckerTeam/chucker/blob/develop/README.md#configure-">Check the setup instructions on GitHub</a></string>
+    <string name="chucker_check_readme"><a href="https://github.com/ChuckerTeam/chucker/blob/develop/README.md#configure-">Check the setup instructions on GitHub</a></string>
     <string name="chucker_setup">Setup</string>
     <string name="chucker_binary_data">binary data</string>
     <string name="chucker_request_not_ready">The request isn\'t ready for sharing or saving</string>


### PR DESCRIPTION
## :page_facing_up: Context
Chucker relied on `findViewById` stuff for quite a long time. Since [ViewBinding](https://developer.android.com/topic/libraries/view-binding) is officially released, I believe we should switch to it to make library code more concise and robust.

## :pencil: Changes
- Enabled `ViewBinding` in `build.gradle`.
- Switched all Activities, Fragments and Adapters to use `ViewBinding`.
- Removed some boilerplate, like duplicate of `onTransactionItemClickListener()`.
- Fixed link to tutorial, which became invalid after recent resources renaming.

## :paperclip: Related PR
- [x] Would like to merge it after #252 so I could add new fields here as well.
- [ ] Need to merge #257 since there were some resources renaming.

## :hammer_and_wrench: How to test
Just run it.
