### PR TITLE
Deprecate Throwable related parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ val client = OkHttpClient.Builder()
         .build()
 ```
 
-### Throwables ☄️
+### Throwables (Deprected) ☄️
+
+#### Warning: This functionality will be unavailable in 4.x release. Details in [this issue](https://github.com/ChuckerTeam/chucker/issues/321#issuecomment-626138370)
 
 Chucker can also collect and display **Throwables** of your application. To inform Chucker that a `Throwable` was fired you need to call the `onError` method of the `ChuckerCollector` (you need to retain an instance of your collector):
 

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -8,9 +8,9 @@ import android.content.Intent
  */
 object Chucker {
 
-    @Deprecated("This param will be removed in 4.x release")
+    @Deprecated("This variable will be removed in 4.x release")
     const val SCREEN_HTTP = 1
-    @Deprecated("This param will be removed in 4.x release")
+    @Deprecated("This variable will be removed in 4.x release")
     const val SCREEN_ERROR = 2
 
     @Suppress("MayBeConst ") // https://github.com/ChuckerTeam/chucker/pull/169#discussion_r362341353

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -8,16 +8,24 @@ import android.content.Intent
  */
 object Chucker {
 
+    @Deprecated("This param will be removed in 4.x release")
     const val SCREEN_HTTP = 1
+    @Deprecated("This param will be removed in 4.x release")
     const val SCREEN_ERROR = 2
 
     @Suppress("MayBeConst ") // https://github.com/ChuckerTeam/chucker/pull/169#discussion_r362341353
     val isOp = false
 
+    @Deprecated(
+        "This fun will be removed in 4.x release",
+        ReplaceWith("Chucker.getLaunchIntent(context)"),
+        DeprecationLevel.WARNING
+    )
     @JvmStatic
-    fun getLaunchIntent(context: Context, screen: Int): Intent {
-        return Intent()
-    }
+    fun getLaunchIntent(context: Context, screen: Int): Intent = Intent()
+
+    @JvmStatic
+    fun getLaunchIntent(context: Context): Intent = Intent()
 
     @JvmStatic
     fun registerDefaultCrashHandler(collector: ChuckerCollector) {

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -11,6 +11,11 @@ class ChuckerCollector @JvmOverloads constructor(
     var retentionPeriod: RetentionManager.Period = RetentionManager.Period.ONE_WEEK
 ) {
 
+    @Deprecated(
+        "This fun will be removed in 4.x release as part of Throwable functionality removal.",
+        ReplaceWith(""),
+        DeprecationLevel.WARNING
+    )
     fun onError(obj: Any?, obj2: Any?) {
         // Empty method for the library-no-op artifact
     }

--- a/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -12,7 +12,9 @@ import com.chuckerteam.chucker.internal.ui.MainActivity
  */
 object Chucker {
 
+    @Deprecated("This variable will be removed in 4.x release")
     const val SCREEN_HTTP = 1
+    @Deprecated("This variable will be removed in 4.x release")
     const val SCREEN_ERROR = 2
 
     /**
@@ -28,11 +30,25 @@ object Chucker {
      * @param screen The [Screen] to display: SCREEN_HTTP or SCREEN_ERROR.
      * @return An Intent for the main Chucker Activity that can be started with [Context.startActivity].
      */
+    @Deprecated(
+        "This fun will be removed in 4.x release",
+        ReplaceWith("Chucker.getLaunchIntent(context)"),
+        DeprecationLevel.WARNING
+    )
     @JvmStatic
     fun getLaunchIntent(context: Context, @Screen screen: Int): Intent {
+        return getLaunchIntent(context).putExtra(MainActivity.EXTRA_SCREEN, screen)
+    }
+
+    /**
+     * Get an Intent to launch the Chucker UI directly.
+     * @param context An Android [Context].
+     * @return An Intent for the main Chucker Activity that can be started with [Context.startActivity].
+     */
+    @JvmStatic
+    fun getLaunchIntent(context: Context): Intent {
         return Intent(context, MainActivity::class.java)
             .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            .putExtra(MainActivity.EXTRA_SCREEN, screen)
     }
 
     /**
@@ -41,6 +57,11 @@ object Chucker {
      *
      * @param collector the ChuckerCollector
      */
+    @Deprecated(
+        "This fun will be removed in 4.x release",
+        ReplaceWith(""),
+        DeprecationLevel.WARNING
+    )
     @JvmStatic
     fun registerDefaultCrashHandler(collector: ChuckerCollector) {
         Thread.setDefaultUncaughtExceptionHandler(ChuckerCrashHandler(collector))
@@ -49,6 +70,11 @@ object Chucker {
     /**
      * Method to dismiss the Chucker notification of HTTP Transactions
      */
+    @Deprecated(
+        "This fun will be removed in 4.x release",
+        ReplaceWith("Chucker.dismissNotifications(context)"),
+        DeprecationLevel.WARNING
+    )
     @JvmStatic
     fun dismissTransactionsNotification(context: Context) {
         NotificationHelper(context).dismissTransactionsNotification()
@@ -57,14 +83,28 @@ object Chucker {
     /**
      * Method to dismiss the Chucker notification of Uncaught Errors.
      */
+    @Deprecated(
+        "This fun will be removed in 4.x release",
+        ReplaceWith("Chucker.dismissNotifications(context)"),
+        DeprecationLevel.WARNING
+    )
     @JvmStatic
     fun dismissErrorsNotification(context: Context) {
         NotificationHelper(context).dismissErrorsNotification()
     }
 
     /**
+     * Dismisses all previous Chucker notifications.
+     */
+    @JvmStatic
+    fun dismissNotifications(context: Context) {
+        NotificationHelper(context).dismissNotifications()
+    }
+
+    /**
      * Annotation used to specify which screen of Chucker should be launched.
      */
+    @Deprecated("This param will be removed in 4.x release")
     @IntDef(value = [SCREEN_HTTP, SCREEN_ERROR])
     annotation class Screen
 

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -37,6 +37,11 @@ class ChuckerCollector @JvmOverloads constructor(
      * @param tag A tag you choose
      * @param throwable The triggered [Throwable]
      */
+    @Deprecated(
+        "This fun will be removed in 4.x release as part of Throwable functionality removal.",
+        ReplaceWith(""),
+        DeprecationLevel.WARNING
+    )
     fun onError(tag: String, throwable: Throwable) {
         val recordedThrowable = RecordedThrowable(tag, throwable)
         CoroutineScope(Dispatchers.IO).launch {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -20,6 +20,8 @@ internal class NotificationHelper(val context: Context) {
 
     companion object {
         private const val TRANSACTIONS_CHANNEL_ID = "chucker_transactions"
+
+        @Deprecated("This variable will be removed in 4.x release")
         private const val ERRORS_CHANNEL_ID = "chucker_errors"
 
         private const val TRANSACTION_NOTIFICATION_ID = 1138

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -45,7 +45,7 @@ internal class NotificationHelper(val context: Context) {
         PendingIntent.getActivity(
             context,
             TRANSACTION_NOTIFICATION_ID,
-            Chucker.getLaunchIntent(context, Chucker.SCREEN_HTTP),
+            Chucker.getLaunchIntent(context),
             PendingIntent.FLAG_UPDATE_CURRENT
         )
     }
@@ -161,6 +161,11 @@ internal class NotificationHelper(val context: Context) {
     }
 
     fun dismissErrorsNotification() {
+        notificationManager.cancel(ERROR_NOTIFICATION_ID)
+    }
+
+    fun dismissNotifications() {
+        notificationManager.cancel(TRANSACTION_NOTIFICATION_ID)
         notificationManager.cancel(ERROR_NOTIFICATION_ID)
     }
 }


### PR DESCRIPTION
## :page_facing_up: Context
Since[ there is a plan](https://github.com/ChuckerTeam/chucker/issues/321#issuecomment-626138370) to remove Throwable catching functionality in `4.x` we need to prepare users to not introduce breaking changes right away. This PR adds proper deprecation messages, which should both inform and help to switch to valid functions.

## :pencil: Changes
- Added deprecation messages to public API.

## :hammer_and_wrench: How to test
Nothing special for testing. IDE should show suggestions if there is a replacement for deprecated function.
