### PR TITLE
Improved unit test coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,13 @@ buildscript {
         leakcanaryVersion = '2.2'
 
         // Testing
+        androidxTestCoreVersion = '1.2.0'
         junitGradlePluignVersion = '1.6.0.0'
-        junitVersion = '5.6.0'
+        junitVersion = '5.6.2'
         mockkVersion = '1.9.3'
+        robolectricVersion = '4.3'
         truthVersion = '1.0.1'
+        vintageJunitVersion = '4.13'
     }
 
     repositories {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -31,6 +31,12 @@ android {
         abortOnError true
     }
 
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
     resourcePrefix 'chucker_'
 }
 
@@ -88,11 +94,15 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+    testImplementation "junit:junit:$vintageJunitVersion"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$vintageJunitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     testImplementation "io.mockk:mockk:$mockkVersion"
     testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3Version"
+    testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "androidx.arch.core:core-testing:$androidXCoreVersion"
     testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProvider.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProvider.kt
@@ -1,6 +1,7 @@
 package com.chuckerteam.chucker.internal.data.repository
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider.initialize
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
 
@@ -34,5 +35,14 @@ internal object RepositoryProvider {
             transactionRepository = HttpTransactionDatabaseRepository(db)
             throwableRepository = RecordedThrowableDatabaseRepository(db)
         }
