### PR TITLE
Optimize RecyclerView items

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableListFragment.kt
@@ -36,6 +36,7 @@ internal class ThrowableListFragment : Fragment(), ThrowableAdapter.ThrowableCli
         with(errorsBinding) {
             tutorialLink.movementMethod = LinkMovementMethod.getInstance()
             errorsRecyclerView.apply {
+                setHasFixedSize(true)
                 addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
                 adapter = errorsAdapter
             }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
@@ -44,6 +44,7 @@ internal class TransactionListFragment :
         with(transactionsBinding) {
             tutorialLink.movementMethod = LinkMovementMethod.getInstance()
             transactionsRecyclerView.apply {
+                setHasFixedSize(true)
                 addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
                 adapter = transactionsAdapter
             }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -79,6 +79,7 @@ internal class TransactionPayloadFragment :
                     showProgress()
                     val result = processPayload(type, transaction)
                     payloadBinding.responseRecyclerView.adapter = TransactionBodyAdapter(result)
+                    payloadBinding.responseRecyclerView.setHasFixedSize(true)
                     hideProgress()
                 }
             }


### PR DESCRIPTION
## :page_facing_up: Context
While working on some other features I saw that all `RecyclerView`s in Chucker have `match_parent` sizes and don't change its height/width depending on its content. Based on that I added `setHasFixedSize(true)` to such lists.

## :pencil: Changes
- Added `setHasFixedSize(true)` to `RecyclerView` items.