### PR TITLE
Use job.env to set global environment variable

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -18,15 +18,13 @@ jobs:
           - 1.3.72
           - 1.4-M1
 
+    env:
+      KOTLIN_VERSION: ${{ matrix.kotlin-version }}
+
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-
-    - name: Set environment variables
-      uses: allenevans/set-env@v1.0.0
-      with:
-        KOTLIN_VERSION: ${{ matrix.kotlin-version }}
-
+      
     - name: Cache Gradle Caches
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
## :page_facing_up: Context
Looks like we don't need to use a third party action to set the `KOTLIN_VERSION` environment variable.

Moreover that action was firing a warning recently so I'd rather switch back to the default way of setting env variable.
 
## :hammer_and_wrench: How to test
If the build is ✅ , we're good to go.
