### PR TITLE
Bump version name to contain -SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,9 @@ org.gradle.parallel=true
 
 android.useAndroidX=true
 
-VERSION_NAME=3.2.0
+VERSION_NAME=3.3.0-SNAPSHOT
 # 3*100*100 + 2*100 + 0 => 30200
-VERSION_CODE=30200
+VERSION_CODE=30300
 GROUP=com.github.chuckerteam.chucker
 
 POM_REPO_NAME=Chucker


### PR DESCRIPTION
## :page_facing_up: Context
I'm bumping the local version to contains `-SNAPSHOT`.
This is needed as I'm preparing the setup to publish to Maven Central.

## :paperclip: Related PR
See #56 

## :hammer_and_wrench: How to test
Nothing really to test here.