### PR TITLE
Feature/truth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         materialComponentsVersion = '1.1.0'
         roomVersion = '2.2.3'
         lifecycleVersion = '2.2.0'
-        androidXCore = '2.1.0'
+        androidXCoreVersion = '2.1.0'
 
         // Publishing
         androidMavenGradleVersion = '2.1'
@@ -29,6 +29,7 @@ buildscript {
         junitGradlePluignVersion = '1.3.1.1'
         junitVersion = '5.4.2'
         mockkVersion = '1.9.3'
+        truthVersion = '1.0.1'
     }
 
     repositories {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -75,7 +75,8 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
-    testImplementation "androidx.arch.core:core-testing:$androidXCore"
+    testImplementation "androidx.arch.core:core-testing:$androidXCoreVersion"
+    testImplementation "com.google.truth:truth:$truthVersion"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/FormatUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/FormatUtilsTest.kt
@@ -1,6 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
-import org.junit.jupiter.api.Assertions.assertEquals
+import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
 class FormatUtilsTest {
@@ -15,13 +15,12 @@ class FormatUtilsTest {
             """.trimIndent()
         )
 
-        assertEquals(
+        assertThat(parsedJson).isEqualTo(
             """
             {
               "field": null
             }
-            """.trimIndent(),
-            parsedJson
+            """.trimIndent()
         )
     }
 
@@ -35,13 +34,12 @@ class FormatUtilsTest {
             """.trimIndent()
         )
 
-        assertEquals(
+        assertThat(parsedJson).isEqualTo(
             """
             {
               "field": ""
             }
-            """.trimIndent(),
-            parsedJson
+            """.trimIndent()
         )
     }
 
@@ -51,14 +49,13 @@ class FormatUtilsTest {
             """{ "field1": "something", "field2": "else" }"""
         )
 