+    }
+
+    /**
+     * Cleanup stored singleton objects
+     */
+    @VisibleForTesting
+    fun close() {
+        transactionRepository = null
+        throwableRepository = null
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
@@ -1,108 +1,109 @@
 package com.chuckerteam.chucker.internal.data.entity
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class HttpTransactionTupleTest {
     @Test
     fun schemeIsSSL() {
-        assertTrue(createTuple(scheme = "https").isSsl)
+        assertThat(createTuple(scheme = "https").isSsl).isTrue()
     }
 
     @Test
     fun schemeIsNotSSL() {
-        assertFalse(createTuple(scheme = "http").isSsl)
+        assertThat(createTuple(scheme = "http").isSsl).isFalse()
     }
 
     @Test
     fun statusIsComplete() {
-        assertEquals(
-            HttpTransaction.Status.Complete,
-            createTuple(responseCode = 200, error = null).status
-        )
+        assertThat(
+            createTuple(
+                responseCode = 200,
+                error = null
+            ).status
+        ).isEqualTo(HttpTransaction.Status.Complete)
     }
 
     @Test
     fun statusIsFailed() {
-        assertEquals(
-            HttpTransaction.Status.Failed,
-            createTuple(error = "foo").status
-        )
+        assertThat(
+            createTuple(
+                error = "foo"
+            ).status
+        ).isEqualTo(HttpTransaction.Status.Failed)
     }
 
     @Test
     fun statusIsRequested() {
-        assertEquals(
-            HttpTransaction.Status.Requested,
-            createTuple(responseCode = null).status
-        )
+        assertThat(
+            createTuple(
+                responseCode = null
+            ).status
+        ).isEqualTo(HttpTransaction.Status.Requested)
     }
 
     @Test
     fun durationBlankUntilWeHaveData() {
-        assertNull(createTuple(tookMs = null).durationString)
+        assertThat(createTuple(tookMs = null).durationString).isNull()
     }
 
     @Test
     fun duration() {
-        assertEquals("123 ms", createTuple(tookMs = 123).durationString)
+        assertThat(createTuple(tookMs = 123).durationString).isEqualTo("123 ms")
     }
 
     @Test
     fun totalSizeHandlesNulls() {
-        assertEquals(
-            "0 B",
+        assertThat(
             createTuple(
                 requestContentLength = null,
                 responseContentLength = null
             ).totalSizeString
-        )
+        ).isEqualTo("0 B")
 
-        assertEquals(
-            "0 B",
+        assertThat(
             createTuple(
                 requestContentLength = 0,
                 responseContentLength = null
             ).totalSizeString
-        )
+        ).isEqualTo("0 B")
 
-        assertEquals(
-            "0 B",
+        assertThat(
             createTuple(
                 requestContentLength = null,
                 responseContentLength = 0
             ).totalSizeString
-        )
+        ).isEqualTo("0 B")
     }
 
     @Test
     fun totalSize() {
-        assertEquals(
-            "579 B",
+        assertThat(
             createTuple(
                 requestContentLength = 123,
                 responseContentLength = 456
             ).totalSizeString
-        )
+        ).isEqualTo("579 B")
     }
 
     @Test
     fun nonEncodedFormattedPath() {
-        assertEquals("/abc/def?foo=bar baz", createTuple(path = "/abc/def?foo=bar baz").getFormattedPath(false))
+        assertThat(createTuple(path = "/abc/def?foo=bar baz").getFormattedPath(false))
+            .isEqualTo("/abc/def?foo=bar baz")
     }
 
     @Test
     fun encodedFormattedPath() {
-        assertEquals("/abc/def?foo=bar%20baz", createTuple(path = "/abc/def?foo=bar baz").getFormattedPath(true))
+        assertThat(createTuple(path = "/abc/def?foo=bar baz").getFormattedPath(true))
+            .isEqualTo("/abc/def?foo=bar%20baz")
     }
 
     @Test
     fun formattedPathHandlesNull() {
-        assertEquals("", createTuple(path = null).getFormattedPath(false))
-        assertEquals("", createTuple(path = null).getFormattedPath(true))
+        assertThat(createTuple(path = null).getFormattedPath(false))
+            .isEqualTo("")
+        assertThat(createTuple(path = null).getFormattedPath(true))
+            .isEqualTo("")
     }
 
     private fun createTuple(

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
@@ -1,0 +1,135 @@
+package com.chuckerteam.chucker.internal.data.entity
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HttpTransactionTupleTest {
+    @Test
+    fun schemeIsSSL() {
+        assertTrue(createTuple(scheme = "https").isSsl)
+    }
+
+    @Test
+    fun schemeIsNotSSL() {
+        assertFalse(createTuple(scheme = "http").isSsl)
+    }
+
+    @Test
+    fun statusIsComplete() {
+        assertEquals(
+            HttpTransaction.Status.Complete,
+            createTuple(responseCode = 200, error = null).status
+        )
+    }
+
+    @Test
+    fun statusIsFailed() {
+        assertEquals(
+            HttpTransaction.Status.Failed,
+            createTuple(error = "foo").status
+        )
+    }
+
+    @Test
+    fun statusIsRequested() {
+        assertEquals(
+            HttpTransaction.Status.Requested,
+            createTuple(responseCode = null).status
+        )
+    }
+
+    @Test
+    fun durationBlankUntilWeHaveData() {
+        assertNull(createTuple(tookMs = null).durationString)
+    }
+
+    @Test
+    fun duration() {
+        assertEquals("123 ms", createTuple(tookMs = 123).durationString)
+    }
+
+    @Test
+    fun totalSizeHandlesNulls() {
+        assertEquals(
+            "0 B",
+            createTuple(
+                requestContentLength = null,
+                responseContentLength = null
+            ).totalSizeString
+        )
+
+        assertEquals(
+            "0 B",
+            createTuple(
+                requestContentLength = 0,
+                responseContentLength = null
+            ).totalSizeString
+        )
+
+        assertEquals(
+            "0 B",
+            createTuple(
+                requestContentLength = null,
+                responseContentLength = 0
+            ).totalSizeString
+        )
+    }
+
+    @Test
+    fun totalSize() {
+        assertEquals(
+            "579 B",
+            createTuple(
+                requestContentLength = 123,
+                responseContentLength = 456
+            ).totalSizeString
+        )
+    }
+
+    @Test
+    fun nonEncodedFormattedPath() {
+        assertEquals("/abc/def?foo=bar baz", createTuple(path = "/abc/def?foo=bar baz").getFormattedPath(false))
+    }
+
+    @Test
+    fun encodedFormattedPath() {
+        assertEquals("/abc/def?foo=bar%20baz", createTuple(path = "/abc/def?foo=bar baz").getFormattedPath(true))
+    }
+
+    @Test
+    fun formattedPathHandlesNull() {
+        assertEquals("", createTuple(path = null).getFormattedPath(false))
+        assertEquals("", createTuple(path = null).getFormattedPath(true))
+    }
+
+    private fun createTuple(
+        id: Long = 0,
+        requestDate: Long? = null,
+        tookMs: Long? = null,
+        protocol: String? = null,
+        method: String? = null,
+        host: String? = null,
+        path: String? = null,
+        scheme: String? = null,
+        responseCode: Int? = null,
+        requestContentLength: Long? = null,
+        responseContentLength: Long? = null,
+        error: String? = null
+    ) = HttpTransactionTuple(
+        id,
+        requestDate,
+        tookMs,
+        protocol,
+        method,
+        host,
+        path,
+        scheme,
+        responseCode,
+        requestContentLength,
+        responseContentLength,
+        error
+    )
+}

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/TransactionTestUtils.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/TransactionTestUtils.kt
@@ -1,9 +1,9 @@
 package com.chuckerteam.chucker.internal.data.entity
 
+import com.google.common.truth.Truth.assertThat
 import java.util.UUID
 import okhttp3.Headers
 import okhttp3.HttpUrl
-import org.junit.Assert.assertEquals
 
 internal fun createRequest(path: String = ""): HttpTransaction =
     HttpTransaction().apply {
@@ -43,9 +43,9 @@ internal fun assertTuples(
     expected: List<HttpTransaction>,
     actual: List<HttpTransactionTuple>
 ) {
-    assertEquals(expected.size, actual.size)
+    assertThat(actual.size).isEqualTo(expected.size)
     expected.forEachIndexed { index, expectedTransaction ->
-        assertEquals(expectedTransaction.id, actual[index].id)
+        assertThat(actual[index].id).isEqualTo(expectedTransaction.id)
         assertTuple(expectedTransaction.id, expectedTransaction, actual[index])
     }
 }
@@ -55,16 +55,16 @@ internal fun assertTuple(
     expected: HttpTransaction,
     actual: HttpTransactionTuple?
 ) {
-    assertEquals(id, actual?.id)
-    assertEquals(expected.requestDate, actual?.requestDate)
-    assertEquals(expected.method, actual?.method)
-    assertEquals(expected.host, actual?.host)
-    assertEquals(expected.path, actual?.path)
-    assertEquals(expected.scheme, actual?.scheme)
-    assertEquals(expected.responseCode, actual?.responseCode)
-    assertEquals(expected.requestContentLength, actual?.requestContentLength)
-    assertEquals(expected.responseContentLength, actual?.responseContentLength)
-    assertEquals(expected.error, actual?.error)
+    assertThat(actual?.id).isEqualTo(id)
+    assertThat(actual?.requestDate).isEqualTo(expected.requestDate)
+    assertThat(actual?.method).isEqualTo(expected.method)
+    assertThat(actual?.host).isEqualTo(expected.host)
+    assertThat(actual?.path).isEqualTo(expected.path)
+    assertThat(actual?.scheme).isEqualTo(expected.scheme)
+    assertThat(actual?.responseCode).isEqualTo(expected.responseCode)
+    assertThat(actual?.requestContentLength).isEqualTo(expected.requestContentLength)
+    assertThat(actual?.responseContentLength).isEqualTo(expected.responseContentLength)
+    assertThat(actual?.error).isEqualTo(expected.error)
 }
 
 internal fun assertTransaction(
@@ -72,27 +72,27 @@ internal fun assertTransaction(
     expected: HttpTransaction,
     actual: HttpTransaction?
 ) {
-    assertEquals(transactionId, actual?.id)
-    assertEquals(expected.url, actual?.url)
-    assertEquals(expected.host, actual?.host)
-    assertEquals(expected.path, actual?.path)
-    assertEquals(expected.scheme, actual?.scheme)
-    assertEquals(expected.requestHeaders, actual?.requestHeaders)
-    assertEquals(expected.isRequestBodyPlainText, actual?.isRequestBodyPlainText)
-    assertEquals(expected.requestDate, actual?.requestDate)
-    assertEquals(expected.method, actual?.method)
-    assertEquals(expected.requestContentType, actual?.requestContentType)
-    assertEquals(expected.requestContentLength, actual?.requestContentLength)
-    assertEquals(expected.requestBody, actual?.requestBody)
-    assertEquals(expected.responseHeaders, actual?.responseHeaders)
-    assertEquals(expected.responseCode, actual?.responseCode)
-    assertEquals(expected.responseDate, actual?.responseDate)
-    assertEquals(expected.tookMs, actual?.tookMs)
-    assertEquals(expected.responseTlsVersion, actual?.responseTlsVersion)
-    assertEquals(expected.responseCipherSuite, actual?.responseCipherSuite)
-    assertEquals(expected.responseContentLength, actual?.responseContentLength)
-    assertEquals(expected.requestContentType, actual?.requestContentType)
-    assertEquals(expected.responseMessage, actual?.responseMessage)
-    assertEquals(expected.responseBody, actual?.responseBody)
-    assertEquals(expected.error, actual?.error)
+    assertThat(actual?.id).isEqualTo(transactionId)
+    assertThat(actual?.url).isEqualTo(expected.url)
+    assertThat(actual?.host).isEqualTo(expected.host)
+    assertThat(actual?.path).isEqualTo(expected.path)
+    assertThat(actual?.scheme).isEqualTo(expected.scheme)
+    assertThat(actual?.requestHeaders).isEqualTo(expected.requestHeaders)
+    assertThat(actual?.isRequestBodyPlainText).isEqualTo(expected.isRequestBodyPlainText)
+    assertThat(actual?.requestDate).isEqualTo(expected.requestDate)
+    assertThat(actual?.method).isEqualTo(expected.method)
+    assertThat(actual?.requestContentType).isEqualTo(expected.requestContentType)
+    assertThat(actual?.requestContentLength).isEqualTo(expected.requestContentLength)
+    assertThat(actual?.requestBody).isEqualTo(expected.requestBody)
+    assertThat(actual?.responseHeaders).isEqualTo(expected.responseHeaders)
+    assertThat(actual?.responseCode).isEqualTo(expected.responseCode)
+    assertThat(actual?.responseDate).isEqualTo(expected.responseDate)
+    assertThat(actual?.tookMs).isEqualTo(expected.tookMs)
+    assertThat(actual?.responseTlsVersion).isEqualTo(expected.responseTlsVersion)
+    assertThat(actual?.responseCipherSuite).isEqualTo(expected.responseCipherSuite)
+    assertThat(actual?.responseContentLength).isEqualTo(expected.responseContentLength)
+    assertThat(actual?.requestContentType).isEqualTo(expected.requestContentType)
+    assertThat(actual?.responseMessage).isEqualTo(expected.responseMessage)
+    assertThat(actual?.responseBody).isEqualTo(expected.responseBody)
+    assertThat(actual?.error).isEqualTo(expected.error)
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/TransactionTestUtils.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/TransactionTestUtils.kt
@@ -1,0 +1,98 @@
+package com.chuckerteam.chucker.internal.data.entity
+
+import java.util.UUID
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import org.junit.Assert.assertEquals
+
+internal fun createRequest(path: String = ""): HttpTransaction =
+    HttpTransaction().apply {
+        setRequestHeaders(randomHeaders())
+        populateUrl(HttpUrl.parse("https://www.example.com/$path?query=baz")!!)
+        isRequestBodyPlainText = true
+        requestDate = 300L
+        method = "GET"
+        requestContentType = "text/plain"
+        requestContentLength = 0L
+        requestBody = randomString()
+    }
+
+internal fun HttpTransaction.withResponseData(): HttpTransaction = this.apply {
+    setResponseHeaders(randomHeaders())
+    responseCode = 418 // I'm a teapot
+    responseDate = 321L
+    tookMs = 21L
+    responseTlsVersion = randomString()
+    responseCipherSuite = randomString()
+    responseContentLength = 0L
+    requestContentType = randomString()
+    responseMessage = randomString()
+    responseBody = randomString()
+    error = randomString()
+}
+
+private fun randomHeaders(): Headers = Headers.Builder()
+    .add("name-one", randomString())
+    .add("name-two", randomString())
+    .add("Content-Encoding", "gzip")
+    .build()
+
+internal fun randomString() = UUID.randomUUID().toString()
+
+internal fun assertTuples(
+    expected: List<HttpTransaction>,
+    actual: List<HttpTransactionTuple>
+) {
+    assertEquals(expected.size, actual.size)
+    expected.forEachIndexed { index, expectedTransaction ->
+        assertEquals(expectedTransaction.id, actual[index].id)
+        assertTuple(expectedTransaction.id, expectedTransaction, actual[index])
+    }
+}
+
+internal fun assertTuple(
+    id: Long,
+    expected: HttpTransaction,
+    actual: HttpTransactionTuple?
+) {
+    assertEquals(id, actual?.id)
+    assertEquals(expected.requestDate, actual?.requestDate)
+    assertEquals(expected.method, actual?.method)
+    assertEquals(expected.host, actual?.host)
+    assertEquals(expected.path, actual?.path)
+    assertEquals(expected.scheme, actual?.scheme)
+    assertEquals(expected.responseCode, actual?.responseCode)
+    assertEquals(expected.requestContentLength, actual?.requestContentLength)
+    assertEquals(expected.responseContentLength, actual?.responseContentLength)
+    assertEquals(expected.error, actual?.error)
+}
+
+internal fun assertTransaction(
+    transactionId: Long,
+    expected: HttpTransaction,
+    actual: HttpTransaction?
+) {
+    assertEquals(transactionId, actual?.id)
+    assertEquals(expected.url, actual?.url)
+    assertEquals(expected.host, actual?.host)
+    assertEquals(expected.path, actual?.path)
+    assertEquals(expected.scheme, actual?.scheme)
+    assertEquals(expected.requestHeaders, actual?.requestHeaders)
+    assertEquals(expected.isRequestBodyPlainText, actual?.isRequestBodyPlainText)
+    assertEquals(expected.requestDate, actual?.requestDate)
+    assertEquals(expected.method, actual?.method)
+    assertEquals(expected.requestContentType, actual?.requestContentType)
+    assertEquals(expected.requestContentLength, actual?.requestContentLength)
+    assertEquals(expected.requestBody, actual?.requestBody)
+    assertEquals(expected.responseHeaders, actual?.responseHeaders)
+    assertEquals(expected.responseCode, actual?.responseCode)
+    assertEquals(expected.responseDate, actual?.responseDate)
+    assertEquals(expected.tookMs, actual?.tookMs)
+    assertEquals(expected.responseTlsVersion, actual?.responseTlsVersion)
+    assertEquals(expected.responseCipherSuite, actual?.responseCipherSuite)
+    assertEquals(expected.responseContentLength, actual?.responseContentLength)
+    assertEquals(expected.requestContentType, actual?.requestContentType)
+    assertEquals(expected.responseMessage, actual?.responseMessage)
+    assertEquals(expected.responseBody, actual?.responseBody)
+    assertEquals(expected.error, actual?.error)
+}

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
@@ -1,0 +1,240 @@
+package com.chuckerteam.chucker.internal.data.repository
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.chuckerteam.chucker.internal.data.entity.assertTuples
+import com.chuckerteam.chucker.internal.data.entity.createRequest
+import com.chuckerteam.chucker.internal.data.entity.randomString
+import com.chuckerteam.chucker.internal.data.entity.withResponseData
+import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HttpTransactionDatabaseRepositoryTest {
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var db: ChuckerDatabase
+    private lateinit var testObject: HttpTransactionDatabaseRepository
+
+    private val transaction = createRequest().apply {
+        id = 123456L
+        host = randomString()
+        requestDate = 100
+    }
+    private val otherTransaction = createRequest().apply {
+        id = 234567L
+        host = randomString()
+        requestDate = 200
+    }
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, ChuckerDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        testObject = HttpTransactionDatabaseRepository(db)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    @Test
+    fun loadSingleTransaction() = runBlocking {
+        val data = createRequest().apply { id = 123L }
+        db.transactionDao().insert(data)
+
+        testObject.getTransaction(data.id).observeForever {
+            assertEquals(data.id, it?.id)
+            assertEquals(data.requestHeaders, it?.requestHeaders)
+            assertEquals(data.url, it?.url)
+            assertEquals(data.host, it?.host)
+            assertEquals(data.path, it?.path)
+            assertEquals(data.scheme, it?.scheme)
+            assertEquals(data.isRequestBodyPlainText, it?.isRequestBodyPlainText)
+            assertEquals(data.requestDate, it?.requestDate)
+            assertEquals(data.method, it?.method)
+            assertEquals(data.requestContentType, it?.requestContentType)
+            assertEquals(data.requestContentLength, it?.requestContentLength)
+        }
+    }
+
+    @Test
+    fun insertTransaction() = runBlocking {
+        val data = createRequest()
+
+        testObject.insertTransaction(data)
+        assertTrue(data.id > 0)
+
+        testObject.getTransaction(data.id).observeForever {
+            assertEquals(data.id, it?.id)
+            assertEquals(data.requestHeaders, it?.requestHeaders)
+            assertEquals(data.url, it?.url)
+            assertEquals(data.host, it?.host)
+            assertEquals(data.path, it?.path)
+            assertEquals(data.scheme, it?.scheme)
+            assertEquals(data.isRequestBodyPlainText, it?.isRequestBodyPlainText)
+            assertEquals(data.requestDate, it?.requestDate)
+            assertEquals(data.method, it?.method)
+            assertEquals(data.requestContentType, it?.requestContentType)
+            assertEquals(data.requestContentLength, it?.requestContentLength)
+        }
+    }
+
+    @Test
+    fun getAllTransactions() = runBlocking {
+        testObject.insertTransaction(transaction)
+        testObject.insertTransaction(otherTransaction)
+
+        val result = testObject.getAllTransactions()
+        val first = result.firstOrNull { it.id == transaction.id }
+        assertNotNull(first)
+        assertEquals(transaction.host, first?.host)
+
+        val second = result.firstOrNull { it.id == otherTransaction.id }
+        assertNotNull(second)
+        assertEquals(otherTransaction.host, second?.host)
+    }
+
+    @Test
+    fun getSortedTransactionTuples() = runBlocking {
+        testObject.insertTransaction(transaction)
+        testObject.insertTransaction(otherTransaction)
+
+        testObject.getSortedTransactionTuples().observeForever { result ->
+            assertTuples(listOf(otherTransaction, transaction), result)
+        }
+    }
+
+    @Test
+    fun getFilteredTransactionTuple_emptyStringsReturnAll() = runBlocking {
+        val transactionOne =
+            createRequest("abc").withResponseData().apply {
+                requestDate = 200L
+            }
+        val transactionTwo =
+            createRequest("abcdef").withResponseData().apply {
+                requestDate = 100L
+            }
+        val transactionThree =
+            createRequest("def").withResponseData().apply {
+                requestDate = 300L
+            }
+
+        testObject.insertTransaction(transactionOne)
+        testObject.insertTransaction(transactionTwo)
+        testObject.insertTransaction(transactionThree)
+
+        testObject.getFilteredTransactionTuples("", "").observeForever { result ->
+            assertTuples(listOf(transactionThree, transactionOne, transactionTwo), result)
+        }
+    }
+
+    @Test
+    fun getFilteredTransactionTuple_filterPath() = runBlocking {
+        val transactionOne =
+            createRequest("abc").withResponseData().apply {
+                requestDate = 200L
+            }
+        val transactionTwo =
+            createRequest("abcdef").withResponseData().apply {
+                requestDate = 100L
+            }
+        val transactionThree =
+            createRequest("def").withResponseData().apply {
+                requestDate = 300L
+            }
+
+        testObject.insertTransaction(transactionOne)
+        testObject.insertTransaction(transactionTwo)
+        testObject.insertTransaction(transactionThree)
+
+        testObject.getFilteredTransactionTuples("", "def").observeForever { result ->
+            assertTuples(listOf(transactionThree, transactionTwo), result)
+        }
+    }
+
+    @Test
+    fun getFilteredTransactionTuple_filterCode() = runBlocking {
+        val transactionOne =
+            createRequest("abc").withResponseData().apply {
+                requestDate = 200L
+                responseCode = 418
+            }
+        val transactionTwo =
+            createRequest("abcdef").withResponseData().apply {
+                requestDate = 100L
+                responseCode = 200
+            }
+        val transactionThree =
+            createRequest("def").withResponseData().apply {
+                requestDate = 300L
+                responseCode = 400
+            }
+
+        testObject.insertTransaction(transactionOne)
+        testObject.insertTransaction(transactionTwo)
+        testObject.insertTransaction(transactionThree)
+
+        testObject.getFilteredTransactionTuples("4", "").observeForever { result ->
+            assertTuples(listOf(transactionThree, transactionOne), result)
+        }
+    }
+
+    @Test
+    fun deleteAllTransactions() = runBlocking {
+        testObject.insertTransaction(transaction)
+        testObject.insertTransaction(otherTransaction)
+
+        val result = testObject.getAllTransactions()
+        assertEquals(2, result.size)
+
+        testObject.deleteAllTransactions()
+        val empty = testObject.getAllTransactions()
+        assertTrue(empty.isEmpty())
+    }
+
+    @Test
+    fun deleteOldTransactions() = runBlocking {
+        testObject.insertTransaction(transaction)
+        testObject.insertTransaction(otherTransaction)
+
+        val result = testObject.getAllTransactions()
+        assertEquals(2, result.size)
+
+        testObject.deleteOldTransactions(150L)
+
+        val secondResult = testObject.getAllTransactions()
+        assertEquals(1, secondResult.size)
+        val second = secondResult.firstOrNull { it.id == otherTransaction.id }
+        assertNotNull(second)
+        assertEquals(otherTransaction.host, second?.host)
+    }
+
+    @Test
+    fun updateTransaction() = runBlocking {
+        testObject.insertTransaction(transaction)
+
+        val newHost = randomString()
+        transaction.host = newHost
+        testObject.updateTransaction(transaction)
+
+        testObject.getTransaction(123456L).observeForever {
+            assertEquals(transaction.id, it?.id)
+            assertEquals(newHost, it?.host)
+        }
+    }
+}

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
@@ -9,11 +9,9 @@ import com.chuckerteam.chucker.internal.data.entity.createRequest
 import com.chuckerteam.chucker.internal.data.entity.randomString
 import com.chuckerteam.chucker.internal.data.entity.withResponseData
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -58,17 +56,17 @@ class HttpTransactionDatabaseRepositoryTest {
         db.transactionDao().insert(data)
 
         testObject.getTransaction(data.id).observeForever {
-            assertEquals(data.id, it?.id)
-            assertEquals(data.requestHeaders, it?.requestHeaders)
-            assertEquals(data.url, it?.url)
-            assertEquals(data.host, it?.host)
-            assertEquals(data.path, it?.path)
-            assertEquals(data.scheme, it?.scheme)
-            assertEquals(data.isRequestBodyPlainText, it?.isRequestBodyPlainText)
-            assertEquals(data.requestDate, it?.requestDate)
-            assertEquals(data.method, it?.method)
-            assertEquals(data.requestContentType, it?.requestContentType)
-            assertEquals(data.requestContentLength, it?.requestContentLength)
+            assertThat(it?.id).isEqualTo(data.id)
+            assertThat(it?.requestHeaders).isEqualTo(data.requestHeaders)
+            assertThat(it?.url).isEqualTo(data.url)
+            assertThat(it?.host).isEqualTo(data.host)
+            assertThat(it?.path).isEqualTo(data.path)
+            assertThat(it?.scheme).isEqualTo(data.scheme)
+            assertThat(it?.isRequestBodyPlainText).isEqualTo(data.isRequestBodyPlainText)
+            assertThat(it?.requestDate).isEqualTo(data.requestDate)
+            assertThat(it?.method).isEqualTo(data.method)
+            assertThat(it?.requestContentType).isEqualTo(data.requestContentType)
+            assertThat(it?.requestContentLength).isEqualTo(data.requestContentLength)
         }
     }
 
@@ -77,20 +75,20 @@ class HttpTransactionDatabaseRepositoryTest {
         val data = createRequest()
 
         testObject.insertTransaction(data)
-        assertTrue(data.id > 0)
+        assertThat(data.id > 0).isTrue()
 
         testObject.getTransaction(data.id).observeForever {
-            assertEquals(data.id, it?.id)
-            assertEquals(data.requestHeaders, it?.requestHeaders)
-            assertEquals(data.url, it?.url)
-            assertEquals(data.host, it?.host)
-            assertEquals(data.path, it?.path)
-            assertEquals(data.scheme, it?.scheme)
-            assertEquals(data.isRequestBodyPlainText, it?.isRequestBodyPlainText)
-            assertEquals(data.requestDate, it?.requestDate)
-            assertEquals(data.method, it?.method)
-            assertEquals(data.requestContentType, it?.requestContentType)
-            assertEquals(data.requestContentLength, it?.requestContentLength)
+            assertThat(it?.id).isEqualTo(data.id)
+            assertThat(it?.requestHeaders).isEqualTo(data.requestHeaders)
+            assertThat(it?.url).isEqualTo(data.url)
+            assertThat(it?.host).isEqualTo(data.host)
+            assertThat(it?.path).isEqualTo(data.path)
+            assertThat(it?.scheme).isEqualTo(data.scheme)
+            assertThat(it?.isRequestBodyPlainText).isEqualTo(data.isRequestBodyPlainText)
+            assertThat(it?.requestDate).isEqualTo(data.requestDate)
+            assertThat(it?.method).isEqualTo(data.method)
+            assertThat(it?.requestContentType).isEqualTo(data.requestContentType)
+            assertThat(it?.requestContentLength).isEqualTo(data.requestContentLength)
         }
     }
 
@@ -101,12 +99,12 @@ class HttpTransactionDatabaseRepositoryTest {
 
         val result = testObject.getAllTransactions()
         val first = result.firstOrNull { it.id == transaction.id }
-        assertNotNull(first)
-        assertEquals(transaction.host, first?.host)
+        assertThat(first).isNotNull()
+        assertThat(first?.host).isEqualTo(transaction.host)
 
         val second = result.firstOrNull { it.id == otherTransaction.id }
-        assertNotNull(second)
-        assertEquals(otherTransaction.host, second?.host)
+        assertThat(second).isNotNull()
+        assertThat(second?.host).isEqualTo(otherTransaction.host)
     }
 
     @Test
@@ -200,11 +198,11 @@ class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(otherTransaction)
 
         val result = testObject.getAllTransactions()
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
 
         testObject.deleteAllTransactions()
         val empty = testObject.getAllTransactions()
-        assertTrue(empty.isEmpty())
+        assertThat(empty.isEmpty()).isTrue()
     }
 
     @Test
@@ -213,15 +211,15 @@ class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(otherTransaction)
 
         val result = testObject.getAllTransactions()
-        assertEquals(2, result.size)
+        assertThat(result.size).isEqualTo(2)
 
         testObject.deleteOldTransactions(150L)
 
         val secondResult = testObject.getAllTransactions()
-        assertEquals(1, secondResult.size)
+        assertThat(secondResult.size).isEqualTo(1)
         val second = secondResult.firstOrNull { it.id == otherTransaction.id }
-        assertNotNull(second)
-        assertEquals(otherTransaction.host, second?.host)
+        assertThat(second).isNotNull()
+        assertThat(second?.host).isEqualTo(otherTransaction.host)
     }
 
     @Test
@@ -233,8 +231,8 @@ class HttpTransactionDatabaseRepositoryTest {
         testObject.updateTransaction(transaction)
 
         testObject.getTransaction(123456L).observeForever {
-            assertEquals(transaction.id, it?.id)
-            assertEquals(newHost, it?.host)
+            assertThat(it?.id).isEqualTo(transaction.id)
+            assertThat(it?.host).isEqualTo(newHost)
         }
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProviderTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProviderTest.kt
@@ -4,9 +4,8 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
+import com.google.common.truth.Truth.assertThat
 import org.junit.After
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,13 +43,13 @@ class RepositoryProviderTest {
     @Test
     fun transactionRepoAvailableAfterInitialize() {
         RepositoryProvider.initialize(context)
-        assertNotNull(RepositoryProvider.transaction())
+        assertThat(RepositoryProvider.transaction()).isNotNull()
     }
 
     @Test
     fun errorRepoAvailableAfterInitialize() {
         RepositoryProvider.initialize(context)
-        assertNotNull(RepositoryProvider.throwable())
+        assertThat(RepositoryProvider.throwable()).isNotNull()
     }
 
     @Test
@@ -58,7 +57,7 @@ class RepositoryProviderTest {
         RepositoryProvider.initialize(context)
         val one = RepositoryProvider.transaction()
         val two = RepositoryProvider.transaction()
-        assertSame(one, two)
+        assertThat(one).isSameInstanceAs(two)
     }
 
     @Test
@@ -66,6 +65,6 @@ class RepositoryProviderTest {
         RepositoryProvider.initialize(context)
         val one = RepositoryProvider.throwable()
         val two = RepositoryProvider.throwable()
-        assertSame(one, two)
+        assertThat(one).isSameInstanceAs(two)
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProviderTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProviderTest.kt
@@ -1,0 +1,71 @@
+package com.chuckerteam.chucker.internal.data.repository
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RepositoryProviderTest {
+    private lateinit var db: ChuckerDatabase
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, ChuckerDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+        RepositoryProvider.close()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun uninitialzedTransactionRepo() {
+        RepositoryProvider.transaction()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun uninitialzedErrorsRepo() {
+        RepositoryProvider.throwable()
+    }
+
+    @Test
+    fun transactionRepoAvailableAfterInitialize() {
+        RepositoryProvider.initialize(context)
+        assertNotNull(RepositoryProvider.transaction())
+    }
+
+    @Test
+    fun errorRepoAvailableAfterInitialize() {
+        RepositoryProvider.initialize(context)
+        assertNotNull(RepositoryProvider.throwable())
+    }
+
+    @Test
+    fun providerCachesInstancesOfTransactionRepo() {
+        RepositoryProvider.initialize(context)
+        val one = RepositoryProvider.transaction()
+        val two = RepositoryProvider.transaction()
+        assertSame(one, two)
+    }
+
+    @Test
+    fun providerCachesInstancesOfErrorRepo() {
+        RepositoryProvider.initialize(context)
+        val one = RepositoryProvider.throwable()
+        val two = RepositoryProvider.throwable()
+        assertSame(one, two)
+    }
+}

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -10,11 +10,9 @@ import com.chuckerteam.chucker.internal.data.entity.assertTransaction
 import com.chuckerteam.chucker.internal.data.entity.assertTuples
 import com.chuckerteam.chucker.internal.data.entity.createRequest
 import com.chuckerteam.chucker.internal.data.entity.withResponseData
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -48,28 +46,28 @@ class HttpTransactionDaoTest {
         val id = testObject.insert(data)
 
         with(db.query("select * from transactions", arrayOf())) {
-            assertEquals(1, count)
-            assertTrue(moveToFirst())
+            assertThat(count).isEqualTo(1)
+            assertThat(moveToFirst()).isTrue()
 
-            assertEquals(id, longValue("id"))
-            assertEquals(data.requestDate, longValue("requestDate"))
-            assertEquals(data.responseDate, longValue("responseDate"))
-            assertEquals(data.tookMs, longValue("tookMs"))
-            assertEquals(data.protocol, stringValue("protocol"))
-            assertEquals(data.requestHeaders, stringValue("requestHeaders"))
-            assertEquals(data.responseHeaders, stringValue("responseHeaders"))
-            assertEquals(data.method, stringValue("method"))
-            assertEquals(data.url, stringValue("url"))
-            assertEquals(data.host, stringValue("host"))
-            assertEquals(data.path, stringValue("path"))
-            assertEquals(data.scheme, stringValue("scheme"))
-            assertEquals(data.responseTlsVersion, stringValue("responseTlsVersion"))
-            assertEquals(data.responseCipherSuite, stringValue("responseCipherSuite"))
-            assertEquals(data.requestContentLength, longValue("requestContentLength"))
-            assertEquals(data.requestContentType, stringValue("requestContentType"))
-            assertEquals(data.responseMessage, stringValue("responseMessage"))
-            assertEquals(data.responseBody, stringValue("responseBody"))
-            assertEquals(data.error, stringValue("error"))
+            assertThat(longValue("id")).isEqualTo(id)
+            assertThat(longValue("requestDate")).isEqualTo(data.requestDate)
+            assertThat(longValue("responseDate")).isEqualTo(data.responseDate)
+            assertThat(longValue("tookMs")).isEqualTo(data.tookMs)
+            assertThat(stringValue("protocol")).isEqualTo(data.protocol)
+            assertThat(stringValue("requestHeaders")).isEqualTo(data.requestHeaders)
+            assertThat(stringValue("responseHeaders")).isEqualTo(data.responseHeaders)
+            assertThat(stringValue("method")).isEqualTo(data.method)
+            assertThat(stringValue("url")).isEqualTo(data.url)
+            assertThat(stringValue("host")).isEqualTo(data.host)
+            assertThat(stringValue("path")).isEqualTo(data.path)
+            assertThat(stringValue("scheme")).isEqualTo(data.scheme)
+            assertThat(stringValue("responseTlsVersion")).isEqualTo(data.responseTlsVersion)
+            assertThat(stringValue("responseCipherSuite")).isEqualTo(data.responseCipherSuite)
+            assertThat(longValue("requestContentLength")).isEqualTo(data.requestContentLength)
+            assertThat(stringValue("requestContentType")).isEqualTo(data.requestContentType)
+            assertThat(stringValue("responseMessage")).isEqualTo(data.responseMessage)
+            assertThat(stringValue("responseBody")).isEqualTo(data.responseBody)
+            assertThat(stringValue("error")).isEqualTo(data.error)
         }
     }
 
@@ -93,14 +91,14 @@ class HttpTransactionDaoTest {
         insertTransaction(newer)
 
         val all = testObject.getAll()
-        assertEquals(2, all.size)
+        assertThat(all.size).isEqualTo(2)
 
         val firstAssertion = all.firstOrNull { it.id == older.id }
-        assertNotNull(firstAssertion)
+        assertThat(firstAssertion).isNotNull()
         assertTransaction(older.id, older, firstAssertion)
 
         val secondAssertion = all.firstOrNull { it.id == newer.id }
-        assertNotNull(secondAssertion)
+        assertThat(secondAssertion).isNotNull()
         assertTransaction(newer.id, newer, secondAssertion)
     }
 
@@ -112,7 +110,7 @@ class HttpTransactionDaoTest {
         newer.id = older.id
 
         val rowsUpdated = testObject.update(newer)
-        assertEquals(1, rowsUpdated)
+        assertThat(rowsUpdated).isEqualTo(1)
 
         testObject.getById(older.id).observeForever {
             assertTransaction(older.id, newer, it)
@@ -228,7 +226,7 @@ class HttpTransactionDaoTest {
     private fun assertRowCountMatchingId(id: Long, expectedCount: Long) {
         with(db.query("select count(*) from transactions where id=$id", arrayOf())) {
             moveToFirst()
-            assertEquals(expectedCount, getLong(0))
+            assertThat(getLong(0)).isEqualTo(expectedCount)
             close()
         }
     }
@@ -236,7 +234,7 @@ class HttpTransactionDaoTest {
     private fun assertRowCount(rowCount: Long) {
         with(db.query("select count(*) from transactions", arrayOf())) {
             moveToFirst()
-            assertEquals(rowCount, getLong(0))
+            assertThat(getLong(0)).isEqualTo(rowCount)
             close()
         }
     }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -1,0 +1,249 @@
+package com.chuckerteam.chucker.internal.data.room
+
+import android.content.Context
+import android.database.Cursor
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
+import com.chuckerteam.chucker.internal.data.entity.assertTransaction
+import com.chuckerteam.chucker.internal.data.entity.assertTuples
+import com.chuckerteam.chucker.internal.data.entity.createRequest
+import com.chuckerteam.chucker.internal.data.entity.withResponseData
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HttpTransactionDaoTest {
+    @Rule
+    @JvmField
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var db: ChuckerDatabase
+    private lateinit var testObject: HttpTransactionDao
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, ChuckerDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        testObject = db.transactionDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    @Test
+    fun insertedDataMakesItToTheDatabase() = runBlocking {
+        val data = createRequest().withResponseData()
+        val id = testObject.insert(data)
+
+        with(db.query("select * from transactions", arrayOf())) {
+            assertEquals(1, count)
+            assertTrue(moveToFirst())
+
+            assertEquals(id, longValue("id"))
+            assertEquals(data.requestDate, longValue("requestDate"))
+            assertEquals(data.responseDate, longValue("responseDate"))
+            assertEquals(data.tookMs, longValue("tookMs"))
+            assertEquals(data.protocol, stringValue("protocol"))
+            assertEquals(data.requestHeaders, stringValue("requestHeaders"))
+            assertEquals(data.responseHeaders, stringValue("responseHeaders"))
+            assertEquals(data.method, stringValue("method"))
+            assertEquals(data.url, stringValue("url"))
+            assertEquals(data.host, stringValue("host"))
+            assertEquals(data.path, stringValue("path"))
+            assertEquals(data.scheme, stringValue("scheme"))
+            assertEquals(data.responseTlsVersion, stringValue("responseTlsVersion"))
+            assertEquals(data.responseCipherSuite, stringValue("responseCipherSuite"))
+            assertEquals(data.requestContentLength, longValue("requestContentLength"))
+            assertEquals(data.requestContentType, stringValue("requestContentType"))
+            assertEquals(data.responseMessage, stringValue("responseMessage"))
+            assertEquals(data.responseBody, stringValue("responseBody"))
+            assertEquals(data.error, stringValue("error"))
+        }
+    }
+
+    @Test
+    fun loadSpecificTransactionById() = runBlocking {
+        val disregardedTransaction = createRequest()
+        insertTransaction(disregardedTransaction)
+        val transaction = createRequest().withResponseData()
+        insertTransaction(transaction)
+
+        testObject.getById(transaction.id).observeForever {
+            assertTransaction(transaction.id, transaction, it)
+        }
+    }
+
+    @Test
+    fun loadAllTransactions() = runBlocking {
+        val older = createRequest().apply { requestDate = 100L }
+        val newer = createRequest().apply { requestDate = 200L }
+        insertTransaction(older)
+        insertTransaction(newer)
+
+        val all = testObject.getAll()
+        assertEquals(2, all.size)
+
+        val firstAssertion = all.firstOrNull { it.id == older.id }
+        assertNotNull(firstAssertion)
+        assertTransaction(older.id, older, firstAssertion)
+
+        val secondAssertion = all.firstOrNull { it.id == newer.id }
+        assertNotNull(secondAssertion)
+        assertTransaction(newer.id, newer, secondAssertion)
+    }
+
+    @Test
+    fun updateTransaction() = runBlocking {
+        val older = createRequest().apply { requestDate = 100L }
+        val newer = createRequest().apply { requestDate = 200L }
+        insertTransaction(older)
+        newer.id = older.id
+
+        val rowsUpdated = testObject.update(newer)
+        assertEquals(1, rowsUpdated)
+
+        testObject.getById(older.id).observeForever {
+            assertTransaction(older.id, newer, it)
+        }
+    }
+
+    @Test
+    fun deleteAllTheData() = runBlocking {
+        testObject.insert(createRequest())
+        assertRowCount(1)
+
+        testObject.deleteAll()
+        assertRowCount(0)
+    }
+
+    @Test
+    fun deleteDataBefore() = runBlocking {
+        val older = createRequest().apply { requestDate = 100L }
+        val newer = createRequest().apply { requestDate = 200L }
+        insertTransaction(older)
+        insertTransaction(newer)
+        assertRowCount(2)
+
+        testObject.deleteBefore(150L)
+
+        assertRowCount(1)
+        assertRowCountMatchingId(older.id, 0)
+        assertRowCountMatchingId(newer.id, 1)
+    }
+
+    @Test
+    fun deleteDataBefore_timestampExactlyMatchesThreshold() = runBlocking {
+        val older = createRequest().apply { requestDate = 100L }
+        val newer = createRequest().apply { requestDate = 200L }
+        insertTransaction(older)
+        insertTransaction(newer)
+        assertRowCount(2)
+
+        testObject.deleteBefore(100L)
+
+        assertRowCount(1)
+        assertRowCountMatchingId(older.id, 0)
+        assertRowCountMatchingId(newer.id, 1)
+    }
+
+    @Test
+    fun loadSortedTuples() = runBlocking {
+        val older = createRequest().withResponseData().apply { requestDate = 100L }
+        val newer = createRequest().withResponseData().apply { requestDate = 200L }
+        insertTransaction(older)
+        insertTransaction(newer)
+
+        testObject.getSortedTuples().observeForever { result ->
+            assertTuples(listOf(newer, older), result)
+        }
+    }
+
+    @Test
+    fun filterTuplesByPath() = runBlocking {
+        val transactionOne =
+            createRequest("abc").withResponseData().apply {
+                requestDate = 200L
+            }
+        val transactionTwo =
+            createRequest("abcdef").withResponseData().apply {
+                requestDate = 100L
+            }
+        val transactionThree =
+            createRequest("def").withResponseData().apply {
+                requestDate = 300L
+            }
+
+        insertTransaction(transactionOne)
+        insertTransaction(transactionTwo)
+        insertTransaction(transactionThree)
+
+        testObject.getFilteredTuples("418", "%abc%").observeForever { result ->
+            assertTuples(listOf(transactionOne, transactionTwo), result)
+        }
+    }
+
+    @Test
+    fun filterTuplesByCode() = runBlocking {
+        val transactionOne =
+            createRequest("abc").withResponseData().apply {
+                requestDate = 200L
+                responseCode = 400
+            }
+        val transactionTwo =
+            createRequest("abcdef").withResponseData().apply {
+                requestDate = 100L
+                responseCode = 200
+            }
+        val transactionThree =
+            createRequest("def").withResponseData().apply {
+                requestDate = 300L
+                responseCode = 418 // I am still a teapot
+            }
+
+        insertTransaction(transactionOne)
+        insertTransaction(transactionTwo)
+        insertTransaction(transactionThree)
+
+        testObject.getFilteredTuples("4%", "%").observeForever { result ->
+            assertTuples(listOf(transactionThree, transactionOne), result)
+        }
+    }
+
+    private suspend fun insertTransaction(transaction: HttpTransaction) {
+        transaction.id = testObject.insert(transaction)!!
+    }
+
+    private fun assertRowCountMatchingId(id: Long, expectedCount: Long) {
+        with(db.query("select count(*) from transactions where id=$id", arrayOf())) {
+            moveToFirst()
+            assertEquals(expectedCount, getLong(0))
+            close()
+        }
+    }
+
+    private fun assertRowCount(rowCount: Long) {
+        with(db.query("select count(*) from transactions", arrayOf())) {
+            moveToFirst()
+            assertEquals(rowCount, getLong(0))
+            close()
+        }
+    }
+
+    private fun Cursor.stringValue(fieldName: String) =
+        getString(getColumnIndex(fieldName))
+
+    private fun Cursor.longValue(fieldName: String) =
+        getLong(getColumnIndex(fieldName))
+}


### PR DESCRIPTION
## :pencil: Changes
Additional unit tests -
* HttpTransactionTupleTest
* HttpTransactionDatabaseRepositoryTest
* RepositoryProviderTest
* HttpTransactionDaoTest

To be able to utilize in-memory Room databases (that still require a `Context` to create) I added *Robolectric* to the test dependencies, and since that doesn't play nice with JUnit 5, added a clear dependency on the vintage test engine.