### PR TITLE
Removed redundant Gson configurations

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/JsonConverter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/JsonConverter.kt
@@ -1,10 +1,7 @@
 package com.chuckerteam.chucker.internal.support
 
-import com.google.gson.FieldNamingPolicy
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.google.gson.internal.bind.DateTypeAdapter
-import java.util.Date
 
 internal object JsonConverter {
 
@@ -12,8 +9,6 @@ internal object JsonConverter {
         GsonBuilder()
             .serializeNulls()
             .setPrettyPrinting()
-            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-            .registerTypeAdapter(Date::class.java, DateTypeAdapter())
             .create()
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/JsonConverterTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/JsonConverterTest.kt
@@ -1,9 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
 import com.google.common.truth.Truth.assertThat
-import java.text.DateFormat
-import java.util.Date
-import java.util.Locale
 import org.junit.jupiter.api.Test
 
 class JsonConverterTest {
@@ -14,32 +11,6 @@ class JsonConverterTest {
         val instance2 = JsonConverter.instance
 
         assertThat(instance1).isEqualTo(instance2)
-    }
-
-    @Test
-    fun testGsonConfiguration_willParseDateTime() {
-        val dateFormat = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US)
-        val expectedDateString = dateFormat.format(Date(0))
-        val json = JsonConverter.instance.toJson(DateTestClass(Date(0)))
-        assertThat(json).isEqualTo(
-            """
-            {
-              "date": "$expectedDateString"
-            }
-            """.trimIndent()
-        )
-    }
-
-    @Test
-    fun testGsonConfiguration_willUseLowerCaseWithUnderscores() {
-        val json = JsonConverter.instance.toJson(NamingTestClass("aCamelCaseString"))
-        assertThat(json).isEqualTo(
-            """
-            {
-              "a_long_name_with_camel_case": "aCamelCaseString"
-            }
-            """.trimIndent()
-        )
     }
 
     @Test
@@ -54,7 +25,5 @@ class JsonConverterTest {
         )
     }
 
-    inner class DateTestClass(var date: Date)
     inner class NullTestClass(var string: String?)
-    inner class NamingTestClass(var aLongNameWithCamelCase: String)
 }


### PR DESCRIPTION
## :page_facing_up: Context
Removed redundant `FieldNamingPolicy` and `DateTypeAdapter` from Gson instance.

Why?
- Dates are not serialized or deserialized anywhere in the codebase.
- The field naming policy (`LOWER_CASE_WITH_UNDERSCORES`) is not in use.

## :pencil: Changes
- Changed `JsonConverter`. Removed redundant Gson configurations.
- Changed `JsonConverterTest`. Removed related test cases.

## :no_entry_sign: Breaking
No. All test cases are passing. No method signature change.
