### PR TITLE
Properly handle unexhausted network responses

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -244,7 +244,7 @@ class ChuckerInterceptor internal constructor(
         override fun onSuccess(file: File) {
             val buffer = readResponseBuffer(file, response.isGzipped)
             file.delete()
-            processResponseBody(response, buffer, transaction)
+            if (buffer != null) processResponseBody(response, buffer, transaction)
             collector.onResponseReceived(transaction)
         }
 
@@ -253,15 +253,17 @@ class ChuckerInterceptor internal constructor(
             collector.onResponseReceived(transaction)
         }
 
-        private fun readResponseBuffer(responseBody: File, isGzipped: Boolean): Buffer {
+        private fun readResponseBuffer(responseBody: File, isGzipped: Boolean): Buffer? {
             val bufferedSource = Okio.buffer(Okio.source(responseBody))
             val source = if (isGzipped) {
                 GzipSource(bufferedSource)
             } else {
                 bufferedSource
             }
-            return Buffer().apply {
-                writeAll(source)
+            return try {
+                Buffer().apply { writeAll(source) }
+            } catch (_: IOException) {
+                null
             }
         }
     }


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
There is an issue #287

## :pencil: Changes
<!-- Which code did you change? How? -->
`TeeSource` now reports partially read responses as failures. This way `ChuckerInterceptor` does not try to process them. The bytes are still available in the side channel file if in the future we'd like to process these bytes.

I also wrapped reading from file in a `try/catch` expression for a good measure because of the volatile nature of a phone storage.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->
No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->
Unit tests are written. @oakkitten might confirm whether this fixes their issue using Chucker version from PR via JitPack.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
Closes #287.