### PR TITLE
Margin fix for transaction payload

### DIFF
--- a/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
@@ -23,7 +23,9 @@
         android:scrollbars="vertical"
         android:visibility="invisible"
         android:clipToPadding="false"
-        android:paddingBottom="@dimen/chucker_octa_grid"
+        android:paddingVertical="@dimen/chucker_doub_grid"
+        tools:listitem="@layout/chucker_transaction_item_body_line"
+        tools:visibility="visible"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
 </FrameLayout>

--- a/library/src/main/res/layout/chucker_transaction_item_headers.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_headers.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/responseHeaders"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="@dimen/chucker_doub_grid"
-    android:textIsSelectable="true" />
+    android:layout_marginHorizontal="@dimen/chucker_doub_grid"
+    android:textIsSelectable="true"
+    tools:text="Content-Type: application/json" />


### PR DESCRIPTION
## :camera: Screenshots
Before
![Screenshot 2020-03-18 at 00 36 00](https://user-images.githubusercontent.com/13467769/76911630-f4970d80-68b9-11ea-99da-6fe70835e49a.png)
After
![Screenshot 2020-03-18 at 01 43 52](https://user-images.githubusercontent.com/13467769/76911634-f791fe00-68b9-11ea-8b00-3fa5184e03be.png)

## :page_facing_up: Context
There was a small UI issue with no margin/padding for `body_item` when no headers present in request/response (check the attached screenshots). It happened because only header item had margins.

## :pencil: Changes
Updated margins and paddings for transaction payload `RecyclerView` and for `item_header`