### PR TITLE
Allow Chucker to display partially read application responses

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
@@ -46,7 +46,9 @@ internal class TeeSource(
             return bytesRead
         }
 
-        copyBytesToFile(sink, bytesRead)
+        if (!isFailure) {
+            copyBytesToFile(sink, bytesRead)
+        }
 
         return bytesRead
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
@@ -58,8 +58,8 @@ internal class TeeSource(
             bytesRead - (totalBytesRead - readBytesLimit)
         }
         val offset = sink.size() - bytesRead
+        sink.copyTo(sideStream.buffer(), offset, byteCountToCopy)
         try {
-            sink.copyTo(sideStream.buffer(), offset, byteCountToCopy)
             sideStream.emitCompleteSegments()
         } catch (e: IOException) {
             callSideChannelFailure(e)


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an open issue - #370.

## :pencil: Changes
<!-- Which code did you change? How? -->

I mostly worked on `TeeSource` and implemented `Callback`. Callers are now informed of finished byte processing whenever an upstream source is closed and now they are responsible for handling any data corruption that might have occurred.

Exceeded byte count limit is no longer reported as a failure. Instead, bytes are no longer written to a file. Also, I added some guarding against failures that might happen when writing to a file (due to low-end devices and so on).

This change also enables displaying not fully read responses if Chucker is applied as an application-level `Interceptor`. Network-level is not always doable due to compression (this might be further improved in the future but right now I don't want to mess with it).

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Some units test are written. You can also run the sample from #370 created by @gmetal with Chucker from my branch `com.github.MiSikora.chucker:library:response-read-SNAPSHOT` available via JitPack.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Closes #370.