### PR TITLE
Fixes for Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,9 @@ updates:
       schedule:
         interval: "weekly"
       open-pull-requests-limit: 10
-      milestone: "3.3.0"
+      reviewers:
+      - "cortinico"
+      - "vbuberen"
       ignore:
         - dependency-name: com.squareup.okhttp3:logging-interceptor
           versions: "> 3.12.10"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,14 +14,11 @@ updates:
       schedule:
         interval: "weekly"
       open-pull-requests-limit: 10
-      milestone: 3.3.0
+      milestone: "3.3.0"
       ignore:
         - dependency-name: com.squareup.okhttp3:logging-interceptor
-          versions:
-        - "> 3.12.10"
+          versions: "> 3.12.10"
         - dependency-name: com.squareup.okhttp3:mockwebserver
-          versions:
-        - "> 3.12.10"
+          versions: "> 3.12.10"
         - dependency-name: com.squareup.okhttp3:okhttp
-          versions:
-        - "> 3.12.10"
+          versions: "> 3.12.10"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,25 +4,24 @@
 version: 2
 updates:
 # Updates for Github Actions used in the repo
-- package-ecosystem: github-actions
-    directory: "/"
-    schedule:
-      interval: weekly
-# Updates for Gradle dependencies used in the library
-- package-ecosystem: gradle
-    directory: "/"
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    milestone: 3.3.0
-    ignore:
-    - dependency-name: com.squareup.okhttp3:logging-interceptor
-      versions:
-      - "> 3.12.10"
-    - dependency-name: com.squareup.okhttp3:mockwebserver
-      versions:
-      - "> 3.12.10"
-    - dependency-name: com.squareup.okhttp3:okhttp
-      versions:
-      - "> 3.12.10"
-    
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+# Updates for Gradle dependencies used in the app      
+    - package-ecosystem: gradle
+      directory: "/"
+      schedule:
+        interval: "weekly"
+      open-pull-requests-limit: 10
+      milestone: 3.3.0
+      ignore:
+        - dependency-name: com.squareup.okhttp3:logging-interceptor
+          versions:
+        - "> 3.12.10"
+        - dependency-name: com.squareup.okhttp3:mockwebserver
+          versions:
+        - "> 3.12.10"
+        - dependency-name: com.squareup.okhttp3:okhttp
+          versions:
+        - "> 3.12.10"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,15 @@
 version: 2
 updates:
 # Updates for Github Actions used in the repo
-- package-ecosystem: "github-actions"
+- package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
 # Updates for Gradle dependencies used in the library
 - package-ecosystem: gradle
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
     open-pull-requests-limit: 10
     milestone: 3.3.0
     ignore:


### PR DESCRIPTION
## :page_facing_up: Context
It seems that I introduced an invalid YAML for Dependabot in #371. This PR fix the issue.
Also, I found out that currently automatic milestones assignment accepts only integers, so we can't add `3.3.0` in the config, but `9` (the number of `3.3.0`). Since `9` has no sense to most people it might be messed up and forgotten with time.
Aside from that I tried to add automatic reviewers assignment.

## :pencil: Changes
- Fixed indents in Dependabot config.
- Removed milestone assignment.
- Added reviewers assignment.

## :no_entry_sign: Breaking
Nothing

## :hammer_and_wrench: How to test
Merge into `develop`
