### PR TITLE
Dialogs update

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableListFragment.kt
@@ -8,7 +8,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -16,6 +15,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentThrowableListBinding
 import com.chuckerteam.chucker.internal.ui.MainViewModel
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 internal class ThrowableListFragment : Fragment(), ThrowableAdapter.ThrowableClickListListener {
 
@@ -75,7 +75,7 @@ internal class ThrowableListFragment : Fragment(), ThrowableAdapter.ThrowableCli
     }
 
     private fun askForConfirmation() {
-        AlertDialog.Builder(requireContext())
+        MaterialAlertDialogBuilder(requireContext())
             .setTitle(R.string.chucker_clear)
             .setMessage(R.string.chucker_clear_throwable_confirmation)
             .setPositiveButton(R.string.chucker_clear) { _, _ ->

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
@@ -8,7 +8,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -17,6 +16,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionListBinding
 import com.chuckerteam.chucker.internal.ui.MainViewModel
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 
 internal class TransactionListFragment :
     Fragment(),
@@ -80,7 +80,7 @@ internal class TransactionListFragment :
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return if (item.itemId == R.id.clear) {
-            AlertDialog.Builder(requireContext())
+            MaterialAlertDialogBuilder(requireContext())
                 .setTitle(R.string.chucker_clear)
                 .setMessage(R.string.chucker_clear_http_confirmation)
                 .setPositiveButton(

--- a/library/src/main/res/layout/chucker_activity_throwable.xml
+++ b/library/src/main/res/layout/chucker_activity_throwable.xml
@@ -20,7 +20,7 @@
 
             <TextView
                 android:id="@+id/toolbarTitle"
-                style="@style/Chucker.TextAppearance.TransactionTitle"
+                style="@style/Chucker.TextAppearance.Title"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 tools:text="Title" />

--- a/library/src/main/res/layout/chucker_activity_transaction.xml
+++ b/library/src/main/res/layout/chucker_activity_transaction.xml
@@ -22,7 +22,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="@dimen/chucker_doub_grid"
-                style="@style/Chucker.TextAppearance.TransactionTitle"
+                style="@style/Chucker.TextAppearance.Title"
                 tools:text="Title"/>
 
         </com.google.android.material.appbar.MaterialToolbar>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -30,7 +30,7 @@
         <item name="android:textIsSelectable">true</item>
     </style>
 
-    <style name="Chucker.TextAppearance.TransactionTitle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
+    <style name="Chucker.TextAppearance.Title" parent="TextAppearance.MaterialComponents.Headline6">
         <item name="android:textSize">16sp</item>
         <item name="android:maxLines">2</item>
     </style>


### PR DESCRIPTION
## :page_facing_up: Context
Continue switching from `AppCompat` to `MaterialComponents`. This time in-app dialogs were updated.

## :pencil: Changes
- Switched from `AlertDialog.Builder()` to `MaterialDialogBuilder()`.
- Updated one of styles to inherit `MaterialComponents` style.