### PR TITLE
Setup publishing to Maven Central

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: 'chucker-local-artifacts'
+        name: 'chucker-local-artifacts-${{ matrix.kotlin-version }}'
         path: '~/.m2/repository/'
 
     # We stop gradle at the end to make sure the cache folders

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -52,6 +52,9 @@ jobs:
 
     - name: Publish to Maven Local
       run: ./gradlew publishToMavenLocal
+      env:
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -53,6 +53,12 @@ jobs:
     - name: Publish to Maven Local
       run: ./gradlew publishToMavenLocal
 
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: 'chucker-local-artifacts'
+        path: '~/.m2/repository/'
+
     # We stop gradle at the end to make sure the cache folders
     # don't contain any lock files and are free to be cached.
     - name: Stop Gradle

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -50,6 +50,9 @@ jobs:
     - name: Build everything
       run: ./gradlew build
 
+    - name: Publish to Maven Local
+      run: ./gradlew publishToMavenLocal
+
     # We stop gradle at the end to make sure the cache folders
     # don't contain any lock files and are free to be cached.
     - name: Stop Gradle

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -12,6 +12,15 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
 
+    - name: Publish to Maven Local
+      run: ./gradlew publishToMavenLocal
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: 'chucker-snapshot-artifacts'
+        path: '~/.m2/repository/'
+
     - name: Publish to the Snapshot Repository
       run: ./gradlew publishReleasePublicationToStagingRepository
       env:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -14,6 +14,9 @@ jobs:
 
     - name: Publish to Maven Local
       run: ./gradlew publishToMavenLocal
+      env:
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,21 @@
+name: Publish Release
+on: 
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish:
+    runs-on: [ubuntu-latest]
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+
+    - name: Publish to the Snapshot Repository
+      run: ./gradlew publishReleasePublicationToStagingRepository
+      env:
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+        ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_USERNAME }}
+        ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_PASSWORD }}

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -1,0 +1,21 @@
+name: Publish Snapshot
+on:
+  push:
+    branches:
+      - develop 
+
+jobs:
+  publish:
+    runs-on: [ubuntu-latest]
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+
+    - name: Publish to the Snapshot Repository
+      run: ./gradlew publishReleasePublicationToSnapshotRepository
+      env:
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+        ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_USERNAME }}
+        ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_PASSWORD }}

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -14,6 +14,9 @@ jobs:
 
     - name: Publish to Maven Local
       run: ./gradlew publishToMavenLocal
+      env:
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
 
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -12,6 +12,15 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
 
+    - name: Publish to Maven Local
+      run: ./gradlew publishToMavenLocal
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: 'chucker-release-artifacts'
+        path: '~/.m2/repository/'
+
     - name: Publish to the Snapshot Repository
       run: ./gradlew publishReleasePublicationToSnapshotRepository
       env:

