### PR TITLE
Detekt to 1.7.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,10 @@ buildscript {
         retrofitVersion = '2.6.4'
 
         // Debug and quality control
-        detektVersion = '1.7.1'
+        detektVersion = '1.7.4'
         dokkaVersion = '0.10.1'
-        ktLintVersion = '9.2.1'
+        ktLintVersion = '0.36.0'
+        ktLintGradleVersion = '9.2.1'
         leakcanaryVersion = '2.2'
 
         // Testing
@@ -46,7 +47,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktLintVersion"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktLintGradleVersion"
     }
 }
 

--- a/gradle/kotlin-static-analysis.gradle
+++ b/gradle/kotlin-static-analysis.gradle
@@ -2,7 +2,7 @@ apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 ktlint {
-    version = "0.36.0"
+    version = rootProject.ext.ktLintVersion
     debug = false
     verbose = true
     android = false
@@ -19,7 +19,6 @@ ktlint {
 }
 
 detekt {
-    toolVersion = "1.4.0"
     config = files("../detekt-config.yml")
     buildUponDefaultConfig = true
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -20,6 +20,7 @@ import okhttp3.HttpUrl
  * Represent a full HTTP transaction (with Request and Response). Instances of this classes
  * should be populated as soon as the library receives data from OkHttp.
  */
+@Suppress("LongParameterList")
 @Entity(tableName = "transactions")
 internal class HttpTransaction(
     @PrimaryKey(autoGenerate = true) @ColumnInfo(name = "id")

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -9,6 +9,7 @@ import okhttp3.HttpUrl
  * A subset of [HttpTransaction] to perform faster Read operations on the Repository.
  * This Tuple is good to be used on List or Preview interfaces.
  */
+@Suppress("LongParameterList")
 internal class HttpTransactionTuple(
     @ColumnInfo(name = "id") var id: Long,
     @ColumnInfo(name = "requestDate") var requestDate: Long?,


### PR DESCRIPTION
##  :page_facing_up: Context
Let's update Detekt before #298 

## :pencil: Changes
Seems like our detekt configuration was still using an older version (`1.4.0`). I've extracted that versions to use the version defined at the top level (same for `ktlint).

## :stopwatch: Next steps
I've re-gerated the config file with `./gradlew detektGenerateConfig`. I've also copied over as we can potentially turn on more rules that are currently disabled by default.