-        assertEquals(
+        assertThat(parsedJson).isEqualTo(
             """
             {
               "field1": "something",
               "field2": "else"
             }
-            """.trimIndent(),
-            parsedJson
+            """.trimIndent()
         )
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/FormattedUrlTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/FormattedUrlTest.kt
@@ -27,7 +27,7 @@ class FormattedUrlTest {
 
         assertThat(formattedUrl.scheme).isEqualTo("https")
         assertThat(formattedUrl.host).isEqualTo("www.example.com")
-        assertThat(formattedUrl.path).isEqualTo("")
+        assertThat(formattedUrl.path).isEmpty()
         assertThat(formattedUrl.query).isEqualTo("q=%22Hello,%20world!%22")
         assertThat(formattedUrl.pathWithQuery).isEqualTo("?q=%22Hello,%20world!%22")
         assertThat(formattedUrl.url).isEqualTo("https://www.example.com?q=%22Hello,%20world!%22")
@@ -42,7 +42,7 @@ class FormattedUrlTest {
         assertThat(formattedUrl.scheme).isEqualTo("https")
         assertThat(formattedUrl.host).isEqualTo("www.example.com")
         assertThat(formattedUrl.path).isEqualTo("/path/to%20some/resource")
-        assertThat(formattedUrl.query).isEqualTo("")
+        assertThat(formattedUrl.query).isEmpty()
         assertThat(formattedUrl.pathWithQuery).isEqualTo("/path/to%20some/resource")
         assertThat(formattedUrl.url).isEqualTo("https://www.example.com/path/to%20some/resource")
     }
@@ -69,7 +69,7 @@ class FormattedUrlTest {
 
         assertThat(formattedUrl.scheme).isEqualTo("https")
         assertThat(formattedUrl.host).isEqualTo("www.example.com")
-        assertThat(formattedUrl.path).isEqualTo("")
+        assertThat(formattedUrl.path).isEmpty()
         assertThat(formattedUrl.query).isEqualTo("q=\"Hello, world!\"")
         assertThat(formattedUrl.pathWithQuery).isEqualTo("?q=\"Hello, world!\"")
         assertThat(formattedUrl.url).isEqualTo("https://www.example.com?q=\"Hello, world!\"")
@@ -84,7 +84,7 @@ class FormattedUrlTest {
         assertThat(formattedUrl.scheme).isEqualTo("https")
         assertThat(formattedUrl.host).isEqualTo("www.example.com")
         assertThat(formattedUrl.path).isEqualTo("/path/to some/resource")
-        assertThat(formattedUrl.query).isEqualTo("")
+        assertThat(formattedUrl.query).isEmpty()
         assertThat(formattedUrl.pathWithQuery).isEqualTo("/path/to some/resource")
         assertThat(formattedUrl.url).isEqualTo("https://www.example.com/path/to some/resource")
     }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/FormattedUrlTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/FormattedUrlTest.kt
@@ -1,6 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
-import junit.framework.TestCase.assertEquals
+import com.google.common.truth.Truth.assertThat
 import okhttp3.HttpUrl
 import org.junit.Test
 
@@ -11,15 +11,12 @@ class FormattedUrlTest {
 
         val formattedUrl = FormattedUrl.fromHttpUrl(url, encoded = true)
 
-        assertEquals("https", formattedUrl.scheme)
-        assertEquals("www.example.com", formattedUrl.host)
-        assertEquals("/path/to%20some/resource", formattedUrl.path)
-        assertEquals("q=%22Hello,%20world!%22", formattedUrl.query)
-        assertEquals("/path/to%20some/resource?q=%22Hello,%20world!%22", formattedUrl.pathWithQuery)
-        assertEquals(
-            "https://www.example.com/path/to%20some/resource?q=%22Hello,%20world!%22",
-            formattedUrl.url
-        )
+        assertThat(formattedUrl.scheme).isEqualTo("https")
+        assertThat(formattedUrl.host).isEqualTo("www.example.com")
+        assertThat(formattedUrl.path).isEqualTo("/path/to%20some/resource")
+        assertThat(formattedUrl.query).isEqualTo("q=%22Hello,%20world!%22")
+        assertThat(formattedUrl.pathWithQuery).isEqualTo("/path/to%20some/resource?q=%22Hello,%20world!%22")
+        assertThat(formattedUrl.url).isEqualTo("https://www.example.com/path/to%20some/resource?q=%22Hello,%20world!%22")
     }
 
     @Test
@@ -28,12 +25,12 @@ class FormattedUrlTest {
 
         val formattedUrl = FormattedUrl.fromHttpUrl(url, encoded = true)
 
-        assertEquals("https", formattedUrl.scheme)
-        assertEquals("www.example.com", formattedUrl.host)
-        assertEquals("", formattedUrl.path)
-        assertEquals("q=%22Hello,%20world!%22", formattedUrl.query)
-        assertEquals("?q=%22Hello,%20world!%22", formattedUrl.pathWithQuery)
-        assertEquals("https://www.example.com?q=%22Hello,%20world!%22", formattedUrl.url)
+        assertThat(formattedUrl.scheme).isEqualTo("https")
+        assertThat(formattedUrl.host).isEqualTo("www.example.com")
+        assertThat(formattedUrl.path).isEqualTo("")
+        assertThat(formattedUrl.query).isEqualTo("q=%22Hello,%20world!%22")
+        assertThat(formattedUrl.pathWithQuery).isEqualTo("?q=%22Hello,%20world!%22")
+        assertThat(formattedUrl.url).isEqualTo("https://www.example.com?q=%22Hello,%20world!%22")
     }
 
     @Test
@@ -42,12 +39,12 @@ class FormattedUrlTest {
 
         val formattedUrl = FormattedUrl.fromHttpUrl(url, encoded = true)
 
-        assertEquals("https", formattedUrl.scheme)
-        assertEquals("www.example.com", formattedUrl.host)
-        assertEquals("/path/to%20some/resource", formattedUrl.path)
-        assertEquals("", formattedUrl.query)
-        assertEquals("/path/to%20some/resource", formattedUrl.pathWithQuery)
-        assertEquals("https://www.example.com/path/to%20some/resource", formattedUrl.url)
+        assertThat(formattedUrl.scheme).isEqualTo("https")
+        assertThat(formattedUrl.host).isEqualTo("www.example.com")
+        assertThat(formattedUrl.path).isEqualTo("/path/to%20some/resource")
+        assertThat(formattedUrl.query).isEqualTo("")
+        assertThat(formattedUrl.pathWithQuery).isEqualTo("/path/to%20some/resource")
+        assertThat(formattedUrl.url).isEqualTo("https://www.example.com/path/to%20some/resource")
     }
 
     @Test
@@ -56,15 +53,12 @@ class FormattedUrlTest {
 
         val formattedUrl = FormattedUrl.fromHttpUrl(url, encoded = false)
 
-        assertEquals("https", formattedUrl.scheme)
-        assertEquals("www.example.com", formattedUrl.host)
-        assertEquals("/path/to some/resource", formattedUrl.path)
-        assertEquals("q=\"Hello, world!\"", formattedUrl.query)
-        assertEquals("/path/to some/resource?q=\"Hello, world!\"", formattedUrl.pathWithQuery)
-        assertEquals(
-            "https://www.example.com/path/to some/resource?q=\"Hello, world!\"",
-            formattedUrl.url
-        )
+        assertThat(formattedUrl.scheme).isEqualTo("https")
+        assertThat(formattedUrl.host).isEqualTo("www.example.com")
+        assertThat(formattedUrl.path).isEqualTo("/path/to some/resource")
+        assertThat(formattedUrl.query).isEqualTo("q=\"Hello, world!\"")
+        assertThat(formattedUrl.pathWithQuery).isEqualTo("/path/to some/resource?q=\"Hello, world!\"")
+        assertThat(formattedUrl.url).isEqualTo("https://www.example.com/path/to some/resource?q=\"Hello, world!\"")
     }
 
     @Test
@@ -73,12 +67,12 @@ class FormattedUrlTest {
 
         val formattedUrl = FormattedUrl.fromHttpUrl(url, encoded = false)
 
-        assertEquals("https", formattedUrl.scheme)
-        assertEquals("www.example.com", formattedUrl.host)
-        assertEquals("", formattedUrl.path)
-        assertEquals("q=\"Hello, world!\"", formattedUrl.query)
-        assertEquals("?q=\"Hello, world!\"", formattedUrl.pathWithQuery)
-        assertEquals("https://www.example.com?q=\"Hello, world!\"", formattedUrl.url)
+        assertThat(formattedUrl.scheme).isEqualTo("https")
+        assertThat(formattedUrl.host).isEqualTo("www.example.com")
+        assertThat(formattedUrl.path).isEqualTo("")
+        assertThat(formattedUrl.query).isEqualTo("q=\"Hello, world!\"")
+        assertThat(formattedUrl.pathWithQuery).isEqualTo("?q=\"Hello, world!\"")
+        assertThat(formattedUrl.url).isEqualTo("https://www.example.com?q=\"Hello, world!\"")
     }
 
     @Test
@@ -87,11 +81,11 @@ class FormattedUrlTest {
 
         val formattedUrl = FormattedUrl.fromHttpUrl(url, encoded = false)
 
-        assertEquals("https", formattedUrl.scheme)
-        assertEquals("www.example.com", formattedUrl.host)
-        assertEquals("/path/to some/resource", formattedUrl.path)
-        assertEquals("", formattedUrl.query)
-        assertEquals("/path/to some/resource", formattedUrl.pathWithQuery)
-        assertEquals("https://www.example.com/path/to some/resource", formattedUrl.url)
+        assertThat(formattedUrl.scheme).isEqualTo("https")
+        assertThat(formattedUrl.host).isEqualTo("www.example.com")
+        assertThat(formattedUrl.path).isEqualTo("/path/to some/resource")
+        assertThat(formattedUrl.query).isEqualTo("")
+        assertThat(formattedUrl.pathWithQuery).isEqualTo("/path/to some/resource")
+        assertThat(formattedUrl.url).isEqualTo("https://www.example.com/path/to some/resource")
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
@@ -2,6 +2,7 @@ package com.chuckerteam.chucker.internal.support
 
 import android.content.Context
 import com.chuckerteam.chucker.R
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -9,10 +10,6 @@ import java.io.EOFException
 import java.nio.charset.Charset
 import java.util.stream.Stream
 import okio.Buffer
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -28,7 +25,7 @@ class IOUtilsTest {
     fun isPlaintext_withEmptyBuffer_returnsTrue() {
         val buffer = Buffer()
 
-        assertTrue(ioUtils.isPlaintext(buffer))
+        assertThat(ioUtils.isPlaintext(buffer)).isTrue()
     }
 
     @Test
@@ -36,7 +33,7 @@ class IOUtilsTest {
         val buffer = Buffer()
         buffer.writeString(" ", Charset.defaultCharset())
 
-        assertTrue(ioUtils.isPlaintext(buffer))
+        assertThat(ioUtils.isPlaintext(buffer)).isTrue()
     }
 
     @Test
@@ -44,7 +41,7 @@ class IOUtilsTest {
         val buffer = Buffer()
         buffer.writeString("just a string", Charset.defaultCharset())
 
-        assertTrue(ioUtils.isPlaintext(buffer))
+        assertThat(ioUtils.isPlaintext(buffer)).isTrue()
     }
 
     @Test
@@ -52,7 +49,7 @@ class IOUtilsTest {
         val buffer = Buffer()
         buffer.writeByte(0x11000000)
 
-        assertFalse(ioUtils.isPlaintext(buffer))
+        assertThat(ioUtils.isPlaintext(buffer)).isFalse()
     }
 
     @Test
@@ -61,9 +58,10 @@ class IOUtilsTest {
         every { mockBuffer.size() } returns 100L
         every { mockBuffer.copyTo(any<Buffer>(), any(), any()) } throws EOFException()
 
-        assertFalse(ioUtils.isPlaintext(mockBuffer))
+        assertThat(ioUtils.isPlaintext(mockBuffer)).isFalse()
     }
 
+    @Test
     fun readFromBuffer_contentNotTruncated() {
         val mockBuffer = mockk<Buffer>()
         every { mockBuffer.size() } returns 100L
@@ -71,7 +69,7 @@ class IOUtilsTest {
 
         val result = ioUtils.readFromBuffer(mockBuffer, Charset.defaultCharset(), 200L)
 
-        assertEquals("{ \"message\": \"just a mock body\"}", result)
+        assertThat(result).isEqualTo("{ \"message\": \"just a mock body\"}")
         verify { mockBuffer.readString(100L, Charset.defaultCharset()) }
     }
 
@@ -84,7 +82,7 @@ class IOUtilsTest {
 
         val result = ioUtils.readFromBuffer(mockBuffer, Charset.defaultCharset(), 50L)
 
-        assertEquals("{ \"message\": \"just a mock body\"}\\n\\n--- Content truncated ---", result)
+        assertThat(result).isEqualTo("{ \"message\": \"just a mock body\"}\\n\\n--- Content truncated ---")
         verify { mockBuffer.readString(50L, Charset.defaultCharset()) }
     }
 
@@ -97,7 +95,7 @@ class IOUtilsTest {
 
         val result = ioUtils.readFromBuffer(mockBuffer, Charset.defaultCharset(), 200L)
 
-        assertEquals("\\n\\n--- Unexpected end of content ---", result)
+        assertThat(result).isEqualTo("\\n\\n--- Unexpected end of content ---")
     }
 
     @Test
@@ -106,7 +104,7 @@ class IOUtilsTest {
 
         val nativeSource = ioUtils.getNativeSource(mockBuffer, false)
 
-        assertEquals(mockBuffer, nativeSource)
+        assertThat(nativeSource).isEqualTo(mockBuffer)
     }
 
     @Test
@@ -114,17 +112,16 @@ class IOUtilsTest {
         val mockBuffer = mockk<Buffer>()
 
         val nativeSource = ioUtils.getNativeSource(mockBuffer, true)
-
-        assertNotEquals(mockBuffer, nativeSource)
+        assertThat(nativeSource).isNotEqualTo(mockBuffer)
     }
 
     @ParameterizedTest(name = "{0} must be supported? {1}")
     @MethodSource("supportedEncodingSource")
     @DisplayName("Check if body encoding is supported")
-    fun bodyHasSupportedEncoding(encoding: String?, supported: Boolean) {
+    fun bodyHasSupportedEncoding(encoding: String?, isSupported: Boolean) {
         val result = ioUtils.bodyHasSupportedEncoding(encoding)
 
-        assertEquals(supported, result)
+        assertThat(result).isEqualTo(isSupported)
     }
 
     companion object {

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/JsonConverterTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/JsonConverterTest.kt
@@ -1,9 +1,10 @@
 package com.chuckerteam.chucker.internal.support
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Test
 import java.text.DateFormat
-import java.util.*
+import java.util.Date
+import java.util.Locale
+import org.junit.jupiter.api.Test
 
 class JsonConverterTest {
 

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/JsonConverterTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/JsonConverterTest.kt
@@ -1,9 +1,9 @@
 package com.chuckerteam.chucker.internal.support
 
-import java.util.Date
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
+import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
+import java.text.DateFormat
+import java.util.*
 
 class JsonConverterTest {
 
@@ -12,45 +12,44 @@ class JsonConverterTest {
         val instance1 = JsonConverter.instance
         val instance2 = JsonConverter.instance
 
-        assertTrue(instance1 == instance2)
+        assertThat(instance1).isEqualTo(instance2)
     }
 
     @Test
     fun testGsonConfiguration_willParseDateTime() {
+        val dateFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US)
+        val expectedDateString = dateFormat.format(Date(0))
         val json = JsonConverter.instance.toJson(DateTestClass(Date(0)))
-        assertEquals(
+        assertThat(json).isEqualTo(
             """
             {
-              "date": "Jan 1, 1970 1:00:00 AM"
+              "date": "$expectedDateString"
             }
-            """.trimIndent(),
-            json
+            """.trimIndent()
         )
     }
 
     @Test
     fun testGsonConfiguration_willUseLowerCaseWithUnderscores() {
         val json = JsonConverter.instance.toJson(NamingTestClass("aCamelCaseString"))
-        assertEquals(
+        assertThat(json).isEqualTo(
             """
             {
               "a_long_name_with_camel_case": "aCamelCaseString"
             }
-            """.trimIndent(),
-            json
+            """.trimIndent()
         )
     }
 
     @Test
     fun testGsonConfiguration_willSerializeNulls() {
         val json = JsonConverter.instance.toJson(NullTestClass(null))
-        assertEquals(
+        assertThat(json).isEqualTo(
             """
             {
               "string": null
             }
-            """.trimIndent(),
-            json
+            """.trimIndent()
         )
     }
 

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataCombineLatestTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataCombineLatestTest.kt
@@ -3,7 +3,7 @@ package com.chuckerteam.chucker.internal.support
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import com.chuckerteam.chucker.test
-import junit.framework.TestCase.assertEquals
+import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
 
@@ -42,7 +42,7 @@ class LiveDataCombineLatestTest {
             inputA.value = true
             inputB.value = 1
 
-            assertEquals(true to 1, expectData())
+            assertThat(expectData()).isEqualTo(true to 1)
         }
     }
 
