### PR TITLE
Setup a Kotlin version matrix on GH Actions

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -10,11 +10,22 @@ on:
 
 jobs:
   gradle:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest]
+    strategy:
+      fail-fast: false
+      matrix:
+        kotlin-version:
+          - 1.3.72
+          - 1.4-M1
+
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
 
+    - name: Set environment variables
+      uses: allenevans/set-env@v1.0.0
+      with:
+        KOTLIN_VERSION: ${{ matrix.kotlin-version }}
 
     - name: Cache Gradle Caches
       uses: actions/cache@v1

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlinVersion = '1.3.72'
+        kotlinVersion = System.getenv("KOTLIN_VERSION") ?: '1.3.72'
         androidGradleVersion = '3.6.1'
         coroutineVersion = '1.3.5'
 
@@ -39,6 +39,7 @@ buildscript {
         jcenter()
         google()
         gradlePluginPortal()
+        maven { url("https://dl.bintray.com/kotlin/kotlin-eap") }
     }
 
     dependencies {
@@ -59,6 +60,7 @@ allprojects {
     repositories {
         jcenter()
         google()
+        maven { url("https://dl.bintray.com/kotlin/kotlin-eap") }
     }
 }
 


### PR DESCRIPTION
## :page_facing_up: Context

I'm setting up a matrix on GH Actions for Kotlin version. This will allow us to have two parallel builds. One for Kotlin 1.3.x and another for the preview of 1.4

Relevant context here https://github.com/ChuckerTeam/chucker/pull/326#issuecomment-614462958

## :pencil: Changes
The Kotlin version is not set from an environment variable and has a fallback at the 1.3.x version so local builds are not impacted.