### PR TITLE
Kotlin variant in pre-merge to 1.4-M3

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         kotlin-version:
           - 1.3.72
-          - 1.4-M2
+          - 1.4-M3
 
     env:
       KOTLIN_VERSION: ${{ matrix.kotlin-version }}


### PR DESCRIPTION
## :page_facing_up: Context
Kotlin 1.4-M3 was released yesterday. Let's update our build matrix to use it.

## :hammer_and_wrench: How to test
PR checks will tell ✅ 