### PR TITLE
Update work with Gradle cache

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -24,16 +24,16 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Cache Gradle Caches
+    - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
-        path: ~/.gradle/caches/
-        key: cache-test-gradle-${{ matrix.kotlin-version }}
-    - name: Cache Gradle Wrapper
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/wrapper/
-        key: cache-test-wrapper-${{ matrix.kotlin-version }}
+        path: |
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/
+        key: cache-gradle-${{ matrix.kotlin-version }}-${{ hashFiles('build.gradle') }}
+        restore-keys: |
+          cache-gradle-${{ matrix.version }}-
+          cache-gradle-
 
     - name: Run all the tests
       run: ./gradlew test
@@ -47,16 +47,14 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Cache Gradle Caches
+    - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
-        path: ~/.gradle/caches/
-        key: cache-detekt-gradle
-    - name: Cache Gradle Wrapper
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/wrapper/
-        key: cache-detekt-wrapper
+        path: |
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/
+        key: cache-gradle-${{ hashFiles('build.gradle') }}
+        restore-keys: cache-gradle-
 
     - name: Run detekt
       run: ./gradlew detekt
@@ -70,17 +68,15 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Cache Gradle Caches
+    - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
-        path: ~/.gradle/caches/
-        key: cache-ktlint-gradle
-    - name: Cache Gradle Wrapper
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/wrapper/
-        key: cache-ktlint-wrapper
-
+        path: |
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/
+        key: cache-gradle-${{ hashFiles('build.gradle') }}
+        restore-keys: cache-gradle-
+ 
     - name: Run ktlint
       run: ./gradlew ktlintCheck
 
@@ -93,18 +89,15 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
-    - name: Cache Gradle Caches
+    - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
-        path: ~/.gradle/caches/
-        key: cache-publish-gradle
-    - name: Cache Gradle Wrapper
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle/wrapper/
-        key: cache-publish-wrapper
-
-
+        path: |
+          ~/.gradle/caches/
+          ~/.gradle/wrapper/
+        key: cache-gradle-${{ hashFiles('build.gradle') }}
+        restore-keys: cache-gradle-
+          
     - name: Publish to Maven Local
       run: ./gradlew publishToMavenLocal
       env:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -25,12 +25,12 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
     - name: Cache Gradle Caches
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches/
         key: cache-test-gradle-${{ matrix.kotlin-version }}
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/wrapper/
         key: cache-test-wrapper-${{ matrix.kotlin-version }}
@@ -48,12 +48,12 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
     - name: Cache Gradle Caches
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches/
         key: cache-detekt-gradle
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/wrapper/
         key: cache-detekt-wrapper
@@ -71,12 +71,12 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
     - name: Cache Gradle Caches
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches/
         key: cache-ktlint-gradle
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/wrapper/
         key: cache-ktlint-wrapper
@@ -94,12 +94,12 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v2
     - name: Cache Gradle Caches
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/caches/
         key: cache-publish-gradle
     - name: Cache Gradle Wrapper
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.gradle/wrapper/
         key: cache-publish-wrapper


### PR DESCRIPTION
## :page_facing_up: Context
It started from the need of invalidating Gradle caches when dependencies are updated. While doing this change I also updated Cache action and changed the way we declare caches.

## :pencil: Changes
- Added cache key based on hash of `build.gradle` file with dependencies versions.
- Updated Cache action to v2.
- Changed caches creation between jobs to re-use the same cache file.
- Added restore keys in case cache wasn't found by key.

## :no_entry_sign: Breaking
No

## :hammer_and_wrench: How to test
Nothing special required.

## :stopwatch: Next steps
Add Dependabot to update dependencies regularly.
