### PR TITLE
Refactor viewmodels initialization to survive process death

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         constraintLayoutVersion = '1.1.3'
         materialComponentsVersion = '1.1.0'
         roomVersion = '2.2.5'
+        fragmentVersion = '1.2.5'
         lifecycleVersion = '2.2.0'
         androidXCoreVersion = '2.1.0'
         paletteKtxVersion = '1.0.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "androidx.palette:palette-ktx:$paletteKtxVersion"
 
+    implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
     implementation "androidx.room:room-ktx:$roomVersion"

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -2,7 +2,6 @@ package com.chuckerteam.chucker.internal.ui
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.lifecycle.ViewModelProvider
 import com.chuckerteam.chucker.api.Chucker
 import com.chuckerteam.chucker.databinding.ChuckerActivityMainBinding
 import com.chuckerteam.chucker.internal.ui.throwable.ThrowableActivity
@@ -16,7 +15,6 @@ internal class MainActivity :
     TransactionAdapter.TransactionClickListListener,
     ThrowableAdapter.ThrowableClickListListener {
 
-    private lateinit var viewModel: MainViewModel
     private lateinit var mainBinding: ChuckerActivityMainBinding
 
     private val applicationName: CharSequence
@@ -24,7 +22,6 @@ internal class MainActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModel = ViewModelProvider(this).get(MainViewModel::class.java)
         mainBinding = ChuckerActivityMainBinding.inflate(layoutInflater)
 
         with(mainBinding) {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableActivity.kt
@@ -6,9 +6,9 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.viewModels
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerActivityThrowableBinding
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
@@ -17,16 +17,16 @@ import java.text.DateFormat
 
 internal class ThrowableActivity : BaseChuckerActivity() {
 
-    private lateinit var viewModel: ThrowableViewModel
-    private lateinit var errorBinding: ChuckerActivityThrowableBinding
+    private val viewModel: ThrowableViewModel by viewModels {
+        ThrowableViewModelFactory(intent.getLongExtra(EXTRA_THROWABLE_ID, 0))
+    }
 
-    private var throwableId: Long = 0
+    private lateinit var errorBinding: ChuckerActivityThrowableBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         errorBinding = ChuckerActivityThrowableBinding.inflate(layoutInflater)
-        throwableId = intent.getLongExtra(EXTRA_THROWABLE_ID, 0)
 
         with(errorBinding) {
             setContentView(root)
@@ -34,9 +34,6 @@ internal class ThrowableActivity : BaseChuckerActivity() {
             throwableItem.date.visibility = View.GONE
         }
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-
-        viewModel = ViewModelProvider(this, ThrowableViewModelFactory(throwableId))
-            .get(ThrowableViewModel::class.java)
 
         viewModel.throwable.observe(
             this,

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableListFragment.kt
@@ -9,8 +9,8 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentThrowableListBinding
@@ -20,14 +20,14 @@ import com.chuckerteam.chucker.internal.ui.MainViewModel
 
 internal class ThrowableListFragment : Fragment(), ThrowableAdapter.ThrowableClickListListener {
 
-    private lateinit var viewModel: MainViewModel
+    private val viewModel: MainViewModel by viewModels()
+
     private lateinit var errorsBinding: ChuckerFragmentThrowableListBinding
     private lateinit var errorsAdapter: ThrowableAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
-        viewModel = ViewModelProvider(requireActivity())[MainViewModel::class.java]
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/throwable/ThrowableViewModel.kt
@@ -15,8 +15,7 @@ internal class ThrowableViewModel(
 
 internal class ThrowableViewModelFactory(
     private val throwableId: Long = 0L
-) :
-    ViewModelProvider.Factory {
+) : ViewModelProvider.NewInstanceFactory() {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         require(modelClass == ThrowableViewModel::class.java) { "Cannot create $modelClass" }
         @Suppress("UNCHECKED_CAST")

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -8,7 +8,6 @@ import android.view.MenuItem
 import androidx.activity.viewModels
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
 import androidx.viewpager.widget.ViewPager
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerActivityTransactionBinding

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import androidx.activity.viewModels
 import androidx.core.app.ShareCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -16,19 +17,15 @@ import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
 
 internal class TransactionActivity : BaseChuckerActivity() {
 
-    private lateinit var viewModel: TransactionViewModel
+    private val viewModel: TransactionViewModel by viewModels {
+        TransactionViewModelFactory(intent.getLongExtra(EXTRA_TRANSACTION_ID, 0))
+    }
+
     private lateinit var transactionBinding: ChuckerActivityTransactionBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         transactionBinding = ChuckerActivityTransactionBinding.inflate(layoutInflater)
-
-        val transactionId = intent.getLongExtra(EXTRA_TRANSACTION_ID, 0)
-
-        // Create the instance now, so it can be shared by the
-        // various fragments in the view pager later.
-        viewModel = ViewModelProvider(this, TransactionViewModelFactory(transactionId))
-            .get(TransactionViewModel::class.java)
 
         with(transactionBinding) {
             setContentView(root)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
@@ -18,8 +18,6 @@ import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionListBinding

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
@@ -16,8 +16,10 @@ import androidx.appcompat.widget.SearchView
 import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionListBinding
@@ -36,7 +38,8 @@ internal class TransactionListFragment :
     SearchView.OnQueryTextListener,
     TransactionAdapter.TransactionClickListListener {
 
-    private lateinit var viewModel: MainViewModel
+    private val viewModel: MainViewModel by viewModels()
+
     private lateinit var transactionsBinding: ChuckerFragmentTransactionListBinding
     private lateinit var transactionsAdapter: TransactionAdapter
     private val cacheFileFactory: FileFactory by lazy {
@@ -47,7 +50,6 @@ internal class TransactionListFragment :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
-        viewModel = ViewModelProvider(requireActivity())[MainViewModel::class.java]
     }
 
     override fun onCreateView(

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -7,8 +7,8 @@ import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionOverviewBinding
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
@@ -16,13 +16,13 @@ import com.chuckerteam.chucker.internal.support.combineLatest
 
 internal class TransactionOverviewFragment : Fragment() {
 
+    private val viewModel: TransactionViewModel by activityViewModels { TransactionViewModelFactory() }
+
     private lateinit var overviewBinding: ChuckerFragmentTransactionOverviewBinding
-    private lateinit var viewModel: TransactionViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
-        viewModel = ViewModelProvider(requireActivity())[TransactionViewModel::class.java]
     }
 
     override fun onCreateView(

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -20,8 +20,8 @@ import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionPayloadBinding
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
@@ -41,23 +41,22 @@ private const val GET_FILE_FOR_SAVING_REQUEST_CODE: Int = 43
 internal class TransactionPayloadFragment :
     Fragment(), SearchView.OnQueryTextListener {
 
+    private val viewModel: TransactionViewModel by activityViewModels { TransactionViewModelFactory() }
+
+    private val payloadType: PayloadType by lazy(LazyThreadSafetyMode.NONE) {
+        arguments?.getSerializable(ARG_TYPE) as PayloadType
+    }
+
     private lateinit var payloadBinding: ChuckerFragmentTransactionPayloadBinding
     private val payloadAdapter = TransactionBodyAdapter()
 
     private var backgroundSpanColor: Int = Color.YELLOW
     private var foregroundSpanColor: Int = Color.RED
 
-    private val payloadType: PayloadType by lazy(LazyThreadSafetyMode.NONE) {
-        arguments?.getSerializable(ARG_TYPE) as PayloadType
-    }
-
-    private lateinit var viewModel: TransactionViewModel
-
     private val uiScope = MainScope()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        viewModel = ViewModelProvider(requireActivity())[TransactionViewModel::class.java]
         setHasOptionsMenu(true)
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
@@ -9,9 +9,7 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.support.combineLatest
 
-internal class TransactionViewModel(
-    transactionId: Long
-) : ViewModel() {
+internal class TransactionViewModel(transactionId: Long) : ViewModel() {
 
     private val mutableEncodeUrl = MutableLiveData<Boolean>(false)
 
@@ -55,8 +53,7 @@ internal class TransactionViewModel(
 
 internal class TransactionViewModelFactory(
     private val transactionId: Long = 0L
-) :
-    ViewModelProvider.Factory {
+) : ViewModelProvider.NewInstanceFactory() {
     override fun <T : ViewModel?> create(modelClass: Class<T>): T {
         require(modelClass == TransactionViewModel::class.java) { "Cannot create $modelClass" }
         @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
## :page_facing_up: Context
Due to how ViewModel objects were initialised Chucker had a bunch of crashes. 
This PR changes the way Chucker works with ViewModels and resolves a bunch of issues:
- Closes #364 
- Closes #366 
- Closes #367 

## :pencil: Changes
- Updated to Fragment 1.2.5 to use latest extensions required.
- Changed the declaration of ViewModel in Activity and Fragments.

## :no_entry_sign: Breaking
No issues found so far.

## :hammer_and_wrench: How to test
For #364 follow the steps provided by @MiSikora 
For #366 and #367 enable `Don't keep activities` and try to share some transaction as curl.

## :stopwatch: Next steps
Add `SavedStateHandle` to save search query in TransactionListFragment and search query in updated TransactionPayloadFragment search (isn't published yet).
