### PR TITLE
Remove unused _config.yaml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
## :page_facing_up: Context
This `_config.yaml` file is unused (was used for a legacy documentation website). We can safely remove it.

