### PR TITLE
Add stale builds canceller

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -12,6 +12,7 @@ jobs:
       uses: yellowmegaman/gh-build-canceller@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflows_filter: "Validate Gradle Wrapper|Pre Merge Checks"
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
       

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -10,6 +10,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Stale run canceller
       uses: yellowmegaman/gh-build-canceller@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
       

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,5 @@
 name: Validate Gradle Wrapper
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   validation:
@@ -8,11 +8,6 @@ jobs:
     steps:
     - name: Checkout latest code
       uses: actions/checkout@v2
-    - name: Stale run canceller
-      uses: yellowmegaman/gh-build-canceller@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        workflows_filter: "Validate Gradle Wrapper|Pre Merge Checks"
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
       

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Stale run canceller
       uses: yellowmegaman/gh-build-canceller@master
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Validate Gradle Wrapper
       uses: gradle/wrapper-validation-action@v1
       

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,12 @@
 name: Validate Gradle Wrapper
-on: pull_request
+on: 
+  push:
+      branches:
+      - develop 
+      - release
+  pull_request:
+    branches: 
+      - '*'
 
 jobs:
   validation:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -6,5 +6,10 @@ jobs:
     name: Validation
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: gradle/wrapper-validation-action@v1
+    - name: Checkout latest code
+      uses: actions/checkout@v2
+    - name: Stale run canceller
+      uses: yellowmegaman/gh-build-canceller@master
+    - name: Validate Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
+      

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -7,5 +7,9 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+    - name: Stale run canceller
+      uses: yellowmegaman/gh-build-canceller@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Gradle preMerge task
       run: ./gradlew clean ktlintCheck lint detekt build test

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,5 +1,5 @@
 name: Pre Merge Checks
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   gradle:
@@ -7,10 +7,5 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Stale run canceller
-      uses: yellowmegaman/gh-build-canceller@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        workflows_filter: "Validate Gradle Wrapper|Pre Merge Checks"
-    - name: Run Gradle preMerge task
+    - name: Run Gradle tasks
       run: ./gradlew clean ktlintCheck lint detekt build test

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,5 +1,12 @@
 name: Pre Merge Checks
-on: pull_request
+on: 
+  push:
+    branches:
+      - develop 
+      - release
+  pull_request:
+    branches: 
+      - '*'
 
 jobs:
   gradle:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -11,5 +11,6 @@ jobs:
       uses: yellowmegaman/gh-build-canceller@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflows_filter: "Validate Gradle Wrapper|Pre Merge Checks"
     - name: Run Gradle preMerge task
       run: ./gradlew clean ktlintCheck lint detekt build test


### PR DESCRIPTION
## :page_facing_up: Context
When first PR with GH Actions was created I saw that builds happen for every single action, be it push or pull request. So it seems that we are ending up with too much redundant work.
According to [this thread ](https://github.community/t5/GitHub-Actions/Github-actions-Cancel-redundant-builds/td-p/29549) Github has no native solution for this issue.
In that thread I also saw a few 3rd party actions and decided to test one of them.

<img width="565" alt="Screenshot 2020-03-05 at 13 26 30" src="https://user-images.githubusercontent.com/13467769/75980249-bfb6ae00-5eea-11ea-999e-a7dc5c45fc25.png">

## :pencil: Changes
- Added https://github.com/marketplace/actions/gh-actions-stale-run-canceller to test auto cancelling

## :stopwatch: Next steps
If it works, I will add this step into the main workflow as well.