### PR TITLE
Response search fixes

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/SearchHighlightUtil.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/SearchHighlightUtil.kt
@@ -7,7 +7,7 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.UnderlineSpan
 
 /**
- * Hightlight parts of the String when it matches the search.
+ * Highlight parts of the String when it matches the search.
  *
  * @param search the text to highlight
  */

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
@@ -57,7 +57,7 @@ internal class TransactionBodyAdapter(
         bodyItems.filterIsInstance<TransactionPayloadItem.BodyLineItem>()
             .withIndex()
             .forEach { (index, item) ->
-                if (newText in item.line) {
+                if (item.line.contains(newText, ignoreCase = true)) {
                     item.line.clearSpans()
                     item.line = item.line.toString()
                         .highlightWithDefinedColors(newText, backgroundColor, foregroundColor)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -170,7 +170,7 @@ internal class TransactionPayloadFragment :
 
     override fun onQueryTextChange(newText: String): Boolean {
         val adapter = (transactionContentList.adapter as TransactionBodyAdapter)
-        if (newText.isNotBlank()) {
+        if (newText.isNotBlank() && newText.length > NUMBER_OF_IGNORED_SYMBOLS) {
             adapter.highlightQueryWithColors(newText, backgroundSpanColor, foregroundSpanColor)
         } else {
             adapter.resetHighlight()
@@ -297,6 +297,8 @@ internal class TransactionPayloadFragment :
     companion object {
         private const val ARG_TYPE = "type"
         private const val TRANSACTION_EXCEPTION = "Transaction not ready"
+
+        private const val NUMBER_OF_IGNORED_SYMBOLS = 1
 
         const val TYPE_REQUEST = 0
         const val TYPE_RESPONSE = 1

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -241,6 +241,7 @@ internal class TransactionPayloadFragment :
             progressBar?.visibility = View.INVISIBLE
             recyclerView?.visibility = View.VISIBLE
             recyclerView?.adapter = TransactionBodyAdapter(result)
+            fragment.requireActivity().invalidateOptionsMenu()
         }
     }
 


### PR DESCRIPTION
## :page_facing_up: Context
Found some issues with response body search, like mentioned in #254 and #255.
Also, it seems not optimal that Chucker performs search even when there is only one symbol in the search fields. To avoid redundant work I decided to update the logic to require more than 1 symbol.

## :pencil: Changes
- Closed #254 by switching from operator function `in` to `contains` with explicit declaration of case ingoring.
- Closed #255 by invalidating options menu after AsyncTask finishes transaction loading.
- Added a requirement to input more than 1 symbol to perform search.

## :no_entry_sign: Breaking
Nothing breaking is expected

## :hammer_and_wrench: How to test
Just try to search something :)
