### PR TITLE
Refactor/change scope

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,8 +21,8 @@ android {
         jvmTarget = "1.8"
     }
 
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        viewBinding = true
     }
 
     lintOptions {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
@@ -18,6 +18,7 @@ import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionListBinding
@@ -27,8 +28,6 @@ import com.chuckerteam.chucker.internal.support.FileFactory
 import com.chuckerteam.chucker.internal.support.ShareUtils
 import com.chuckerteam.chucker.internal.support.showDialog
 import com.chuckerteam.chucker.internal.ui.MainViewModel
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 internal class TransactionListFragment :
@@ -43,7 +42,6 @@ internal class TransactionListFragment :
     private val cacheFileFactory: FileFactory by lazy {
         AndroidCacheFileFactory(requireContext())
     }
-    private val uiScope = MainScope()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -80,11 +78,6 @@ internal class TransactionListFragment :
                     if (transactionTuples.isEmpty()) View.VISIBLE else View.GONE
             }
         )
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        uiScope.cancel()
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
@@ -140,7 +133,7 @@ internal class TransactionListFragment :
     }
 
     private fun exportTransactions() {
-        uiScope.launch {
+        lifecycleScope.launch {
             val transactions = viewModel.getAllTransactions()
             if (transactions.isNullOrEmpty()) {
                 Toast.makeText(requireContext(), R.string.chucker_export_empty_text, Toast.LENGTH_SHORT).show()

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -22,14 +22,13 @@ import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
+import androidx.lifecycle.lifecycleScope
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionPayloadBinding
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.support.calculateLuminance
 import com.chuckerteam.chucker.internal.support.combineLatest
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.FileNotFoundException
@@ -52,8 +51,6 @@ internal class TransactionPayloadFragment :
 
     private var backgroundSpanColor: Int = Color.YELLOW
     private var foregroundSpanColor: Int = Color.RED
-
-    private val uiScope = MainScope()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -86,7 +83,7 @@ internal class TransactionPayloadFragment :
                 viewLifecycleOwner,
                 Observer { (transaction, formatRequestBody) ->
                     if (transaction == null) return@Observer
-                    uiScope.launch {
+                    lifecycleScope.launch {
                         payloadBinding.loadingProgress.visibility = View.VISIBLE
 
                         val result = processPayload(payloadType, transaction, formatRequestBody)
@@ -122,11 +119,6 @@ internal class TransactionPayloadFragment :
             emptyStateGroup.visibility = View.GONE
             payloadRecyclerView.visibility = View.VISIBLE
         }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        uiScope.cancel()
     }
 
     @SuppressLint("NewApi")
@@ -211,7 +203,7 @@ internal class TransactionPayloadFragment :
             val uri = resultData?.data
             val transaction = viewModel.transaction.value
             if (uri != null && transaction != null) {
-                uiScope.launch {
+                lifecycleScope.launch {
                     val result = saveToFile(payloadType, uri, transaction)
                     val toastMessageId = if (result) {
                         R.string.chucker_file_saved


### PR DESCRIPTION
## :page_facing_up: Context
After recent changes with updated dependencies Chucker now has `lifecycleScope` extension available to manage coroutines. It means that previously used `MainScope()` can be dropped in favor of such extension for better handling of coroutines launched in fragements.

## :pencil: Changes
- Switch from `MainScope()` to `lifecycleScope` extension.
- Resolved ktLint warning about deprecated `ViewBinding` declaration.
