### PR TITLE
Migrate to Kotlin Coroutines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext {
         kotlinVersion = '1.3.70'
         androidGradleVersion = '3.6.0'
+        coroutineVersion = '1.3.4'
 
         // Google libraries
         appCompatVersion = '1.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         appCompatVersion = '1.1.0'
         constraintLayoutVersion = '1.1.3'
         materialComponentsVersion = '1.1.0'
-        roomVersion = '2.2.3'
+        roomVersion = '2.2.5'
         lifecycleVersion = '2.2.0'
         androidXCoreVersion = '2.1.0'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -71,6 +71,9 @@ dependencies {
     implementation "androidx.room:room-runtime:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
 
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion"
+
     implementation "com.google.code.gson:gson:$gsonVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttp3Version"
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -68,6 +68,7 @@ dependencies {
 
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
+    implementation "androidx.room:room-ktx:$roomVersion"
     implementation "androidx.room:room-runtime:$roomVersion"
     kapt "androidx.room:room-compiler:$roomVersion"
 

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -5,6 +5,9 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.support.NotificationHelper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * The collector responsible of collecting data from a [ChuckerInterceptor] and
@@ -36,7 +39,9 @@ class ChuckerCollector @JvmOverloads constructor(
      */
     fun onError(tag: String, throwable: Throwable) {
         val recordedThrowable = RecordedThrowable(tag, throwable)
-        RepositoryProvider.throwable().saveThrowable(recordedThrowable)
+        CoroutineScope(Dispatchers.IO).launch {
+            RepositoryProvider.throwable().saveThrowable(recordedThrowable)
+        }
         if (showNotification) {
             notificationHelper.show(recordedThrowable)
         }
@@ -48,7 +53,9 @@ class ChuckerCollector @JvmOverloads constructor(
      * @param transaction The HTTP transaction sent
      */
     internal fun onRequestSent(transaction: HttpTransaction) {
-        RepositoryProvider.transaction().insertTransaction(transaction)
+        CoroutineScope(Dispatchers.IO).launch {
+            RepositoryProvider.transaction().insertTransaction(transaction)
+        }
         if (showNotification) {
             notificationHelper.show(transaction)
         }

--- a/library/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
@@ -6,6 +6,9 @@ import android.util.Log
 import com.chuckerteam.chucker.api.Chucker.LOG_TAG
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 /**
  * Class responsible of holding the logic for the retention of your HTTP transactions
@@ -62,8 +65,10 @@ class RetentionManager @JvmOverloads constructor(
     }
 
     private fun deleteSince(threshold: Long) {
-        RepositoryProvider.transaction().deleteOldTransactions(threshold)
-        RepositoryProvider.throwable().deleteOldThrowables(threshold)
+        CoroutineScope(Dispatchers.IO).launch {
+            RepositoryProvider.transaction().deleteOldTransactions(threshold)
+            RepositoryProvider.throwable().deleteOldThrowables(threshold)
+        }
     }
 
     private fun isCleanupDue(now: Long) = now - getLastCleanup(now) > cleanupFrequency

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -5,7 +5,9 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
 import com.chuckerteam.chucker.internal.support.distinctUntilChanged
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 internal class HttpTransactionDatabaseRepository(private val database: ChuckerDatabase) : HttpTransactionRepository {
 
@@ -32,10 +34,10 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
     }
 
     override fun insertTransaction(transaction: HttpTransaction) {
-       backgroundScope.launch {
-           val id = transactionDao.insert(transaction)
-           transaction.id = id ?: 0
-       }
+        backgroundScope.launch {
+            val id = transactionDao.insert(transaction)
+            transaction.id = id ?: 0
+        }
     }
 
     override fun updateTransaction(transaction: HttpTransaction): Int {
@@ -43,6 +45,6 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
     }
 
     override fun deleteOldTransactions(threshold: Long) {
-         backgroundScope.launch { transactionDao.deleteBefore(threshold) }
+        backgroundScope.launch { transactionDao.deleteBefore(threshold) }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -5,13 +5,8 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
 import com.chuckerteam.chucker.internal.support.distinctUntilChanged
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 internal class HttpTransactionDatabaseRepository(private val database: ChuckerDatabase) : HttpTransactionRepository {
-
-    private val backgroundScope = CoroutineScope(Dispatchers.IO)
 
     private val transactionDao get() = database.transactionDao()
 
@@ -29,22 +24,20 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
         return transactionDao.getSortedTuples()
     }
 
-    override fun deleteAllTransactions() {
-        backgroundScope.launch { transactionDao.deleteAll() }
+    override suspend fun deleteAllTransactions() {
+        transactionDao.deleteAll()
     }
 
-    override fun insertTransaction(transaction: HttpTransaction) {
-        backgroundScope.launch {
-            val id = transactionDao.insert(transaction)
-            transaction.id = id ?: 0
-        }
+    override suspend fun insertTransaction(transaction: HttpTransaction) {
+        val id = transactionDao.insert(transaction)
+        transaction.id = id ?: 0
     }
 
     override fun updateTransaction(transaction: HttpTransaction): Int {
         return transactionDao.update(transaction)
     }
 
-    override fun deleteOldTransactions(threshold: Long) {
-        backgroundScope.launch { transactionDao.deleteBefore(threshold) }
+    override suspend fun deleteOldTransactions(threshold: Long) {
+        transactionDao.deleteBefore(threshold)
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
@@ -11,13 +11,13 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
  */
 internal interface HttpTransactionRepository {
 
-    fun insertTransaction(transaction: HttpTransaction)
+    suspend fun insertTransaction(transaction: HttpTransaction)
 
     fun updateTransaction(transaction: HttpTransaction): Int
 
-    fun deleteOldTransactions(threshold: Long)
+    suspend fun deleteOldTransactions(threshold: Long)
 
-    fun deleteAllTransactions()
+    suspend fun deleteAllTransactions()
 
     fun getSortedTransactionTuples(): LiveData<List<HttpTransactionTuple>>
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableDatabaseRepository.kt
@@ -5,6 +5,9 @@ import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
 import com.chuckerteam.chucker.internal.support.distinctUntilChanged
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
@@ -12,14 +15,14 @@ internal class RecordedThrowableDatabaseRepository(
     private val database: ChuckerDatabase
 ) : RecordedThrowableRepository {
 
-    private val executor: Executor = Executors.newSingleThreadExecutor()
+    private val backgroundScope = CoroutineScope(Dispatchers.IO)
 
     override fun getRecordedThrowable(id: Long): LiveData<RecordedThrowable> {
         return database.throwableDao().getById(id).distinctUntilChanged()
     }
 
     override fun deleteAllThrowables() {
-        executor.execute { database.throwableDao().deleteAll() }
+        backgroundScope.launch { database.throwableDao().deleteAll() }
     }
 
     override fun getSortedThrowablesTuples(): LiveData<List<RecordedThrowableTuple>> {
@@ -27,10 +30,10 @@ internal class RecordedThrowableDatabaseRepository(
     }
 
     override fun saveThrowable(throwable: RecordedThrowable) {
-        executor.execute { database.throwableDao().insert(throwable) }
+        backgroundScope.launch { database.throwableDao().insert(throwable) }
     }
 
     override fun deleteOldThrowables(threshold: Long) {
-        executor.execute { database.throwableDao().deleteBefore(threshold) }
+        backgroundScope.launch { database.throwableDao().deleteBefore(threshold) }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableDatabaseRepository.kt
@@ -8,8 +8,6 @@ import com.chuckerteam.chucker.internal.support.distinctUntilChanged
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 
 internal class RecordedThrowableDatabaseRepository(
     private val database: ChuckerDatabase

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableDatabaseRepository.kt
@@ -5,33 +5,28 @@ import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
 import com.chuckerteam.chucker.internal.support.distinctUntilChanged
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 
 internal class RecordedThrowableDatabaseRepository(
     private val database: ChuckerDatabase
 ) : RecordedThrowableRepository {
 
-    private val backgroundScope = CoroutineScope(Dispatchers.IO)
-
     override fun getRecordedThrowable(id: Long): LiveData<RecordedThrowable> {
         return database.throwableDao().getById(id).distinctUntilChanged()
     }
 
-    override fun deleteAllThrowables() {
-        backgroundScope.launch { database.throwableDao().deleteAll() }
+    override suspend fun deleteAllThrowables() {
+        database.throwableDao().deleteAll()
     }
 
     override fun getSortedThrowablesTuples(): LiveData<List<RecordedThrowableTuple>> {
         return database.throwableDao().getTuples()
     }
 
-    override fun saveThrowable(throwable: RecordedThrowable) {
-        backgroundScope.launch { database.throwableDao().insert(throwable) }
+    override suspend fun saveThrowable(throwable: RecordedThrowable) {
+        database.throwableDao().insert(throwable)
     }
 
-    override fun deleteOldThrowables(threshold: Long) {
-        backgroundScope.launch { database.throwableDao().deleteBefore(threshold) }
+    override suspend fun deleteOldThrowables(threshold: Long) {
+        database.throwableDao().deleteBefore(threshold)
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RecordedThrowableRepository.kt
@@ -11,11 +11,11 @@ import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple
  */
 internal interface RecordedThrowableRepository {
 
-    fun saveThrowable(throwable: RecordedThrowable)
+    suspend fun saveThrowable(throwable: RecordedThrowable)
 
-    fun deleteOldThrowables(threshold: Long)
+    suspend fun deleteOldThrowables(threshold: Long)
 
-    fun deleteAllThrowables()
+    suspend fun deleteAllThrowables()
 
     fun getSortedThrowablesTuples(): LiveData<List<RecordedThrowableTuple>>
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -28,17 +28,17 @@ internal interface HttpTransactionDao {
     fun getFilteredTuples(codeQuery: String, pathQuery: String): LiveData<List<HttpTransactionTuple>>
 
     @Insert
-    fun insert(transaction: HttpTransaction): Long?
+    suspend fun insert(transaction: HttpTransaction): Long?
 
     @Update(onConflict = OnConflictStrategy.REPLACE)
     fun update(transaction: HttpTransaction): Int
 
     @Query("DELETE FROM transactions")
-    fun deleteAll()
+    suspend fun deleteAll()
 
     @Query("SELECT * FROM transactions WHERE id = :id")
     fun getById(id: Long): LiveData<HttpTransaction?>
 
     @Query("DELETE FROM transactions WHERE requestDate <= :threshold")
-    fun deleteBefore(threshold: Long)
+    suspend fun deleteBefore(threshold: Long)
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/RecordedThrowableDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/RecordedThrowableDao.kt
@@ -13,15 +13,15 @@ internal interface RecordedThrowableDao {
     @Query("SELECT id,tag,date,clazz,message FROM throwables ORDER BY date DESC")
     fun getTuples(): LiveData<List<RecordedThrowableTuple>>
 
-    @Insert()
-    fun insert(throwable: RecordedThrowable): Long?
+    @Insert
+    suspend fun insert(throwable: RecordedThrowable): Long?
 
     @Query("DELETE FROM throwables")
-    fun deleteAll()
+    suspend fun deleteAll()
 
     @Query("SELECT * FROM throwables WHERE id = :id")
     fun getById(id: Long): LiveData<RecordedThrowable>
 
     @Query("DELETE FROM throwables WHERE date <= :threshold")
-    fun deleteBefore(threshold: Long)
+    suspend fun deleteBefore(threshold: Long)
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
@@ -4,6 +4,9 @@ import android.app.IntentService
 import android.content.Intent
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import java.io.Serializable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 internal class ClearDatabaseService : IntentService(CLEAN_DATABASE_SERVICE_NAME) {
 
@@ -11,13 +14,17 @@ internal class ClearDatabaseService : IntentService(CLEAN_DATABASE_SERVICE_NAME)
         when (intent?.getSerializableExtra(EXTRA_ITEM_TO_CLEAR)) {
             is ClearAction.Transaction -> {
                 RepositoryProvider.initialize(applicationContext)
-                RepositoryProvider.transaction().deleteAllTransactions()
+                CoroutineScope(Dispatchers.IO).launch {
+                    RepositoryProvider.transaction().deleteAllTransactions()
+                }
                 NotificationHelper.clearBuffer()
                 NotificationHelper(this).dismissTransactionsNotification()
             }
             is ClearAction.Error -> {
                 RepositoryProvider.initialize(applicationContext)
-                RepositoryProvider.throwable().deleteAllThrowables()
+                CoroutineScope(Dispatchers.IO).launch {
+                    RepositoryProvider.throwable().deleteAllThrowables()
+                }
                 NotificationHelper(this).dismissErrorsNotification()
             }
         }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -5,20 +5,16 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.switchMap
+import androidx.lifecycle.viewModelScope
 import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.support.NotificationHelper
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 
 internal class MainViewModel : ViewModel() {
 
     private val currentFilter = MutableLiveData<String>("")
-    private val backgroundScope = CoroutineScope(Dispatchers.IO) + Job()
 
     val transactions: LiveData<List<HttpTransactionTuple>> = currentFilter.switchMap { searchQuery ->
         with(RepositoryProvider.transaction()) {
@@ -44,14 +40,14 @@ internal class MainViewModel : ViewModel() {
     }
 
     fun clearTransactions() {
-        backgroundScope.launch {
+        viewModelScope.launch {
             RepositoryProvider.transaction().deleteAllTransactions()
         }
         NotificationHelper.clearBuffer()
     }
 
     fun clearThrowables() {
-        backgroundScope.launch {
+        viewModelScope.launch {
             RepositoryProvider.throwable().deleteAllThrowables()
         }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -9,10 +9,16 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowableTuple
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.support.NotificationHelper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 
 internal class MainViewModel : ViewModel() {
 
     private val currentFilter = MutableLiveData<String>("")
+    private val backgroundScope = CoroutineScope(Dispatchers.IO) + Job()
 
     val transactions: LiveData<List<HttpTransactionTuple>> = currentFilter.switchMap { searchQuery ->
         with(RepositoryProvider.transaction()) {
@@ -38,11 +44,15 @@ internal class MainViewModel : ViewModel() {
     }
 
     fun clearTransactions() {
-        RepositoryProvider.transaction().deleteAllTransactions()
+        backgroundScope.launch {
+            RepositoryProvider.transaction().deleteAllTransactions()
+        }
         NotificationHelper.clearBuffer()
     }
 
     fun clearThrowables() {
-        RepositoryProvider.throwable().deleteAllThrowables()
+        backgroundScope.launch {
+            RepositoryProvider.throwable().deleteAllThrowables()
+        }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -30,11 +30,9 @@ import java.io.FileOutputStream
 import java.io.IOException
 import kotlinx.android.synthetic.main.chucker_fragment_transaction_payload.*
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 
 private const val GET_FILE_FOR_SAVING_REQUEST_CODE: Int = 43

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -28,7 +28,6 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
-import kotlinx.android.synthetic.main.chucker_fragment_transaction_payload.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
@@ -79,7 +78,7 @@ internal class TransactionPayloadFragment :
                 uiScope.launch {
                     showProgress()
                     val result = processPayload(type, transaction)
-                    responseRecyclerView.adapter = TransactionBodyAdapter(result)
+                    payloadBinding.responseRecyclerView.adapter = TransactionBodyAdapter(result)
                     hideProgress()
                 }
             }
@@ -240,7 +239,7 @@ internal class TransactionPayloadFragment :
             if (type == TYPE_RESPONSE && responseBitmap != null) {
                 result.add(TransactionPayloadItem.ImageItem(responseBitmap))
             } else if (!isBodyPlainText) {
-                context?.getString(R.string.chucker_body_omitted)?.let {
+                requireContext().getString(R.string.chucker_body_omitted)?.let {
                     result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
                 }
             } else {
@@ -252,12 +251,11 @@ internal class TransactionPayloadFragment :
         }
     }
 
-    @Suppress("NestedBlockDepth", "ThrowsCount")
+    @Suppress("ThrowsCount")
     private suspend fun saveToFile(type: Int, uri: Uri, transaction: HttpTransaction): Boolean {
         return withContext(Dispatchers.IO) {
             try {
-                val context = context ?: return@withContext false
-                context.contentResolver.openFileDescriptor(uri, "w")?.use {
+                requireContext().contentResolver.openFileDescriptor(uri, "w")?.use {
                     FileOutputStream(it.fileDescriptor).use { fos ->
                         when (type) {
                             TYPE_REQUEST -> {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -37,7 +37,7 @@ import java.io.IOException
 private const val GET_FILE_FOR_SAVING_REQUEST_CODE: Int = 43
 
 internal class TransactionPayloadFragment :
-        Fragment(), SearchView.OnQueryTextListener {
+    Fragment(), SearchView.OnQueryTextListener {
 
     private lateinit var payloadBinding: ChuckerFragmentTransactionPayloadBinding
 
@@ -56,27 +56,30 @@ internal class TransactionPayloadFragment :
     }
 
     override fun onCreateView(
-            inflater: LayoutInflater,
-            container: ViewGroup?,
-            savedInstanceState: Bundle?
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
     ): View? {
-        payloadBinding = ChuckerFragmentTransactionPayloadBinding.inflate(inflater, container, false)
+        payloadBinding = ChuckerFragmentTransactionPayloadBinding.inflate(
+            inflater, container,
+            false
+        )
         return payloadBinding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel.transaction.observe(
-                viewLifecycleOwner,
-                Observer { transaction ->
-                    if (transaction == null) return@Observer
-                    CoroutineScope(Dispatchers.Main).launch {
-                        showProgress()
-                        val result = processPayload(type, transaction)
-                        responseRecyclerView.adapter = TransactionBodyAdapter(result)
-                        hideProgress()
-                    }
+            viewLifecycleOwner,
+            Observer { transaction ->
+                if (transaction == null) return@Observer
+                CoroutineScope(Dispatchers.Main).launch {
+                    showProgress()
+                    val result = processPayload(type, transaction)
+                    responseRecyclerView.adapter = TransactionBodyAdapter(result)
+                    hideProgress()
                 }
+            }
         )
     }
 
@@ -144,8 +147,8 @@ internal class TransactionPayloadFragment :
                 startActivityForResult(intent, GET_FILE_FOR_SAVING_REQUEST_CODE)
             } else {
                 Toast.makeText(
-                        requireContext(), R.string.chucker_save_failed_to_open_document,
-                        Toast.LENGTH_SHORT
+                    requireContext(), R.string.chucker_save_failed_to_open_document,
+                    Toast.LENGTH_SHORT
                 ).show()
             }
         }
@@ -180,7 +183,6 @@ internal class TransactionPayloadFragment :
         }
         return true
     }
-
 
     private fun showProgress() {
         payloadBinding.apply {
@@ -217,9 +219,11 @@ internal class TransactionPayloadFragment :
 
             if (headersString.isNotBlank()) {
                 result.add(
-                        TransactionPayloadItem.HeaderItem(
-                                HtmlCompat.fromHtml(headersString, HtmlCompat.FROM_HTML_MODE_LEGACY)
+                    TransactionPayloadItem.HeaderItem(
+                        HtmlCompat.fromHtml(
+                            headersString, HtmlCompat.FROM_HTML_MODE_LEGACY
                         )
+                    )
                 )
             }
 
@@ -240,7 +244,7 @@ internal class TransactionPayloadFragment :
         }
     }
 
-
+    @Suppress("NestedBlockDepth", "ThrowsCount")
     private suspend fun saveToFile(type: Int, uri: Uri, transaction: HttpTransaction): Boolean {
         return withContext(Dispatchers.IO) {
             try {
@@ -250,11 +254,11 @@ internal class TransactionPayloadFragment :
                         when (type) {
                             TYPE_REQUEST -> {
                                 transaction.requestBody?.byteInputStream()?.copyTo(fos)
-                                        ?: throw IOException(TRANSACTION_EXCEPTION)
+                                    ?: throw IOException(TRANSACTION_EXCEPTION)
                             }
                             TYPE_RESPONSE -> {
                                 transaction.responseBody?.byteInputStream()?.copyTo(fos)
-                                        ?: throw IOException(TRANSACTION_EXCEPTION)
+                                    ?: throw IOException(TRANSACTION_EXCEPTION)
                             }
                             else -> {
                                 if (transaction.responseImageData != null) {
@@ -289,10 +293,10 @@ internal class TransactionPayloadFragment :
         const val DEFAULT_FILE_PREFIX = "chucker-export-"
 
         fun newInstance(type: Int): TransactionPayloadFragment =
-                TransactionPayloadFragment().apply {
-                    arguments = Bundle().apply {
-                        putInt(ARG_TYPE, type)
-                    }
+            TransactionPayloadFragment().apply {
+                arguments = Bundle().apply {
+                    putInt(ARG_TYPE, type)
                 }
+            }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -29,9 +29,9 @@ import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
 import kotlinx.android.synthetic.main.chucker_fragment_transaction_payload.*
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -51,7 +51,7 @@ internal class TransactionPayloadFragment :
 
     private lateinit var viewModel: TransactionViewModel
 
-    private val uiScope = CoroutineScope(Dispatchers.Main) + Job()
+    private val uiScope = MainScope() + Job()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -51,7 +51,7 @@ internal class TransactionPayloadFragment :
 
     private lateinit var viewModel: TransactionViewModel
 
-    private val uiScope = MainScope() + Job()
+    private val uiScope = MainScope()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
No UI change in the commit. Only functional Change.

## :page_facing_up: Context
The AsyncTask that is being used in Chucker library currently is going to be deprecated in android R. Also, AsyncTask is not that elegant solution to perform the background and CPU intensive work.
As we are leveraging all the functions of kotlin, this one is another addition to it.

## :pencil: Changes
I basically change the code where we can use kotlin coroutines which is the background threading work. So, I changed `TransactionPayloadFragment` , `HTTPTranasctionDatabaseRepository` and `RecordedThrowableRepository` .

## :paperclip: Related PR
No blocking PR

## :no_entry_sign: Breaking
Nothing breaking in the API. No method signature change!

## :hammer_and_wrench: How to test
There's no need actually. As all unit tests are already passing.
But though if needed we can Unit test the AsyncTask related changed I migrated to Kotlin Coroutines.
