### PR TITLE
Update rebase workflow to use new checkout

### DIFF
--- a/.github/workflows/auto_rebase.yaml
+++ b/.github/workflows/auto_rebase.yaml
@@ -9,7 +9,8 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Checkout target branch for rebase
+      uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Automatic Rebase


### PR DESCRIPTION
## :page_facing_up: Context
It seems that Rebase workflow used old version of Checkout Action

## :pencil: Changes
Switched to `checkout@v2`

## :stopwatch: Next steps
If this one works fine I will also update the same Action in Revert workflow.
