### PR TITLE
Fix the CI setup for build on forks

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish:
+    if: ${{ github.repository == 'ChuckerTeam/chucker'}}
     runs-on: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish:
+    if: ${{ github.repository == 'ChuckerTeam/chucker'}}
     runs-on: [ubuntu-latest]
 
     steps:

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -86,7 +86,7 @@ afterEvaluate {
 
     def signingKey = findProperty("SIGNING_KEY")
     def signingPwd = findProperty("SIGNING_PWD")
-    if (signingKey != null && signingPwd != null) {
+    if (signingKey && signingPwd) {
         signing {
             useInMemoryPgpKeys(signingKey, signingPwd)
             sign publishing.publications.release


### PR DESCRIPTION
## :page_facing_up: Context

With the previous commit I accidentally broke the
CI builds coming from external forks. See #159 

Forks don't have access to this ORG secrets so
the publishToMavenLocal task was failing as the
environment variables were blank.

Moreover I'm also disabling the publishing workflow for forks.

## :hammer_and_wrench: How to test
If the build is ✅ , let's merge and rebase #159 on top of this.
