### PR TITLE
Split the CI steps between build and check

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -14,5 +14,36 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Run Gradle tasks
-      run: ./gradlew clean ktlintCheck lint detekt build test
+
+
+    - name: Cache Gradle Caches
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches/
+        key: cache-clean-gradle-${{ matrix.os }}-${{ matrix.jdk }}
+    - name: Cache Gradle Wrapper
+      uses: actions/cache@v1
+      with:
+        path: ~/.gradle/wrapper/
+        key: cache-clean-wrapper-${{ matrix.os }}-${{ matrix.jdk }}
+
+    - name: Run ktlint
+      run: ./gradlew ktlintCheck
+
+    - name: Run detekt
+      run: ./gradlew detekt
+
+    - name: Build Chucker
+      run: ./gradlew build
+
+    - name: Run all the tests
+      run: ./gradlew test
+
+    - name: Run all the other checks
+      run: ./gradlew check
+
+
+    # We stop gradle at the end to make sure the cache folders
+    # don't contain any lock files and are free to be cached.
+    - name: Stop Gradle
+      run: ./gradlew --stop

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -33,15 +33,11 @@ jobs:
     - name: Run detekt
       run: ./gradlew detekt
 
-    - name: Build Chucker
-      run: ./gradlew build
-
     - name: Run all the tests
       run: ./gradlew test
 
-    - name: Run all the other checks
-      run: ./gradlew check
-
+    - name: Build everything
+      run: ./gradlew build
 
     # We stop gradle at the end to make sure the cache folders
     # don't contain any lock files and are free to be cached.


### PR DESCRIPTION
## :page_facing_up: Context
Currently we run our build in only on Gradle run and it makes hard to understand where the failure actually happened. Let's split it into separate steps.

## :hammer_and_wrench: How to test
Let's check if we have a major impact on the build time.
I expect some improvement due to the caching (not on the first run though). On the other side, running several separate gradle commands will lead to running configuration phase multiple times, as well as some duplicate work.
