### PR TITLE
Refactor palette

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/BitmapUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/BitmapUtils.kt
@@ -17,10 +17,10 @@ private val BITMAP_PAINT = Paint(Paint.FILTER_BITMAP_FLAG)
 
 internal suspend fun Bitmap.calculateLuminance(): Double? {
     val color = Color.MAGENTA
-    val alphaColouredBitmap = withContext(Dispatchers.Default) {
-        return@withContext replaceAlphaWithColor(color)
+    return withContext(Dispatchers.Default) {
+        val alpha = replaceAlphaWithColor(color)
+        return@withContext alpha.getLuminance(color)
     }
-    return alphaColouredBitmap.getLuminance(color)
 }
 
 private fun Bitmap.replaceAlphaWithColor(@ColorInt color: Int): Bitmap {
@@ -32,16 +32,11 @@ private fun Bitmap.replaceAlphaWithColor(@ColorInt color: Int): Bitmap {
     return result
 }
 
-private suspend fun Bitmap.getLuminance(@ColorInt alphaSubstitute: Int): Double? {
-    return suspendCancellableCoroutine { continuation ->
-        val luminanceTask = Palette.from(this)
-            .clearFilters()
-            .addFilter { rgb, _ -> rgb != alphaSubstitute }
-            .generate { palette ->
-                val dominantSwatch = palette?.dominantSwatch
-                val luminance = dominantSwatch?.rgb?.let { ColorUtils.calculateLuminance(it) }
-                continuation.resume(luminance)
-            }
-        continuation.invokeOnCancellation { luminanceTask.cancel(true) }
-    }
+private fun Bitmap.getLuminance(@ColorInt alphaSubstitute: Int): Double? {
+    val imagePalette = Palette.from(this)
+        .clearFilters()
+        .addFilter { rgb, _ -> (rgb != alphaSubstitute) }
+        .generate()
+    val dominantSwatch = imagePalette.dominantSwatch
+    return dominantSwatch?.let { ColorUtils.calculateLuminance(it.rgb) }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/BitmapUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/BitmapUtils.kt
@@ -8,9 +8,7 @@ import android.graphics.Paint
 import androidx.annotation.ColorInt
 import androidx.core.graphics.ColorUtils
 import androidx.palette.graphics.Palette
-import kotlin.coroutines.resume
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 
 private val BITMAP_PAINT = Paint(Paint.FILTER_BITMAP_FLAG)
@@ -38,5 +36,5 @@ private fun Bitmap.getLuminance(@ColorInt alphaSubstitute: Int): Double? {
         .addFilter { rgb, _ -> (rgb != alphaSubstitute) }
         .generate()
     val dominantSwatch = imagePalette.dominantSwatch
-    return dominantSwatch?.let { ColorUtils.calculateLuminance(it.rgb) }
+    return dominantSwatch?.rgb?.let(ColorUtils::calculateLuminance)
 }


### PR DESCRIPTION
## :page_facing_up: Context
Found out that during review of #320 I missed the fact that async `generate()` from Palette was used, which relies on `AsyncTaks` under the hood. We added coroutines to get rid of `AsyncTasks`, so I refactored the code to use only coroutines.

## :pencil: Changes
- Switched from asynchronous `generate` to synchronous.
- Forced `getLuminance()` to be called from `Dispatchers.Default` to not rely on the caller of `calculateLuminance()`
