### PR TITLE
Update Revert Action to use new Checkout

### DIFF
--- a/.github/workflows/auto_revert.yaml
+++ b/.github/workflows/auto_revert.yaml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.comment.body, '/revert')
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout the latest code
+        uses: actions/checkout@v2
       - name: Automatic Revert
         uses: srt32/revert@v0.0.1
         env:


### PR DESCRIPTION
## :page_facing_up: Context
Revert Action used old Checkout.

## :pencil: Changes
Switched to `checkout@v2`

## :paperclip: Related PR
Smilar to #348 

## :stopwatch: Next steps
Going to open PRs in both Revert and Rebase repos to update their installation examples, so less people will copy outdated workflows.
