### PR TITLE
Fix wrong artifact name

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: 'chucker-snapshot-artifacts'
+        name: 'chucker-release-artifacts'
         path: '~/.m2/repository/'
 
     - name: Publish to the Snapshot Repository

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: 'chucker-release-artifacts'
+        name: 'chucker-snapshot-artifacts'
         path: '~/.m2/repository/'
 
     - name: Publish to the Snapshot Repository


### PR DESCRIPTION
## Context

The name of the artifact generated by the publish
workflows is accidentally swapped between release and snapshot.
I'm fixing it.
