### PR TITLE
Update Maven Coordinates to be lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ repositories {
 
 ```groovy
 dependencies {
-  debugImplementation "com.github.ChuckerTeam.Chucker:library:3.2.0"
-  releaseImplementation "com.github.ChuckerTeam.Chucker:library-no-op:3.2.0"
+  debugImplementation "com.github.chuckerteam.chucker:library:3.2.0"
+  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.2.0"
 }
 ```
 
@@ -150,8 +150,8 @@ repositories {
 
 ```gradle
 dependencies {
-  debugImplementation "com.github.ChuckerTeam.Chucker:library:develop-SNAPSHOT"
-  releaseImplementation "com.github.ChuckerTeam.Chucker:library-no-op:develop-SNAPSHOT"
+  debugImplementation "com.github.chuckerteam.chucker:library:develop-SNAPSHOT"
+  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:develop-SNAPSHOT"
 }
 ```
 


### PR DESCRIPTION
## :page_facing_up: Context
I'm updating the Maven Coordinates to be all lowercase. This is to smooth the support for publishing to Maven Central

I've tested the coordinates on the sample app at it works fine (both with a version and a SNAPSHOT release).

## :paperclip: Related PR
Related Issue #56 

## :stopwatch: Next steps
I'll send out the machinery for publishing to Maven Central shortly after.
