### PR TITLE
Bump targetSDK to 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,8 @@ os:
     - linux
 env:
   global:
-    - ANDROID_API_LEVEL=28
-    - ANDROID_BUILD_TOOLS_VERSION=28.0.3
-    - ANDROID_ABI=armeabi-v7a
-    - ANDROID_TAG=google_apis
+    - ANDROID_API_LEVEL=29
+    - ANDROID_BUILD_TOOLS_VERSION=29.0.3
 
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,12 @@ android:
     - platform-tools
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION
     - android-$ANDROID_API_LEVEL
-    - extra-android-support
     - extra-android-m2repository
     - extra-google-m2repository
+
+before_install:
+  - yes | sdkmanager "platforms;android-29"
+  - yes | sdkmanager "build-tools;29.0.3"
 
 script:
    - ./gradlew clean ktlintCheck lint detekt build test

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,6 @@ task clean(type: Delete) {
 
 ext {
     minSdkVersion = 16
-    targetSdkVersion = 28
-    compileSdkVersion = 28
+    targetSdkVersion = 29
+    compileSdkVersion = 29
 }


### PR DESCRIPTION
## :page_facing_up: Context
Despite SDK 29 being available for quite a long time Chucker still used 28 as its targetSDK. 
There were no changes which could break Chucker after updating 28 to 29.

## :pencil: Changes
- Bumped targetSDK from 28 to 29
- Updated Travis config to use 29 SDK as well.
- Removed a few redundant variables in Travis config.