### PR TITLE
Add Retrofit to ignored list by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,5 @@ updates:
           versions: "> 3.12.10"
         - dependency-name: com.squareup.okhttp3:okhttp
           versions: "> 3.12.10"
+        - dependency-name: com.squareup.retrofit2:retrofit
+          versions: "> 2.6.4"


### PR DESCRIPTION
## :page_facing_up: Context
Chucker uses Retrofit in its sample app. Since we still have minSDK 16 we can't update it.
To avoid redundant PR by Dependabot I added Retrofit into ignored list.

## :pencil: Changes
- Added Retrofit to ignored dependencies.
