### PR TITLE
Format URL encoded forms

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -192,10 +192,11 @@ internal class HttpTransaction(
 
     private fun formatBody(body: String, contentType: String?): String {
         return when {
-            contentType != null && contentType.contains("json", ignoreCase = true) ->
-                FormatUtils.formatJson(body)
-            contentType != null && contentType.contains("xml", ignoreCase = true) ->
-                FormatUtils.formatXml(body)
+            contentType.isNullOrBlank() -> body
+            contentType.contains("json", ignoreCase = true) -> FormatUtils.formatJson(body)
+            contentType.contains("xml", ignoreCase = true) -> FormatUtils.formatXml(body)
+            contentType.contains("x-www-form-urlencoded", ignoreCase = true) ->
+                FormatUtils.formatUrlEncodedForm(body)
             else -> body
         }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/FormatUtils.kt
@@ -10,6 +10,8 @@ import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.io.UnsupportedEncodingException
+import java.net.URLDecoder
 import java.nio.charset.Charset
 import java.util.Locale
 import javax.xml.XMLConstants
@@ -91,6 +93,24 @@ internal object FormatUtils {
             xml
         } catch (t: TransformerException) {
             xml
+        }
+    }
+
+    fun formatUrlEncodedForm(form: String): String {
+        return try {
+            if (form.isBlank()) {
+                return form
+            }
+            form.split("&").joinToString(separator = "\n") { entry ->
+                val keyValue = entry.split("=")
+                val key = keyValue[0]
+                val value = if (keyValue.size > 1) URLDecoder.decode(keyValue[1], "UTF-8") else ""
+                "$key: $value"
+            }
+        } catch (e: IllegalArgumentException) {
+            form
+        } catch (e: UnsupportedEncodingException) {
+            form
         }
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/JsonConverter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/JsonConverter.kt
@@ -7,6 +7,7 @@ internal object JsonConverter {
 
     val instance: Gson by lazy {
         GsonBuilder()
+            .disableHtmlEscaping()
             .serializeNulls()
             .setPrettyPrinting()
             .create()

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
@@ -33,7 +33,18 @@ internal class TransactionViewModel(
             }
         }
 
+    val doesRequestBodyRequireEncoding: LiveData<Boolean> = RepositoryProvider.transaction()
+        .getTransaction(transactionId)
+        .map { transaction ->
+            transaction?.requestContentType?.contains("x-www-form-urlencoded", ignoreCase = true) ?: false
+        }
+
     val transaction: LiveData<HttpTransaction?> = RepositoryProvider.transaction().getTransaction(transactionId)
+
+    val formatRequestBody: LiveData<Boolean> = doesRequestBodyRequireEncoding
+        .combineLatest(encodeUrl) { requiresEncoding, encodeUrl ->
+            !(requiresEncoding && encodeUrl)
+        }
 
     fun switchUrlEncoding() = encodeUrl(!encodeUrl.value!!)
 

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/FormatUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/FormatUtilsTest.kt
@@ -168,6 +168,61 @@ class FormatUtilsTest {
     }
 
     @Test
+    fun testFormatUrlEncodedForm_blankString() {
+        assertThat(FormatUtils.formatUrlEncodedForm("    ")).isEqualTo("    ")
+    }
+
+    @Test
+    fun testFormatUrlEncodedForm_properRequest() {
+        val request =
+            """
+            sampleKey=Some%20value&someOtherKey=With%20symbols%20%25!%40%25
+            """.trimIndent()
+        val expected =
+            """
+            sampleKey: Some value
+            someOtherKey: With symbols %!@%
+            """.trimIndent()
+        assertThat(FormatUtils.formatUrlEncodedForm(request)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testFormatUrlEncodedForm_singleParam() {
+        val request =
+            """
+            sampleKey=Some%20value
+            """.trimIndent()
+        val expected =
+            """
+            sampleKey: Some value
+            """.trimIndent()
+        assertThat(FormatUtils.formatUrlEncodedForm(request)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testFormatUrlEncodedForm_noValues() {
+        val request =
+            """
+            sampleKey=&someOtherKey=
+            """.trimIndent()
+        val expected =
+            """
+            sampleKey: 
+            someOtherKey: 
+            """.trimIndent()
+        assertThat(FormatUtils.formatUrlEncodedForm(request)).isEqualTo(expected)
+    }
+
+    @Test
+    fun testFormatUrlEncodedForm_invalidRequest() {
+        val request =
+            """
+            sampleKey=Some%20value%someOtherKey=With%20symbols%20%25!%40%25
+            """.trimIndent()
+        assertThat(FormatUtils.formatUrlEncodedForm(request)).isEqualTo(request)
+    }
+
+    @Test
     fun testCurlCommandWithoutHeaders() {
         getRequestMethods().forEach { method ->
             val transaction = TestTransactionFactory.createTransaction(method)

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinApi.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinApi.kt
@@ -3,6 +3,8 @@ package com.chuckerteam.chucker.sample
 import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.PATCH
@@ -95,6 +97,10 @@ internal interface HttpBinApi {
 
     @GET("/cache/{seconds}")
     fun cache(@Path("seconds") seconds: Int): Call<Void>
+
+    @FormUrlEncoded
+    @POST("/post")
+    fun postForm(@Field("key1") value1: String, @Field("key2") value2: String): Call<Void>
 
     class Data(val thing: String)
 }

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -91,6 +91,7 @@ class HttpBinClient(
             cache(30).enqueue(cb)
             redirectTo("https://ascii.cl?parameter=%22Click+on+%27URL+Encode%27%21%22").enqueue(cb)
             redirectTo("https://ascii.cl?parameter=\"Click on 'URL Encode'!\"").enqueue(cb)
+            postForm("Value 1", "Value with symbols &$%").enqueue(cb)
         }
         downloadSampleImage(colorHex = "fff")
         downloadSampleImage(colorHex = "000")


### PR DESCRIPTION
## :camera: Screenshots
|Current|Formatted|
|-|-|
|![current](https://user-images.githubusercontent.com/54670603/79045408-3db55580-7c0b-11ea-8724-2e29d094fc8c.png)|![formatted](https://user-images.githubusercontent.com/54670603/79045412-40b04600-7c0b-11ea-97c0-f608407f54df.png)|

## :page_facing_up: Context
Reading encoded forms is nearly impossible, especially when dealing values have symbols in them. Unlike for XML and JSON requests, this does not simply pretty print the body and that may be undesired.
