### PR TITLE
Close response file when it is no longer needed.

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -255,7 +255,7 @@ class ChuckerInterceptor internal constructor(
                 bufferedSource
             }
             return try {
-                Buffer().apply { writeAll(source) }
+                Buffer().apply { source.use { writeAll(it) } }
             } catch (_: IOException) {
                 null
             }


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an open issue. #311

## :pencil: Changes
<!-- Which code did you change? How? -->

File resource containing response is now closed after Chucker reads from it.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Apply `StrictMode.setVmPolicy(StrictMode.VmPolicy.Builder().detectAll().penaltyLog().build())` to the test application. It should no longer warn about opened resources.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Closes #311 