### PR TITLE
identify time consuming api with time being configurable

### DIFF
--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -12,7 +12,8 @@ class ChuckerInterceptor @JvmOverloads constructor(
     context: Context,
     collector: Any? = null,
     maxContentLength: Any? = null,
-    headersToRedact: Any? = null
+    headersToRedact: Any? = null,
+    normalAPIDuration: Any? = null
 ) : Interceptor {
 
     fun redactHeaders(vararg names: String): ChuckerInterceptor {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -48,7 +48,8 @@ internal class HttpTransaction(
     @ColumnInfo(name = "responseHeaders") var responseHeaders: String?,
     @ColumnInfo(name = "responseBody") var responseBody: String?,
     @ColumnInfo(name = "isResponseBodyPlainText") var isResponseBodyPlainText: Boolean = true,
-    @ColumnInfo(name = "responseImageData") var responseImageData: ByteArray?
+    @ColumnInfo(name = "responseImageData") var responseImageData: ByteArray?,
+    @ColumnInfo(name = "isSlowApiCall") var isSlowApiCall: Boolean = false
 ) {
 
     @Ignore
@@ -262,6 +263,7 @@ internal class HttpTransaction(
             (responseHeaders == other.responseHeaders) &&
             (responseBody == other.responseBody) &&
             (isResponseBodyPlainText == other.isResponseBodyPlainText) &&
-            (responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) != false)
+            (responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) != false) &&
+            (isSlowApiCall == other.isSlowApiCall)
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -21,7 +21,8 @@ internal class HttpTransactionTuple(
     @ColumnInfo(name = "responseCode") var responseCode: Int?,
     @ColumnInfo(name = "requestContentLength") var requestContentLength: Long?,
     @ColumnInfo(name = "responseContentLength") var responseContentLength: Long?,
-    @ColumnInfo(name = "error") var error: String?
+    @ColumnInfo(name = "error") var error: String?,
+    @ColumnInfo(name = "isSlowApiCall") var isSlowApiCall: Boolean = false
 ) {
     val isSsl: Boolean get() = scheme.equals("https", ignoreCase = true)
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -13,14 +13,14 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 internal interface HttpTransactionDao {
 
     @Query(
-        "SELECT id, requestDate, tookMs, protocol, method, host, " +
+        "SELECT id, requestDate, tookMs, isSlowApiCall, protocol, method, host, " +
             "path, scheme, responseCode, requestContentLength, responseContentLength, error FROM " +
             "transactions ORDER BY requestDate DESC"
     )
     fun getSortedTuples(): LiveData<List<HttpTransactionTuple>>
 
     @Query(
-        "SELECT id, requestDate, tookMs, protocol, method, host, " +
+        "SELECT id, requestDate, tookMs, isSlowApiCall, protocol, method, host, " +
             "path, scheme, responseCode, requestContentLength, responseContentLength, error FROM " +
             "transactions WHERE responseCode LIKE :codeQuery AND path LIKE :pathQuery " +
             "ORDER BY requestDate DESC"

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -29,6 +29,7 @@ internal class TransactionAdapter internal constructor(
     private val color500: Int = ContextCompat.getColor(context, R.color.chucker_status_500)
     private val color400: Int = ContextCompat.getColor(context, R.color.chucker_status_400)
     private val color300: Int = ContextCompat.getColor(context, R.color.chucker_status_300)
+    private val colorSlow: Int = ContextCompat.getColor(context, R.color.chucker_slow_api_call)
 
     override fun getItemCount(): Int = transactions.size
 
@@ -84,6 +85,7 @@ internal class TransactionAdapter internal constructor(
                 if (transaction.status === HttpTransaction.Status.Failed) {
                     code.text = "!!!"
                 }
+                duration.setTextColor(if (transaction.isSlowApiCall) colorSlow else size.currentTextColor)
             }
 
             setStatusColor(transaction)
@@ -105,6 +107,7 @@ internal class TransactionAdapter internal constructor(
                 (transaction.responseCode!! >= HttpsURLConnection.HTTP_INTERNAL_ERROR) -> color500
                 (transaction.responseCode!! >= HttpsURLConnection.HTTP_BAD_REQUEST) -> color400
                 (transaction.responseCode!! >= HttpsURLConnection.HTTP_MULT_CHOICE) -> color300
+                transaction.isSlowApiCall -> colorSlow
                 else -> colorDefault
             }
             itemBinding.code.setTextColor(color)

--- a/library/src/main/res/values-night/colors.xml
+++ b/library/src/main/res/values-night/colors.xml
@@ -21,4 +21,6 @@
 
     <color name="chucker_background_span_color">#ffe082</color>
     <color name="chucker_foreground_span_color">#ef5350</color>
+    
+    <color name="chucker_slow_api_call">#AF8DEC</color>
 </resources>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -21,4 +21,6 @@
 
     <color name="chucker_background_span_color">#ffffff00</color>
     <color name="chucker_foreground_span_color">#ffff0000</color>
+    
+    <color name="chucker_slow_api_call">#6625DC</color>
 </resources>

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -30,7 +30,8 @@ class HttpBinClient(
         context = context,
         collector = collector,
         maxContentLength = 250000L,
-        headersToRedact = emptySet<String>()
+        headersToRedact = emptySet<String>(),
+        normalAPIDuration = 1000L
     )
 
     private val httpClient =


### PR DESCRIPTION
## :camera: Screenshots
![darkmode](https://user-images.githubusercontent.com/3454986/77147759-08a65f00-6ab4-11ea-956d-79c8003678ef.png)
![normalmode](https://user-images.githubusercontent.com/3454986/77147761-0a702280-6ab4-11ea-9c93-317cc1786987.png)


## :page_facing_up: Context
Identify time-consuming API's in a different color with time being configurable.
issue: https://github.com/ChuckerTeam/chucker/issues/273

## :no_entry_sign: Breaking
Nothing breaking is expected

## :hammer_and_wrench: How to test
Just set `normalAPIDuration` any API taking more than normalAPIDuration time will be highlighted in purple color, as shown in the screenshot.
