### PR TITLE
Update targetSDK and Kotlin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlinVersion = '1.3.61'
+        kotlinVersion = '1.3.70'
         androidGradleVersion = '3.6.0'
 
         // Google libraries
@@ -65,6 +65,6 @@ task clean(type: Delete) {
 
 ext {
     minSdkVersion = 16
-    targetSdkVersion = 28
-    compileSdkVersion = 28
+    targetSdkVersion = 29
+    compileSdkVersion = 29
 }


### PR DESCRIPTION
## :page_facing_up: Context
Another attempt to update targetSDK in Chucker. Since we migrated from Travis, I expect no issues with licences. Also updated Kotlin version.

## :pencil: Changes
- Bumped targetSDK to 29
- Updated Kotlin plugin version to 1.3.70
