### PR TITLE
Add selective interception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,30 @@ You can redact headers that contain sensitive information by calling `redactHead
 interceptor.redactHeader("Auth-Token", "User-Session");
 ```
 
+### Skip Chucker inspection 🙅‍♀️🕵️
+
+If you need to selectively skip Chucker inspection on some endpoints or on particular requests you can a special header - `Skip-ChuckerInterceptor: true`. This will inform Chucker to not process this request. Chucker will also strip this header from any request before sending it to a server.
+
+If you use `OkHttp` directly, create requests like below.
+
+```kotlin
+val request = Request.Builder().url(serverUrl)
+        .addHeader(Chucker.SKIP_INTERCEPTOR_HEADER_NAME, "true")
+        .build()
+
+client.newCall(request).execute()
+```
+
+If you are a `Retrofit` user you can configure it per endpoint like this.
+
+```kotlin
+fun Service {
+    @GET("/")
+    @Headers(Chucker.SKIP_INTERCEPTOR_HEADER)
+    fun networkRequest(): Unit
+}
+```
+
 ## Migrating 🚗
 
 If you're migrating **from [Chuck](https://github.com/jgilfelt/chuck) to Chucker**, please refer to this [migration guide](/docs/migrating-from-chuck.md).

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can redact headers that contain sensitive information by calling `redactHead
 interceptor.redactHeader("Auth-Token", "User-Session");
 ```
 
-### Skip Chucker inspection 🙅‍♀️🕵️
+### Skip-Inspection 🙅‍♀️🕵️
 
 If you need to selectively skip Chucker inspection on some endpoints or on particular requests you can add a special header - `Skip-ChuckerInterceptor: true`. This will inform Chucker to not process this request. Chucker will also strip this header from any request before sending it to a server.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ You can redact headers that contain sensitive information by calling `redactHead
 interceptor.redactHeader("Auth-Token", "User-Session");
 ```
 