--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,6 @@ buildscript {
         androidXCoreVersion = '2.1.0'
         paletteKtxVersion = '1.0.0'
 
-        // Publishing
-        androidMavenGradleVersion = '2.1'
-
         // Networking
         gsonVersion = '2.8.6'
         okhttp3Version = '3.12.10'
@@ -44,7 +41,6 @@ buildscript {
 
     dependencies {
         classpath "com.android.tools.build:gradle:$androidGradleVersion"
-        classpath "com.github.dcendents:android-maven-gradle-plugin:$androidMavenGradleVersion"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:$junitGradlePluignVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,11 +24,8 @@ VERSION_CODE=30300
 GROUP=com.github.chuckerteam.chucker
 
 POM_REPO_NAME=Chucker
-POM_GITHUB_REPO=ChuckerTeam/chucker
 POM_DESCRIPTION=Android in-app HTTP inspector
 POM_URL=https://github.com/ChuckerTeam/chucker
-POM_ISSUE_TRACKER=https://github.com/ChuckerTeam/chucker/issues
-POM_SCM_CONNECTION=https://github.com/ChuckerTeam/chucker.git
-POM_LICENCE=Apache-2.0
-POM_LICENCE_NAME=The Apache Software License, Version 2.0
-POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_SCM_CONNECTION=scm:git:git://github.com/ChuckerTeam/chucker.git
+POM_LICENSE_NAME=The Apache Software License, Version 2.0
+POM_LICENSE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,44 +1,97 @@
-apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+apply plugin: 'org.jetbrains.dokka'
 
-def siteUrl = 'https://github.com/ChuckerTeam/chucker' // Homepage URL of the library
-def gitUrl = 'https://github.com/ChuckerTeam/chucker.git' // Git repository URL
-group = GROUP // Maven Group ID for the artifact
+group = GROUP
+version = VERSION_NAME
 
-afterEvaluate { proj ->
+dokka {
+    outputFormat = 'html'
+    outputDirectory = "$buildDir/javadoc"
 
-    install {
-        repositories.mavenInstaller {
-            // This generates POM.xml with proper parameters
-            pom {
-                project {
-                    packaging 'aar'
+    configuration {
+        includeNonPublic = false
+        reportUndocumented = true
+        skipEmptyPackages = true
 
-                    // Add your description here
-                    name "${rootProject.group}:${proj.name}"
+        perPackageOption {
+            prefix = "com.chuckerteam.chucker.internal"
+            suppress = true
+        }
+    }
+}
+
+def dokka = tasks['dokka']
+
+task javadocJar(type: Jar, dependsOn: dokka) {
+    archiveClassifier.set('javadoc')
+    from dokka.outputDirectory
+}
+
+task sourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    from android.sourceSets.main.java.srcDirs
+}
+
+artifacts {
+    archives javadocJar
+    archives sourcesJar
+}
+
+afterEvaluate {
+    publishing {
+        repositories {
+            maven {
+                name "snapshot"
+                url = "https://oss.sonatype.org/content/repositories/snapshots"
+                credentials {
+                    username = findProperty("NEXUS_USERNAME")
+                    password = findProperty("NEXUS_PASSWORD")
+                }
+            }
+            maven {
+                name "staging"
+                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                credentials {
+                    username = findProperty("NEXUS_USERNAME")
+                    password = findProperty("NEXUS_PASSWORD")
+                }
+            }
+        }
+        publications {
+            release(MavenPublication) {
+                from components.release
+                artifact javadocJar
+                artifact sourcesJar
+                artifactId = project.name
+                pom {
+                    name = POM_REPO_NAME
                     description = POM_DESCRIPTION
-                    url siteUrl
-
-                    // Set your license
+                    url = POM_URL
                     licenses {
                         license {
-                            name POM_LICENCE_NAME
-                            url POM_SCM_CONNECTION
-                        }
-                    }
-                    developers {
-                        developer {
-                            id 'olivierperez'
-                            name 'Olivier Perez'
-                            email 'olivier@olivierperez.fr'
+                            name = POM_LICENSE_NAME
+                            url = POM_LICENSE_URL
                         }
                     }
                     scm {
-                        connection gitUrl
-                        developerConnection gitUrl
-                        url siteUrl
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_CONNECTION
+                        url = POM_URL
                     }
                 }
             }
         }
+    }
+
+    def signingKey = findProperty("SIGNING_KEY")
+    def signingPwd = findProperty("SIGNING_PWD")
+    if (signingKey != null && signingPwd != null) {
+        signing {
+            useInMemoryPgpKeys(signingKey, signingPwd)
+            sign publishing.publications.release
+        }
+    } else {
+        logger.info("Signing Disable as the PGP key was not found")
     }
 }

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -18,15 +18,6 @@ android {
     }
 }
 
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    archiveClassifier.set('sources')
-}
-
-artifacts {
-    archives sourcesJar
-}
-
 dependencies {
     implementation "com.squareup.okhttp3:okhttp:$okhttp3Version"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"

--- a/library-no-op/gradle.properties
+++ b/library-no-op/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=library-no-op
-POM_NAME=Chucker no-op
-POM_PACKAGING=aar

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'org.jetbrains.dokka'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -32,39 +31,6 @@ android {
     }
 
     resourcePrefix 'chucker_'
-}
-
-dokka {
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc"
-
-    configuration {
-        includeNonPublic = false
-        reportUndocumented = true
-        skipEmptyPackages = true
-
-        perPackageOption {
-            prefix = "com.chuckerteam.chucker.internal"
-            suppress = true
-        }
-    }
-}
-
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    archiveClassifier.set('sources')
-}
-
-def dokka = tasks['dokka']
-
-task javadocJar(type: Jar, dependsOn: dokka) {
-    archiveClassifier.set('javadoc')
-    from dokka.outputDirectory
-}
-
-artifacts {
-    archives javadocJar
-    archives sourcesJar
 }
 
 dependencies {

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,3 +1,0 @@
-POM_ARTIFACT_ID=library
-POM_NAME=Chucker
-POM_PACKAGING=aar


### PR DESCRIPTION
## :page_facing_up: Context
Setup the repository to publish Chucker also on Maven Central.

The idea is to keep JitPack and Maven Central running side by side for some time.
Ideally we can publish the next version of Chucker (`3.3.0`) to Maven Central.

The publishing will be done by Github Actions in this way:
- Every merge to `develop` will publish a version to the `SNAPSHOT` repository.
- Every push of a new tag will publish a version to the staging repository (for releasing on the Central Repository).

Moreover I've added a step in the Pre Merge action that will trigger a Publishing on Maven Local (this will make sure we're able to publish correctly).

## :pencil: Changes
- Some general cleanup of the Gradle files (we had several unused/old properties).
- Moved the Dokka setup from libraries to the shared external script file.

## :paperclip: Related PR
Closes #56 
Closes #178

## :stopwatch: Next steps
We should update the readme with indication of the repository and the new status badges.