### PR TITLE
Update payload type definition

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/PayloadType.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/PayloadType.kt
@@ -1,0 +1,8 @@
+package com.chuckerteam.chucker.internal.ui.transaction
+
+import java.io.Serializable
+
+sealed class PayloadType : Serializable {
+    object Request : PayloadType()
+    object Response : PayloadType()
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/PayloadType.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/PayloadType.kt
@@ -1,8 +1,6 @@
 package com.chuckerteam.chucker.internal.ui.transaction
 
-import java.io.Serializable
-
-sealed class PayloadType : Serializable {
-    object Request : PayloadType()
-    object Response : PayloadType()
+internal enum class PayloadType {
+    REQUEST,
+    RESPONSE
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPagerAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPagerAdapter.kt
@@ -17,8 +17,8 @@ internal class TransactionPagerAdapter(context: Context, fm: FragmentManager) :
 
     override fun getItem(position: Int): Fragment = when (position) {
         0 -> TransactionOverviewFragment()
-        1 -> TransactionPayloadFragment.newInstance(TransactionPayloadFragment.TYPE_REQUEST)
-        2 -> TransactionPayloadFragment.newInstance(TransactionPayloadFragment.TYPE_RESPONSE)
+        1 -> TransactionPayloadFragment.newInstance(PayloadType.Request)
+        2 -> TransactionPayloadFragment.newInstance(PayloadType.Response)
         else -> throw IllegalArgumentException("no item")
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPagerAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPagerAdapter.kt
@@ -17,8 +17,8 @@ internal class TransactionPagerAdapter(context: Context, fm: FragmentManager) :
 
     override fun getItem(position: Int): Fragment = when (position) {
         0 -> TransactionOverviewFragment()
-        1 -> TransactionPayloadFragment.newInstance(PayloadType.Request)
-        2 -> TransactionPayloadFragment.newInstance(PayloadType.Response)
+        1 -> TransactionPayloadFragment.newInstance(PayloadType.REQUEST)
+        2 -> TransactionPayloadFragment.newInstance(PayloadType.RESPONSE)
         else -> throw IllegalArgumentException("no item")
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -47,7 +47,9 @@ internal class TransactionPayloadFragment :
     private var backgroundSpanColor: Int = Color.YELLOW
     private var foregroundSpanColor: Int = Color.RED
 
-    private var type: Int = 0
+    private val payloadType: PayloadType by lazy {
+        arguments?.getSerializable(ARG_TYPE) as PayloadType
+    }
 
     private lateinit var viewModel: TransactionViewModel
 
@@ -55,7 +57,6 @@ internal class TransactionPayloadFragment :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        type = arguments!!.getInt(ARG_TYPE)
         viewModel = ViewModelProvider(requireActivity())[TransactionViewModel::class.java]
         setHasOptionsMenu(true)
     }
@@ -89,7 +90,7 @@ internal class TransactionPayloadFragment :
                     uiScope.launch {
                         payloadBinding.loadingProgress.visibility = View.VISIBLE
 
-                        val result = processPayload(type, transaction, formatRequestBody)
+                        val result = processPayload(payloadType, transaction, formatRequestBody)
                         if (result.isEmpty()) {
                             showEmptyState()
                         } else {
@@ -107,7 +108,7 @@ internal class TransactionPayloadFragment :
 
     private fun showEmptyState() {
         payloadBinding.apply {
-            emptyPayloadTextView.text = if (type == TYPE_RESPONSE) {
+            emptyPayloadTextView.text = if (payloadType is PayloadType.Response) {
                 getString(R.string.chucker_response_is_empty)
             } else {
                 getString(R.string.chucker_request_is_empty)
@@ -151,7 +152,7 @@ internal class TransactionPayloadFragment :
             }
         }
 
-        if (type == TYPE_REQUEST) {
+        if (payloadType is PayloadType.Request) {
             viewModel.doesRequestBodyRequireEncoding.observe(
                 viewLifecycleOwner,
                 Observer { menu.findItem(R.id.encode_url).isVisible = it }
@@ -166,19 +167,18 @@ internal class TransactionPayloadFragment :
     private fun shouldShowSaveIcon(transaction: HttpTransaction?) = when {
         // SAF is not available on pre-Kit Kat so let's hide the icon.
         (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) -> false
-        (type == TYPE_REQUEST) -> (0L != (transaction?.requestContentLength))
-        (type == TYPE_RESPONSE) -> (0L != (transaction?.responseContentLength))
+        (payloadType is PayloadType.Request) -> (0L != (transaction?.requestContentLength))
+        (payloadType is PayloadType.Response) -> (0L != (transaction?.responseContentLength))
         else -> true
     }
 
-    private fun shouldShowSearchIcon(transaction: HttpTransaction?) = when (type) {
-        TYPE_REQUEST -> {
+    private fun shouldShowSearchIcon(transaction: HttpTransaction?) = when (payloadType) {
+        PayloadType.Request -> {
             (true == transaction?.isRequestBodyPlainText) && (0L != (transaction.requestContentLength))
         }
-        TYPE_RESPONSE -> {
+        PayloadType.Response -> {
             (true == transaction?.isResponseBodyPlainText) && (0L != (transaction.responseContentLength))
         }
-        else -> false
     }
 
     override fun onAttach(context: Context) {
@@ -213,7 +213,7 @@ internal class TransactionPayloadFragment :
             val transaction = viewModel.transaction.value
             if (uri != null && transaction != null) {
                 uiScope.launch {
-                    val result = saveToFile(type, uri, transaction)
+                    val result = saveToFile(payloadType, uri, transaction)
                     val toastMessageId = if (result) {
                         R.string.chucker_file_saved
                     } else {
@@ -237,7 +237,7 @@ internal class TransactionPayloadFragment :
     }
 
     private suspend fun processPayload(
-        type: Int,
+        type: PayloadType,
         transaction: HttpTransaction,
         formatRequestBody: Boolean
     ): MutableList<TransactionPayloadItem> {
@@ -248,7 +248,7 @@ internal class TransactionPayloadFragment :
             val isBodyPlainText: Boolean
             val bodyString: String
 
-            if (type == TYPE_REQUEST) {
+            if (type is PayloadType.Request) {
                 headersString = transaction.getRequestHeadersString(true)
                 isBodyPlainText = transaction.isRequestBodyPlainText
                 bodyString = if (formatRequestBody) {
@@ -274,7 +274,7 @@ internal class TransactionPayloadFragment :
 
             // The body could either be an image, binary encoded or plain text.
             val responseBitmap = transaction.responseImageBitmap
-            if (type == TYPE_RESPONSE && responseBitmap != null) {
+            if (type is PayloadType.Response && responseBitmap != null) {
                 val bitmapLuminance = responseBitmap.calculateLuminance()
                 result.add(TransactionPayloadItem.ImageItem(responseBitmap, bitmapLuminance))
             } else if (!isBodyPlainText) {
@@ -293,26 +293,23 @@ internal class TransactionPayloadFragment :
     }
 
     @Suppress("ThrowsCount")
-    private suspend fun saveToFile(type: Int, uri: Uri, transaction: HttpTransaction): Boolean {
+    private suspend fun saveToFile(type: PayloadType, uri: Uri, transaction: HttpTransaction): Boolean {
         return withContext(Dispatchers.IO) {
             try {
                 requireContext().contentResolver.openFileDescriptor(uri, "w")?.use {
                     FileOutputStream(it.fileDescriptor).use { fos ->
                         when (type) {
-                            TYPE_REQUEST -> {
+                            is PayloadType.Request -> {
                                 transaction.requestBody?.byteInputStream()?.copyTo(fos)
                                     ?: throw IOException(TRANSACTION_EXCEPTION)
                             }
-                            TYPE_RESPONSE -> {
+                            is PayloadType.Response -> {
                                 transaction.responseBody?.byteInputStream()?.copyTo(fos)
-                                    ?: throw IOException(TRANSACTION_EXCEPTION)
-                            }
-                            else -> {
-                                if (transaction.responseImageData != null) {
-                                    fos.write(transaction.responseImageData)
-                                } else {
-                                    throw IOException(TRANSACTION_EXCEPTION)
-                                }
+                                    ?: if (transaction.responseImageData != null) {
+                                        fos.write(transaction.responseImageData)
+                                    } else {
+                                        throw IOException(TRANSACTION_EXCEPTION)
+                                    }
                             }
                         }
                     }
@@ -334,15 +331,12 @@ internal class TransactionPayloadFragment :
 
         private const val NUMBER_OF_IGNORED_SYMBOLS = 1
 
-        const val TYPE_REQUEST = 0
-        const val TYPE_RESPONSE = 1
-
         const val DEFAULT_FILE_PREFIX = "chucker-export-"
 
-        fun newInstance(type: Int): TransactionPayloadFragment =
+        fun newInstance(type: PayloadType): TransactionPayloadFragment =
             TransactionPayloadFragment().apply {
                 arguments = Bundle().apply {
-                    putInt(ARG_TYPE, type)
+                    putSerializable(ARG_TYPE, type)
                 }
             }
     }


### PR DESCRIPTION
## :page_facing_up: Context
This PR starts a process of sort of big rework how payload data is fetched to remove any business logic related things from fragments. To avoid bloated PR which is hard to review I will do a series of small when it is possible.
This time I changed approach to definition of required payload type for `TransactionPayloadFragment` from constants to a sealed class, which should help have less checks in place as well as be used by other classes in future.

## :pencil: Changes
- Switched from constants to sealed class in `TransactionPayloadFragment`.

## :stopwatch: Next steps
To bring more context - I would like to move all payload processing from fragment and have everything in `ViewModel`, so fragment will just render data provided to it without any decisions.
With current state of things in the library it will be quite hard, but can be managed in a step by step manner.
I am still not sure if we should try to fit all the logic into the shared ViewModel as we currently have or split them in separate ones. Having separate ones would require additional sync for common things like `encodeURL`, etc., but should ease the process of testing. At the same time having everything in one ViewModel would benefit from not having to sync data, but will be hard to test, not to mention issues with mixed responsibility. 
Due to mentioned facts I would like to also hear some feedback/thoughts about preferred ways to ease future development.