### PR TITLE
Add description for empty body items during export

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
@@ -120,7 +120,11 @@ internal object FormatUtils {
         }
 
         text += if (transaction.isRequestBodyPlainText) {
-            transaction.getFormattedRequestBody()
+            if (transaction.requestBody.isNullOrBlank()) {
+                context.getString(R.string.chucker_body_empty)
+            } else {
+                transaction.getFormattedRequestBody()
+            }
         } else {
             context.getString(R.string.chucker_body_omitted)
         }
@@ -135,7 +139,11 @@ internal object FormatUtils {
         }
 
         text += if (transaction.isResponseBodyPlainText) {
-            transaction.getFormattedResponseBody()
+            if (transaction.responseBody.isNullOrBlank()) {
+                context.getString(R.string.chucker_body_empty)
+            } else {
+                transaction.getFormattedResponseBody()
+            }
         } else {
             context.getString(R.string.chucker_body_omitted)
         }

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="chucker_save_failed_to_open_document">Failed to open file chooser</string>
     <string name="chucker_file_saved">File was saved successfully!</string>
     <string name="chucker_file_not_saved">Failed to save file</string>
+    <string name="chucker_body_empty">(body is empty)</string>
     <string name="chucker_body_omitted">(encoded or binary body omitted)</string>
     <string name="chucker_search">Search</string>
     <string name="chucker_body_unexpected_eof">\n\n--- Unexpected end of content ---</string>

--- a/library/src/test/java/com/chuckerteam/chucker/TestTransactionFactory.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/TestTransactionFactory.kt
@@ -56,7 +56,7 @@ object TestTransactionFactory {
         
         ---------- Request ----------
         
-        
+        (body is empty)
         
         ---------- Response ----------
         
@@ -84,7 +84,7 @@ object TestTransactionFactory {
         
         ---------- Request ----------
         
-        
+        (body is empty)
         
         ---------- Response ----------
         

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/FormatUtilsSharedTextTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/FormatUtilsSharedTextTest.kt
@@ -3,7 +3,7 @@ package com.chuckerteam.chucker.internal.support
 import android.content.Context
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.TestTransactionFactory
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
@@ -27,18 +27,19 @@ class FormatUtilsSharedTextTest {
         every { getString(R.string.chucker_total_size) } returns "Total size"
         every { getString(R.string.chucker_request) } returns "Request"
         every { getString(R.string.chucker_body_omitted) } returns "(encoded or binary body omitted)"
+        every { getString(R.string.chucker_body_empty) } returns "(body is empty)"
     }
 
     @Test
     fun getShareTextForGetTransaction() {
         val shareText = getShareText("GET")
-        Truth.assertThat(shareText).isEqualTo(TestTransactionFactory.expectedGetHttpTransaction)
+        assertThat(shareText).isEqualTo(TestTransactionFactory.expectedGetHttpTransaction)
     }
 
     @Test
     fun getShareTextForPostTransaction() {
         val shareText = getShareText("POST")
-        Truth.assertThat(shareText).isEqualTo(TestTransactionFactory.expectedHttpPostTransaction)
+        assertThat(shareText).isEqualTo(TestTransactionFactory.expectedHttpPostTransaction)
     }
 
     private fun getShareText(method: String): String {


### PR DESCRIPTION
## :camera: Screenshots
Before:
<img width="216" alt="Screenshot 2020-04-06 at 17 11 16" src="https://user-images.githubusercontent.com/13467769/78567636-aa0a1080-7829-11ea-9caa-974370210523.png">
After:
<img width="232" alt="Screenshot 2020-04-06 at 17 13 36" src="https://user-images.githubusercontent.com/13467769/78567874-fead8b80-7829-11ea-9634-e58bc349a8c7.png">

## :page_facing_up: Context
During tests of export feature I found out that in case of empty body (happens both in request and in response) Chucker shows empty lines. So I decided to add some text to clearly indicate that body is empty for real, not because of some error.

## :pencil: Changes
Added a placeholder text for cases with empty body

## :stopwatch: Next steps
Add more tests for different requests (with empty request/response bodies, etc.)
