### PR TITLE
Do not rely on "Content-Length" for payload size.

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -246,7 +246,7 @@ class ChuckerInterceptor internal constructor(
             file.delete()
         }
 
-        override fun onFailure(exception: IOException, file: File) = Unit
+        override fun onFailure(file: File, exception: IOException) = Unit
 
         private fun readResponseBuffer(responseBody: File, isGzipped: Boolean): Buffer {
             val bufferedSource = Okio.buffer(Okio.source(responseBody))

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -6,7 +6,6 @@ import com.chuckerteam.chucker.internal.support.AndroidCacheFileFactory
 import com.chuckerteam.chucker.internal.support.FileFactory
 import com.chuckerteam.chucker.internal.support.IOUtils
 import com.chuckerteam.chucker.internal.support.TeeSource
-import com.chuckerteam.chucker.internal.support.contentLength
 import com.chuckerteam.chucker.internal.support.contentType
 import com.chuckerteam.chucker.internal.support.hasBody
 import com.chuckerteam.chucker.internal.support.isGzipped
@@ -109,7 +108,7 @@ class ChuckerInterceptor internal constructor(
             requestDate = System.currentTimeMillis()
             method = request.method()
             requestContentType = requestBody?.contentType()?.toString()
-            requestContentLength = requestBody?.contentLength() ?: 0L
+            requestPayloadSize = requestBody?.contentLength() ?: 0L
         }
 
         if (requestBody != null && encodingIsSupported) {
@@ -157,7 +156,6 @@ class ChuckerInterceptor internal constructor(
             }
 
             responseContentType = response.contentType
-            responseContentLength = response.contentLength
 
             tookMs = (response.receivedResponseAtMillis() - response.sentRequestAtMillis())
         }
@@ -235,13 +233,15 @@ class ChuckerInterceptor internal constructor(
         private val response: Response,
         private val transaction: HttpTransaction
     ) : TeeSource.Callback {
-        override fun onClosed(file: File) {
+
+        override fun onClosed(file: File, totalBytesRead: Long) {
             val buffer = try {
                 readResponseBuffer(file, response.isGzipped)
             } catch (e: IOException) {
                 null
             }
             if (buffer != null) processResponseBody(response, buffer, transaction)
+            transaction.responsePayloadSize = totalBytesRead
             collector.onResponseReceived(transaction)
             file.delete()
         }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -36,7 +36,7 @@ internal class HttpTransaction(
     @ColumnInfo(name = "scheme") var scheme: String?,
     @ColumnInfo(name = "responseTlsVersion") var responseTlsVersion: String?,
     @ColumnInfo(name = "responseCipherSuite") var responseCipherSuite: String?,
-    @ColumnInfo(name = "requestContentLength") var requestContentLength: Long?,
+    @ColumnInfo(name = "requestPayloadSize") var requestPayloadSize: Long?,
     @ColumnInfo(name = "requestContentType") var requestContentType: String?,
     @ColumnInfo(name = "requestHeaders") var requestHeaders: String?,
     @ColumnInfo(name = "requestBody") var requestBody: String?,
@@ -44,7 +44,7 @@ internal class HttpTransaction(
     @ColumnInfo(name = "responseCode") var responseCode: Int?,
     @ColumnInfo(name = "responseMessage") var responseMessage: String?,
     @ColumnInfo(name = "error") var error: String?,
-    @ColumnInfo(name = "responseContentLength") var responseContentLength: Long?,
+    @ColumnInfo(name = "responsePayloadSize") var responsePayloadSize: Long?,
     @ColumnInfo(name = "responseContentType") var responseContentType: String?,
     @ColumnInfo(name = "responseHeaders") var responseHeaders: String?,
     @ColumnInfo(name = "responseBody") var responseBody: String?,
@@ -65,14 +65,14 @@ internal class HttpTransaction(
         scheme = null,
         responseTlsVersion = null,
         responseCipherSuite = null,
-        requestContentLength = null,
+        requestPayloadSize = null,
         requestContentType = null,
         requestHeaders = null,
         requestBody = null,
         responseCode = null,
         responseMessage = null,
         error = null,
-        responseContentLength = null,
+        responsePayloadSize = null,
         responseContentType = null,
         responseHeaders = null,
         responseBody = null,
@@ -102,15 +102,15 @@ internal class HttpTransaction(
         get() = tookMs?.let { "$it ms" }
 
     val requestSizeString: String
-        get() = formatBytes(requestContentLength ?: 0)
+        get() = formatBytes(requestPayloadSize ?: 0)
 
     val responseSizeString: String?
-        get() = responseContentLength?.let { formatBytes(it) }
+        get() = responsePayloadSize?.let { formatBytes(it) }
 
     val totalSizeString: String
         get() {
-            val reqBytes = requestContentLength ?: 0
-            val resBytes = responseContentLength ?: 0
+            val reqBytes = requestPayloadSize ?: 0
+            val resBytes = responsePayloadSize ?: 0
             return formatBytes(reqBytes + resBytes)
         }
 
@@ -251,7 +251,7 @@ internal class HttpTransaction(
             (scheme == other.scheme) &&
             (responseTlsVersion == other.responseTlsVersion) &&
             (responseCipherSuite == other.responseCipherSuite) &&
-            (requestContentLength == other.requestContentLength) &&
+            (requestPayloadSize == other.requestPayloadSize) &&
             (requestContentType == other.requestContentType) &&
             (requestHeaders == other.requestHeaders) &&
             (requestBody == other.requestBody) &&
@@ -259,7 +259,7 @@ internal class HttpTransaction(
             (responseCode == other.responseCode) &&
             (responseMessage == other.responseMessage) &&
             (error == other.error) &&
-            (responseContentLength == other.responseContentLength) &&
+            (responsePayloadSize == other.responsePayloadSize) &&
             (responseContentType == other.responseContentType) &&
             (responseHeaders == other.responseHeaders) &&
             (responseBody == other.responseBody) &&

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -20,8 +20,8 @@ internal class HttpTransactionTuple(
     @ColumnInfo(name = "path") var path: String?,
     @ColumnInfo(name = "scheme") var scheme: String?,
     @ColumnInfo(name = "responseCode") var responseCode: Int?,
-    @ColumnInfo(name = "requestContentLength") var requestContentLength: Long?,
-    @ColumnInfo(name = "responseContentLength") var responseContentLength: Long?,
+    @ColumnInfo(name = "requestPayloadSize") var requestPayloadSize: Long?,
+    @ColumnInfo(name = "responsePayloadSize") var responsePayloadSize: Long?,
     @ColumnInfo(name = "error") var error: String?
 ) {
     val isSsl: Boolean get() = scheme.equals("https", ignoreCase = true)
@@ -37,8 +37,8 @@ internal class HttpTransactionTuple(
 
     val totalSizeString: String
         get() {
-            val reqBytes = requestContentLength ?: 0
-            val resBytes = responseContentLength ?: 0
+            val reqBytes = requestPayloadSize ?: 0
+            val resBytes = responsePayloadSize ?: 0
             return formatBytes(reqBytes + resBytes)
         }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
@@ -7,7 +7,7 @@ import androidx.room.RoomDatabase
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.RecordedThrowable
 
-@Database(entities = [RecordedThrowable::class, HttpTransaction::class], version = 3, exportSchema = false)
+@Database(entities = [RecordedThrowable::class, HttpTransaction::class], version = 4, exportSchema = false)
 internal abstract class ChuckerDatabase : RoomDatabase() {
 
     abstract fun throwableDao(): RecordedThrowableDao

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -14,14 +14,14 @@ internal interface HttpTransactionDao {
 
     @Query(
         "SELECT id, requestDate, tookMs, protocol, method, host, " +
-            "path, scheme, responseCode, requestContentLength, responseContentLength, error FROM " +
+            "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error FROM " +
             "transactions ORDER BY requestDate DESC"
     )
     fun getSortedTuples(): LiveData<List<HttpTransactionTuple>>
 
     @Query(
         "SELECT id, requestDate, tookMs, protocol, method, host, " +
-            "path, scheme, responseCode, requestContentLength, responseContentLength, error FROM " +
+            "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error FROM " +
             "transactions WHERE responseCode LIKE :codeQuery AND path LIKE :pathQuery " +
             "ORDER BY requestDate DESC"
     )

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
@@ -29,7 +29,7 @@ internal fun Response.hasBody(): Boolean {
     return ((contentLength > 0) || isChunked)
 }
 
-internal val Response.contentLength: Long
+private val Response.contentLength: Long
     get() {
         return this.header("Content-Length")?.toLongOrNull() ?: -1L
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
@@ -73,7 +73,7 @@ internal class TeeSource(
         upstream.close()
         if (!isClosed) {
             isClosed = true
-            callback.onClosed(sideChannel)
+            callback.onClosed(sideChannel, totalBytesRead)
         }
     }
 
@@ -90,10 +90,11 @@ internal class TeeSource(
     interface Callback {
         /**
          * Called when the upstream was closed. All read bytes are copied to the [file].
-         * This does not mean that the content of a [file] is valid. Only that the user
-         * is done with the reading process.
+         * This does not mean that the content of the [file] is valid. Only that the user
+         * is done with the reading process. [totalBytesRead] is the exact amount of data
+         * that the client downloaded even if the [file] is corrupted.
          */
-        fun onClosed(file: File)
+        fun onClosed(file: File, totalBytesRead: Long)
 
         /**
          * Called when an exception was thrown while reading bytes from the upstream

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
@@ -83,7 +83,7 @@ internal class TeeSource(
         if (!isFailure) {
             isFailure = true
             sideStream.close()
-            callback.onFailure(exception, sideChannel)
+            callback.onFailure(sideChannel, exception)
         }
     }
 
@@ -100,6 +100,6 @@ internal class TeeSource(
          * Called when an exception was thrown while reading bytes from the upstream
          * or when writing to a side channel file fails. Any read bytes are available in a [file].
          */
-        fun onFailure(exception: IOException, file: File)
+        fun onFailure(file: File, exception: IOException)
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TeeSource.kt
@@ -90,7 +90,7 @@ internal class TeeSource(
     interface Callback {
         /**
          * Called when the upstream was closed. All read bytes are copied to the [file].
-         * This does not mean that the content of the [file] is valid. Only that the user
+         * This does not mean that the content of the [file] is valid. Only that the client
          * is done with the reading process. [totalBytesRead] is the exact amount of data
          * that the client downloaded even if the [file] is corrupted.
          */

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -158,17 +158,17 @@ internal class TransactionPayloadFragment :
     private fun shouldShowSaveIcon(transaction: HttpTransaction?) = when {
         // SAF is not available on pre-Kit Kat so let's hide the icon.
         (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) -> false
-        (payloadType == PayloadType.REQUEST) -> (0L != (transaction?.requestContentLength))
-        (payloadType == PayloadType.RESPONSE) -> (0L != (transaction?.responseContentLength))
+        (payloadType == PayloadType.REQUEST) -> (0L != (transaction?.requestPayloadSize))
+        (payloadType == PayloadType.RESPONSE) -> (0L != (transaction?.responsePayloadSize))
         else -> true
     }
 
     private fun shouldShowSearchIcon(transaction: HttpTransaction?) = when (payloadType) {
         PayloadType.REQUEST -> {
-            (true == transaction?.isRequestBodyPlainText) && (0L != (transaction.requestContentLength))
+            (true == transaction?.isRequestBodyPlainText) && (0L != (transaction.requestPayloadSize))
         }
         PayloadType.RESPONSE -> {
-            (true == transaction?.isResponseBodyPlainText) && (0L != (transaction.responseContentLength))
+            (true == transaction?.isResponseBodyPlainText) && (0L != (transaction.responsePayloadSize))
         }
     }
 

--- a/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
@@ -12,10 +12,10 @@ import okhttp3.Response
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicLong
 
-internal data class ChuckerInterceptorDelegate(
-    private val fileFactory: FileFactory,
-    private val maxContentLength: Long = 250000L,
-    private val headersToRedact: Set<String> = emptySet()
+internal class ChuckerInterceptorDelegate(
+    fileFactory: FileFactory,
+    maxContentLength: Long = 250000L,
+    headersToRedact: Set<String> = emptySet()
 ) : Interceptor {
     private val idGenerator = AtomicLong()
     private val transactions = CopyOnWriteArrayList<HttpTransaction>()

--- a/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
@@ -12,10 +12,10 @@ import okhttp3.Response
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicLong
 
-internal class ChuckerInterceptorDelegate(
-    fileFactory: FileFactory,
-    maxContentLength: Long = 250000L,
-    headersToRedact: Set<String> = emptySet()
+internal data class ChuckerInterceptorDelegate(
+    private val fileFactory: FileFactory,
+    private val maxContentLength: Long = 250000L,
+    private val headersToRedact: Set<String> = emptySet()
 ) : Interceptor {
     private val idGenerator = AtomicLong()
     private val transactions = CopyOnWriteArrayList<HttpTransaction>()

--- a/library/src/test/java/com/chuckerteam/chucker/TestTransactionFactory.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/TestTransactionFactory.kt
@@ -19,7 +19,7 @@ object TestTransactionFactory {
             scheme = "",
             responseTlsVersion = "",
             responseCipherSuite = "",
-            requestContentLength = 1000L,
+            requestPayloadSize = 1000L,
             requestContentType = "application/json",
             requestHeaders = null,
             requestBody = null,
@@ -27,7 +27,7 @@ object TestTransactionFactory {
             responseCode = 200,
             responseMessage = "OK",
             error = null,
-            responseContentLength = 1000L,
+            responsePayloadSize = 1000L,
             responseContentType = "application/json",
             responseHeaders = null,
             responseBody =

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
@@ -56,22 +56,22 @@ class HttpTransactionTupleTest {
     fun totalSizeHandlesNulls() {
         assertThat(
             createTuple(
-                requestContentLength = null,
-                responseContentLength = null
+                requestPayloadSize = null,
+                responsePayloadSize = null
             ).totalSizeString
         ).isEqualTo("0 B")
 
         assertThat(
             createTuple(
-                requestContentLength = 0,
-                responseContentLength = null
+                requestPayloadSize = 0,
+                responsePayloadSize = null
             ).totalSizeString
         ).isEqualTo("0 B")
 
         assertThat(
             createTuple(
-                requestContentLength = null,
-                responseContentLength = 0
+                requestPayloadSize = null,
+                responsePayloadSize = 0
             ).totalSizeString
         ).isEqualTo("0 B")
     }
@@ -80,8 +80,8 @@ class HttpTransactionTupleTest {
     fun totalSize() {
         assertThat(
             createTuple(
-                requestContentLength = 123,
-                responseContentLength = 456
+                requestPayloadSize = 123,
+                responsePayloadSize = 456
             ).totalSizeString
         ).isEqualTo("579 B")
     }
@@ -116,8 +116,8 @@ class HttpTransactionTupleTest {
         path: String? = null,
         scheme: String? = null,
         responseCode: Int? = null,
-        requestContentLength: Long? = null,
-        responseContentLength: Long? = null,
+        requestPayloadSize: Long? = null,
+        responsePayloadSize: Long? = null,
         error: String? = null
     ) = HttpTransactionTuple(
         id,
@@ -129,8 +129,8 @@ class HttpTransactionTupleTest {
         path,
         scheme,
         responseCode,
-        requestContentLength,
-        responseContentLength,
+        requestPayloadSize,
+        responsePayloadSize,
         error
     )
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/TransactionTestUtils.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/TransactionTestUtils.kt
@@ -13,7 +13,7 @@ internal fun createRequest(path: String = ""): HttpTransaction =
         requestDate = 300L
         method = "GET"
         requestContentType = "text/plain"
-        requestContentLength = 0L
+        requestPayloadSize = 0L
         requestBody = randomString()
     }
 
@@ -24,7 +24,7 @@ internal fun HttpTransaction.withResponseData(): HttpTransaction = this.apply {
     tookMs = 21L
     responseTlsVersion = randomString()
     responseCipherSuite = randomString()
-    responseContentLength = 0L
+    responsePayloadSize = 0L
     requestContentType = randomString()
     responseMessage = randomString()
     responseBody = randomString()
@@ -62,8 +62,8 @@ internal fun assertTuple(
     assertThat(actual?.path).isEqualTo(expected.path)
     assertThat(actual?.scheme).isEqualTo(expected.scheme)
     assertThat(actual?.responseCode).isEqualTo(expected.responseCode)
-    assertThat(actual?.requestContentLength).isEqualTo(expected.requestContentLength)
-    assertThat(actual?.responseContentLength).isEqualTo(expected.responseContentLength)
+    assertThat(actual?.requestPayloadSize).isEqualTo(expected.requestPayloadSize)
+    assertThat(actual?.responsePayloadSize).isEqualTo(expected.responsePayloadSize)
     assertThat(actual?.error).isEqualTo(expected.error)
 }
 
@@ -82,7 +82,7 @@ internal fun assertTransaction(
     assertThat(actual?.requestDate).isEqualTo(expected.requestDate)
     assertThat(actual?.method).isEqualTo(expected.method)
     assertThat(actual?.requestContentType).isEqualTo(expected.requestContentType)
-    assertThat(actual?.requestContentLength).isEqualTo(expected.requestContentLength)
+    assertThat(actual?.requestPayloadSize).isEqualTo(expected.requestPayloadSize)
     assertThat(actual?.requestBody).isEqualTo(expected.requestBody)
     assertThat(actual?.responseHeaders).isEqualTo(expected.responseHeaders)
     assertThat(actual?.responseCode).isEqualTo(expected.responseCode)
@@ -90,7 +90,7 @@ internal fun assertTransaction(
     assertThat(actual?.tookMs).isEqualTo(expected.tookMs)
     assertThat(actual?.responseTlsVersion).isEqualTo(expected.responseTlsVersion)
     assertThat(actual?.responseCipherSuite).isEqualTo(expected.responseCipherSuite)
-    assertThat(actual?.responseContentLength).isEqualTo(expected.responseContentLength)
+    assertThat(actual?.responsePayloadSize).isEqualTo(expected.responsePayloadSize)
     assertThat(actual?.requestContentType).isEqualTo(expected.requestContentType)
     assertThat(actual?.responseMessage).isEqualTo(expected.responseMessage)
     assertThat(actual?.responseBody).isEqualTo(expected.responseBody)

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
@@ -66,7 +66,7 @@ class HttpTransactionDatabaseRepositoryTest {
             assertThat(it?.requestDate).isEqualTo(data.requestDate)
             assertThat(it?.method).isEqualTo(data.method)
             assertThat(it?.requestContentType).isEqualTo(data.requestContentType)
-            assertThat(it?.requestContentLength).isEqualTo(data.requestContentLength)
+            assertThat(it?.requestPayloadSize).isEqualTo(data.requestPayloadSize)
         }
     }
 
@@ -88,7 +88,7 @@ class HttpTransactionDatabaseRepositoryTest {
             assertThat(it?.requestDate).isEqualTo(data.requestDate)
             assertThat(it?.method).isEqualTo(data.method)
             assertThat(it?.requestContentType).isEqualTo(data.requestContentType)
-            assertThat(it?.requestContentLength).isEqualTo(data.requestContentLength)
+            assertThat(it?.requestPayloadSize).isEqualTo(data.requestPayloadSize)
         }
     }
 

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -63,7 +63,7 @@ class HttpTransactionDaoTest {
             assertThat(stringValue("scheme")).isEqualTo(data.scheme)
             assertThat(stringValue("responseTlsVersion")).isEqualTo(data.responseTlsVersion)
             assertThat(stringValue("responseCipherSuite")).isEqualTo(data.responseCipherSuite)
-            assertThat(longValue("requestContentLength")).isEqualTo(data.requestContentLength)
+            assertThat(longValue("requestPayloadSize")).isEqualTo(data.requestPayloadSize)
             assertThat(stringValue("requestContentType")).isEqualTo(data.requestContentType)
             assertThat(stringValue("responseMessage")).isEqualTo(data.responseMessage)
             assertThat(stringValue("responseBody")).isEqualTo(data.responseBody)

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
@@ -11,30 +11,6 @@ import org.junit.jupiter.api.Test
 class OkHttpUtilsTest {
 
     @Test
-    fun contentLength_withNoHeader_returnsInvalidValue() {
-        val mockResponse = mockk<Response>()
-        every { mockResponse.header("Content-Length") } returns null
-
-        assertThat(mockResponse.contentLength).isEqualTo(-1)
-    }
-
-    @Test
-    fun contentLength_withZeroLength_returnsZero() {
-        val mockResponse = mockk<Response>()
-        every { mockResponse.header("Content-Length") } returns "0"
-
-        assertThat(mockResponse.contentLength).isEqualTo(0L)
-    }
-
-    @Test
-    fun contentLength_withRealLength_returnsValue() {
-        val mockResponse = mockk<Response>()
-        every { mockResponse.header("Content-Length") } returns "42"
-
-        assertThat(mockResponse.contentLength).isEqualTo(42L)
-    }
-
-    @Test
     fun isChunked_withNotChunked() {
         val mockResponse = mockk<Response>()
         every { mockResponse.header("Transfer-Encoding") } returns "gzip"

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
@@ -179,7 +179,7 @@ class TeeSourceTest {
             this.file = file
         }
 
-        override fun onFailure(exception: IOException, file: File) {
+        override fun onFailure(file: File, exception: IOException) {
             this.exception = exception
             this.file = file
         }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
@@ -174,7 +174,7 @@ class TeeSourceTest {
         var isSuccess = false
             private set
 
-        override fun onClosed(file: File) {
+        override fun onClosed(file: File, totalBytesRead: Long) {
             isSuccess = true
             this.file = file
         }


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

| Before | After |
| --- | --- |
| ![Screenshot_20200719-064434](https://user-images.githubusercontent.com/30936061/87867490-878da480-c98d-11ea-808c-8ba16b2b4c07.jpg) | ![Screenshot_20200719-064034](https://user-images.githubusercontent.com/30936061/87867492-89576800-c98d-11ea-8087-fb4c399d4f8b.jpg) |

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an open issue - #209. Also, recently the community asked for it.

## :pencil: Changes
<!-- Which code did you change? How? -->

Two main changes. I redesigned a little bit DB entities to reflect that they have payload size and not content length. This required a destructive migration. Since this is changed, the field is set after the response read is done by `ChuckerInterceptor` and it does not rely on the `Content-Length` header.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Run the sample app. Responses without the `Content-Length` headers should display now payload size correctly. Also, some tests were written.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Closes #209.
