### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+# Updates for Github Actions used in the repo
+- package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+# Updates for Gradle dependencies used in the library
+- package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    milestone: 3.3.0
+    ignore:
+    - dependency-name: com.squareup.okhttp3:logging-interceptor
+      versions:
+      - "> 3.12.10"
+    - dependency-name: com.squareup.okhttp3:mockwebserver
+      versions:
+      - "> 3.12.10"
+    - dependency-name: com.squareup.okhttp3:okhttp
+      versions:
+      - "> 3.12.10"
+    


### PR DESCRIPTION
## :page_facing_up: Context
To avoid burden of updating dependencies manually as well as forgetting to update something we could rely on Dependabot to take care of updates for library dependencies as well as updates to used Github Actions.
This PR has a required configuration file to run Dependabot from Github.

## :pencil: Changes
- Added a .yml config file specifying schedule of checks and versions to ignore, since we can update OkHttp, for example.

## :no_entry_sign: Breaking
Nothing is expected

## :hammer_and_wrench: How to test
Merge the PR into `develop` and see how new PRs magically appear.

## :stopwatch: Next steps
Check how it works in real life, since updates for Gradle dependencies were tested by me and work fine, while updates to Github Actions is something new.