@@ -51,10 +51,10 @@ class LiveDataCombineLatestTest {
         upstream.test {
             inputA.value = true
             inputB.value = 1
-            assertEquals(true to 1, expectData())
+            assertThat(expectData()).isEqualTo(true to 1)
 
             inputB.value = 2
-            assertEquals(true to 2, expectData())
+            assertThat(expectData()).isEqualTo(true to 2)
         }
     }
 
@@ -63,10 +63,10 @@ class LiveDataCombineLatestTest {
         upstream.test {
             inputA.value = true
             inputB.value = 1
-            assertEquals(true to 1, expectData())
+            assertThat(expectData()).isEqualTo(true to 1)
 
             inputA.value = false
-            assertEquals(false to 1, expectData())
+            assertThat(expectData()).isEqualTo(false to 1)
         }
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
@@ -4,7 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
 import com.chuckerteam.chucker.test
-import junit.framework.TestCase.assertEquals
+import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
 
@@ -16,7 +16,7 @@ class LiveDataDistinctUntilChangedTest {
         val upstream = MutableLiveData<Any?>(null)
 
         upstream.distinctUntilChanged().test {
-            assertEquals(null, expectData())
+            assertThat(expectData()).isEqualTo(null)
         }
     }
 
@@ -35,16 +35,16 @@ class LiveDataDistinctUntilChangedTest {
 
         upstream.distinctUntilChanged().test {
             upstream.value = 1
-            assertEquals(1, expectData())
+            assertThat(expectData()).isEqualTo(1)
 
             upstream.value = 2
-            assertEquals(2, expectData())
+            assertThat(expectData()).isEqualTo(2)
 
             upstream.value = null
-            assertEquals(null, expectData())
+            assertThat(expectData()).isEqualTo(null)
 
             upstream.value = 2
-            assertEquals(2, expectData())
+            assertThat(expectData()).isEqualTo(2)
         }
     }
 
@@ -54,13 +54,13 @@ class LiveDataDistinctUntilChangedTest {
 
         upstream.distinctUntilChanged().test {
             upstream.value = null
-            assertEquals(null, expectData())
+            assertThat(expectData()).isEqualTo(null)
 
             upstream.value = null
             expectNoData()
 
             upstream.value = ""
-            assertEquals("", expectData())
+            assertThat(expectData()).isEqualTo("")
 
             upstream.value = ""
             expectNoData()
@@ -73,16 +73,16 @@ class LiveDataDistinctUntilChangedTest {
 
         upstream.distinctUntilChanged { old, new -> old.first == new.first }.test {
             upstream.value = 1 to ""
-            assertEquals(1 to "", expectData())
+            assertThat(expectData()).isEqualTo(1 to "")
 
             upstream.value = 1 to "a"
             expectNoData()
 
             upstream.value = 2 to "b"
-            assertEquals(2 to "b", expectData())
+            assertThat(expectData()).isEqualTo(2 to "b")
 
             upstream.value = 3 to "b"
-            assertEquals(3 to "b", expectData())
+            assertThat(expectData()).isEqualTo(3 to "b")
         }
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
@@ -16,7 +16,7 @@ class LiveDataDistinctUntilChangedTest {
         val upstream = MutableLiveData<Any?>(null)
 
         upstream.distinctUntilChanged().test {
-            assertThat(expectData()).isEqualTo(null)
+            assertThat(expectData()).isNull()
         }
     }
 
@@ -41,7 +41,7 @@ class LiveDataDistinctUntilChangedTest {
             assertThat(expectData()).isEqualTo(2)
 
             upstream.value = null
-            assertThat(expectData()).isEqualTo(null)
+            assertThat(expectData()).isNull()
 
             upstream.value = 2
             assertThat(expectData()).isEqualTo(2)
@@ -54,13 +54,13 @@ class LiveDataDistinctUntilChangedTest {
 
         upstream.distinctUntilChanged().test {
             upstream.value = null
-            assertThat(expectData()).isEqualTo(null)
+            assertThat(expectData()).isNull()
 
             upstream.value = null
             expectNoData()
 
             upstream.value = ""
-            assertThat(expectData()).isEqualTo("")
+            assertThat(expectData()).isEmpty()
 
             upstream.value = ""
             expectNoData()

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
@@ -1,13 +1,11 @@
 package com.chuckerteam.chucker.internal.support
 
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.Response
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class OkHttpUtilsTest {
@@ -17,7 +15,7 @@ class OkHttpUtilsTest {
         val mockResponse = mockk<Response>()
         every { mockResponse.header("Content-Length") } returns null
 
-        assertEquals(-1, mockResponse.contentLenght)
+        assertThat(mockResponse.contentLenght).isEqualTo(-1)
     }
 
     @Test
@@ -25,7 +23,7 @@ class OkHttpUtilsTest {
         val mockResponse = mockk<Response>()
         every { mockResponse.header("Content-Length") } returns "0"
 
-        assertEquals(0L, mockResponse.contentLenght)
+        assertThat(mockResponse.contentLenght).isEqualTo(0L)
     }
 
     @Test
@@ -33,7 +31,7 @@ class OkHttpUtilsTest {
         val mockResponse = mockk<Response>()
         every { mockResponse.header("Content-Length") } returns "42"
 
-        assertEquals(42L, mockResponse.contentLenght)
+        assertThat(mockResponse.contentLenght).isEqualTo(42L)
     }
 
     @Test
@@ -41,7 +39,7 @@ class OkHttpUtilsTest {
         val mockResponse = mockk<Response>()
         every { mockResponse.header("Transfer-Encoding") } returns "gzip"
 
-        assertFalse(mockResponse.isChunked)
+        assertThat(mockResponse.isChunked).isFalse()
     }
 
     @Test
@@ -50,7 +48,7 @@ class OkHttpUtilsTest {
         every { mockResponse.header("Content-Length") } returns null
         every { mockResponse.header("Transfer-Encoding") } returns null
 
-        assertFalse(mockResponse.isChunked)
+        assertThat(mockResponse.isChunked).isFalse()
     }
 
     @Test
@@ -58,7 +56,7 @@ class OkHttpUtilsTest {
         val mockResponse = mockk<Response>()
         every { mockResponse.header("Transfer-Encoding") } returns "chunked"
 
-        assertTrue(mockResponse.isChunked)
+        assertThat(mockResponse.isChunked).isTrue()
     }
 
     @Test
@@ -66,7 +64,7 @@ class OkHttpUtilsTest {
         val mockResponse = mockk<Response>()
         every { mockResponse.headers() } returns Headers.of("Content-Encoding", "gzip")
 
-        assertTrue(mockResponse.isGzipped)
+        assertThat(mockResponse.isGzipped).isTrue()
     }
 
     @Test
@@ -74,7 +72,7 @@ class OkHttpUtilsTest {
         val mockResponse = mockk<Response>()
         every { mockResponse.headers() } returns Headers.of("Content-Encoding", "identity")
 
-        assertFalse(mockResponse.isGzipped)
+        assertThat(mockResponse.isGzipped).isFalse()
     }
 
     @Test
@@ -82,7 +80,7 @@ class OkHttpUtilsTest {
         val mockRequest = mockk<Request>()
         every { mockRequest.headers() } returns Headers.of("Content-Encoding", "gzip")
 
-        assertTrue(mockRequest.isGzipped)
+        assertThat(mockRequest.isGzipped).isTrue()
     }
 
     @Test
@@ -90,6 +88,6 @@ class OkHttpUtilsTest {
         val mockRequest = mockk<Request>()
         every { mockRequest.headers() } returns Headers.of("Content-Encoding", "identity")
 
-        assertFalse(mockRequest.isGzipped)
+        assertThat(mockRequest.isGzipped).isFalse()
     }
 }


### PR DESCRIPTION
## :page_facing_up: Context
As a part of test coverage improvement I would like to add [Truth](https://truth.dev/) for more concise assertions in tests.
While updating assertions found one test with missing `@Test` annotation and issue with one of tests.

## :pencil: Changes
- Added Truth.
- Added missing `@Test` annotation.
- Fixed `testGsonConfiguration_willParseDateTime()` since its success or failure was dependent on the timezone of the machine running it. Namely, `Date(0)` returns `Jan. 1 1970`, but the time is always different in different timezones, so the time specified in the expected result string wasn't the same for me.