### PR TITLE
Update the build matrix to run on Kotlin 1.4-M2

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         kotlin-version:
           - 1.3.72
-          - 1.4-M1
+          - 1.4-M2
 
     steps:
     - name: Checkout Repo


### PR DESCRIPTION
## :page_facing_up: Context
Just keeping our build matrix up to date

## :pencil: Changes
Bumped the value for Kotlin 1.4 from `M1` to `M2`

## :stopwatch: Next steps
Not much, if this PR is ✅ we're good to go