### PR TITLE
Allow Transaction List Item to be focusable for use with TV apps

### DIFF
--- a/library/src/main/res/layout/chucker_list_item_transaction.xml
+++ b/library/src/main/res/layout/chucker_list_item_transaction.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:focusable="true"
     android:background="?android:attr/selectableItemBackground"
     android:padding="@dimen/chucker_base_grid">
 


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/399749/79916592-dbfca480-83dd-11ea-93dd-2dd245232d65.gif)

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
When trying to use on a TV device that only has a remote, you were not able to scroll.
## :pencil: Changes
<!-- Which code did you change? How? -->
In `chucker_list_item_transaction.xml` I added `android:focusable="true"` to the root ConstraintLayout
## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->
N/A
## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->
Only change is UI
## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->
Load the sample app on a TV device. You will now be able to scroll the list
## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
Not right now, but I plan on adding more TV layout support.