-### Skip-Inspection 🙅‍♀️🕵️
+### Skip-Inspection ️🕵️
 
 If you need to selectively skip Chucker inspection on some endpoints or on particular requests you can add a special header - `Skip-ChuckerInterceptor: true`. This will inform Chucker to not process this request. Chucker will also strip this header from any request before sending it to a server.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ try {
 
 ### Redact-Header 👮‍♂️
 
-**Warning** The data generated and stored when using Chucker may contain sensitive information such as Authorization or Cookie headers, and the contents of request and response bodies. 
+**Warning** The data generated and stored when using Chucker may contain sensitive information such as Authorization or Cookie headers, and the contents of request and response bodies.
 
 It is intended for **use during development**, and not in release builds or other production deployments.
 
@@ -131,7 +131,7 @@ interceptor.redactHeader("Auth-Token", "User-Session");
 
 ### Skip Chucker inspection 🙅‍♀️🕵️
 
-If you need to selectively skip Chucker inspection on some endpoints or on particular requests you can a special header - `Skip-ChuckerInterceptor: true`. This will inform Chucker to not process this request. Chucker will also strip this header from any request before sending it to a server.
+If you need to selectively skip Chucker inspection on some endpoints or on particular requests you can add a special header - `Skip-ChuckerInterceptor: true`. This will inform Chucker to not process this request. Chucker will also strip this header from any request before sending it to a server.
 
 If you use `OkHttp` directly, create requests like below.
 

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -25,6 +25,13 @@ artifacts {
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:$okhttp3Version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+    testImplementation "io.mockk:mockk:$mockkVersion"
+    testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
+    testImplementation "com.google.truth:truth:$truthVersion"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -11,6 +11,9 @@ object Chucker {
     const val SCREEN_HTTP = 1
     const val SCREEN_ERROR = 2
 
+    const val SKIP_INTERCEPTOR_HEADER_NAME = "Skip-Chucker-Interceptor"
+    const val SKIP_INTERCEPTOR_HEADER = "Skip-Chucker-Interceptor: true"
+
     @Suppress("MayBeConst ") // https://github.com/ChuckerTeam/chucker/pull/169#discussion_r362341353
     val isOp = false
 

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -12,7 +12,7 @@ object Chucker {
     const val SCREEN_ERROR = 2
 
     const val SKIP_INTERCEPTOR_HEADER_NAME = "Skip-Chucker-Interceptor"
-    const val SKIP_INTERCEPTOR_HEADER = "Skip-Chucker-Interceptor: true"
+    const val SKIP_INTERCEPTOR_HEADER = "$SKIP_INTERCEPTOR_HEADER_NAME: true"
 
     @Suppress("MayBeConst ") // https://github.com/ChuckerTeam/chucker/pull/169#discussion_r362341353
     val isOp = false

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -21,7 +21,9 @@ class ChuckerInterceptor @JvmOverloads constructor(
 
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request()
+        val request = chain.request().newBuilder()
+            .removeHeader(Chucker.SKIP_INTERCEPTOR_HEADER_NAME)
+            .build()
         return chain.proceed(request)
     }
 }

--- a/library-no-op/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library-no-op/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -34,7 +34,7 @@ class ChuckerInterceptorTest {
     }
 
     @Test
-    fun doNotskipChuckerHeader_isNotAvailableForTheServerRequest() {
+    fun doNotSkipChuckerHeader_isNotAvailableForTheServerRequest() {
         server.enqueue(MockResponse().setBody("Hello, world!"))
         val request = Request.Builder().url(serverUrl)
             .addHeader(Chucker.SKIP_INTERCEPTOR_HEADER_NAME, "false")

--- a/library-no-op/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library-no-op/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -1,0 +1,47 @@
+package com.chuckerteam.chucker.api
+
+import android.content.Context
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Rule
+import org.junit.jupiter.api.Test
+
+class ChuckerInterceptorTest {
+    @get:Rule val server = MockWebServer()
+    private val serverUrl = server.url("/") // Starts server implicitly
+    private val mockContext = mockk<Context> {
+        every { getString(any()) } returns ""
+    }
+    private val client = OkHttpClient.Builder()
+        .addInterceptor(ChuckerInterceptor(mockContext))
+        .build()
+
+    @Test
+    fun skipChuckerHeader_isNotAvailableForTheServerRequest() {
+        server.enqueue(MockResponse().setBody("Hello, world!"))
+        val request = Request.Builder().url(serverUrl)
+            .addHeader(Chucker.SKIP_INTERCEPTOR_HEADER_NAME, "true")
+            .build()
+
+        val response = client.newCall(request).execute()
+
+        assertThat(response.request().header(Chucker.SKIP_INTERCEPTOR_HEADER_NAME)).isNull()
+    }
+
+    @Test
+    fun doNotskipChuckerHeader_isNotAvailableForTheServerRequest() {
+        server.enqueue(MockResponse().setBody("Hello, world!"))
+        val request = Request.Builder().url(serverUrl)
+            .addHeader(Chucker.SKIP_INTERCEPTOR_HEADER_NAME, "false")
+            .build()
+
+        val response = client.newCall(request).execute()
+
+        assertThat(response.request().header(Chucker.SKIP_INTERCEPTOR_HEADER_NAME)).isNull()
+    }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -15,6 +15,9 @@ object Chucker {
     const val SCREEN_HTTP = 1
     const val SCREEN_ERROR = 2
 
+    const val SKIP_INTERCEPTOR_HEADER_NAME = "Skip-Chucker-Interceptor"
+    const val SKIP_INTERCEPTOR_HEADER = "$SKIP_INTERCEPTOR_HEADER_NAME: true"
+
     /**
      * Check if this instance is the operation one or no-op.
      * @return `true` if this is the operation instance.

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -47,7 +47,14 @@ class ChuckerInterceptor @JvmOverloads constructor(
 
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request()
+        val request = chain.request().newBuilder()
+            .removeHeader(Chucker.SKIP_INTERCEPTOR_HEADER_NAME)
+            .build()
+
+        if (chain.request().header(Chucker.SKIP_INTERCEPTOR_HEADER_NAME)?.toBoolean() == true) {
+            return chain.proceed(request)
+        }
+
         val response: Response
         val transaction = HttpTransaction()
 

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -149,7 +149,7 @@ class ChuckerInterceptorTest {
     }
 
     @Test
-    fun doNotskipChuckerHeader_isNotAvailableForTheServerRequest() {
+    fun doNotSkipChuckerHeader_isNotAvailableForTheServerRequest() {
         server.enqueue(MockResponse().setBody("Hello, world!"))
         val request = Request.Builder().url(serverUrl)
             .addHeader(Chucker.SKIP_INTERCEPTOR_HEADER_NAME, "false")


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an open issue that I declared to do - #266.

## :pencil: Changes
<!-- Which code did you change? How? -->

I added to the public API a header that allows to skip interception. `ChuckerInterceptor` respects this header and does not process requests if ordered not to do so. It also strips out this header before passing it down the chain.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

Kind of, but not really. If someone in the past used a header like `Skip-Chucker-Interceptor` it would be no longer passed to the server. It would also skip Chucker processing if set to `true`.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Unit tests are written. I don't think there is a point in adding anything to the `HttpBinApi`.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Closes #266