### PR TITLE
Enforce Lint findings

### DIFF
--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -11,6 +11,11 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
+    }
 }
 
 task sourcesJar(type: Jar) {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,6 +25,11 @@ android {
     viewBinding {
         enabled = true
     }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
+    }
 }
 
 dokka {

--- a/library/src/main/res/menu/chucker_throwable.xml
+++ b/library/src/main/res/menu/chucker_throwable.xml
@@ -5,5 +5,5 @@
         android:id="@+id/share_text"
         android:icon="@drawable/chucker_ic_share_white"
         android:title="@string/chucker_share"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 </menu>

--- a/library/src/main/res/menu/chucker_throwables_list.xml
+++ b/library/src/main/res/menu/chucker_throwables_list.xml
@@ -4,5 +4,5 @@
     <item android:title="@string/chucker_clear"
         android:id="@+id/clear"
         android:icon="@drawable/chucker_ic_delete_white"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 </menu>

--- a/library/src/main/res/menu/chucker_transaction.xml
+++ b/library/src/main/res/menu/chucker_transaction.xml
@@ -13,12 +13,12 @@
         android:title="@string/chucker_encode_url"
         android:id="@+id/encode_url"
         android:visible="false"
-        app:showAsAction="always">
+        app:showAsAction="ifRoom">
     </item>
     <item
         android:icon="@drawable/chucker_ic_share_white"
         android:title="@string/chucker_share"
-        app:showAsAction="always">
+        app:showAsAction="ifRoom">
         <menu>
             <group>
                 <item
@@ -35,6 +35,6 @@
         android:title="@string/chucker_save"
         android:id="@+id/save_body"
         android:visible="false"
-        app:showAsAction="always">
+        app:showAsAction="ifRoom">
     </item>
 </menu>

--- a/library/src/main/res/menu/chucker_transactions_list.xml
+++ b/library/src/main/res/menu/chucker_transactions_list.xml
@@ -9,5 +9,5 @@
     <item android:title="@string/chucker_clear"
         android:id="@+id/clear"
         android:icon="@drawable/chucker_ic_delete_white"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
 </menu>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -34,6 +34,11 @@ android {
             storePassword 'android'
         }
     }
+
+    lintOptions {
+        warningsAsErrors true
+        abortOnError true
+    }
 }
 
 dependencies {

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!--
     Palette from
     https://material.io/tools/color/#!/?view.left=0&view.right=0&primary.color=01579B&secondary.color=00E676
     -->
     <color name="primary_color">#01579b</color>
-    <color name="primary_light_color">#4f83cc</color>
+    <color name="primary_light_color" tools:ignore="UnusedResources">#4f83cc</color>
     <color name="primary_dark_color">#002f6c</color>
     <color name="secondary_color">#00e676</color>
-    <color name="secondary_light_color">#66ffa6</color>
-    <color name="secondary_dark_color">#00b248</color>
-    <color name="primary_text_color">#ffffff</color>
-    <color name="secondary_text_color">#000000</color>
+    <color name="secondary_light_color" tools:ignore="UnusedResources">#66ffa6</color>
+    <color name="secondary_dark_color" tools:ignore="UnusedResources">#00b248</color>
+    <color name="primary_text_color" tools:ignore="UnusedResources">#ffffff</color>
+    <color name="secondary_text_color" tools:ignore="UnusedResources">#000000</color>
 </resources>


### PR DESCRIPTION
##  :page_facing_up: Context
We had several Lint warnings showing up during builds. I've fixed them plus raised Lint warnings to be errors so they will be reported as build failures.
Happy to discuss if we feel this is a too strict approach.

## :pencil: Changes

* Configured Lint to treat warnings as errors
* Add missing `roundIcon` directive on the Manifest
* Skipped failures of unused resources on some palette color.
* Fixed `showAsAction="always"` to `ifRoom`.

## :paperclip: Related PR
n/a

## :no_entry_sign: Breaking
n/a

## :hammer_and_wrench: How to test
`./gradlew check` on the branch should be green now and no lint warnings should be shown.

## :stopwatch: Next steps
n/a
