### PR TITLE
Add sample for partial body download.

### DIFF
--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinApi.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinApi.kt
@@ -16,70 +16,70 @@ import retrofit2.http.Query
 @Suppress("TooManyFunctions")
 internal interface HttpBinApi {
     @GET("/get")
-    fun get(): Call<Void>
+    fun get(): Call<Any?>
 
     @POST("/post")
-    fun post(@Body body: Data): Call<Void>
+    fun post(@Body body: Data): Call<Any?>
 
     @PATCH("/patch")
-    fun patch(@Body body: Data): Call<Void>
+    fun patch(@Body body: Data): Call<Any?>
 
     @PUT("/put")
-    fun put(@Body body: Data): Call<Void>
+    fun put(@Body body: Data): Call<Any?>
 
     @DELETE("/delete")
-    fun delete(): Call<Void>
+    fun delete(): Call<Any?>
 
     @GET("/status/{code}")
-    fun status(@Path("code") code: Int): Call<Void>
+    fun status(@Path("code") code: Int): Call<Any?>
 
     @GET("/stream/{lines}")
-    fun stream(@Path("lines") lines: Int): Call<Void>
+    fun stream(@Path("lines") lines: Int): Call<Any?>
 
     @GET("/stream-bytes/{bytes}")
-    fun streamBytes(@Path("bytes") bytes: Int): Call<Void>
+    fun streamBytes(@Path("bytes") bytes: Int): Call<Any?>
 
     @GET("/delay/{seconds}")
-    fun delay(@Path("seconds") seconds: Int): Call<Void>
+    fun delay(@Path("seconds") seconds: Int): Call<Any?>
 
     @GET("/bearer")
-    fun bearer(@Header("Authorization") token: String): Call<Void>
+    fun bearer(@Header("Authorization") token: String): Call<Any?>
 
     @GET("/redirect-to")
-    fun redirectTo(@Query("url") url: String): Call<Void>
+    fun redirectTo(@Query("url") url: String): Call<Any?>
 
     @GET("/redirect/{times}")
-    fun redirect(@Path("times") times: Int): Call<Void>
+    fun redirect(@Path("times") times: Int): Call<Any?>
 
     @GET("/relative-redirect/{times}")
-    fun redirectRelative(@Path("times") times: Int): Call<Void>
+    fun redirectRelative(@Path("times") times: Int): Call<Any?>
 
     @GET("/absolute-redirect/{times}")
-    fun redirectAbsolute(@Path("times") times: Int): Call<Void>
+    fun redirectAbsolute(@Path("times") times: Int): Call<Any?>
 
     @GET("/image")
-    fun image(@Header("Accept") accept: String): Call<Void>
+    fun image(@Header("Accept") accept: String): Call<Any?>
 
     @GET("/gzip")
-    fun gzip(): Call<Void>
+    fun gzip(): Call<Any?>
 
     @GET("/xml")
-    fun xml(): Call<Void>
+    fun xml(): Call<Any?>
 
     @GET("/encoding/utf8")
-    fun utf8(): Call<Void>
+    fun utf8(): Call<Any?>
 
     @GET("/deflate")
-    fun deflate(): Call<Void>
+    fun deflate(): Call<Any?>
 
     @GET("/cookies/set")
-    fun cookieSet(@Query("k1") value: String): Call<Void>
+    fun cookieSet(@Query("k1") value: String): Call<Any?>
 
     @GET("/basic-auth/{user}/{passwd}")
     fun basicAuth(
         @Path("user") user: String,
         @Path("passwd") passwd: String
-    ): Call<Void>
+    ): Call<Any?>
 
     @GET("/drip")
     fun drip(
@@ -87,20 +87,20 @@ internal interface HttpBinApi {
         @Query("duration") seconds: Int,
         @Query("delay") delay: Int,
         @Query("code") code: Int
-    ): Call<Void>
+    ): Call<Any?>
 
     @GET("/deny")
-    fun deny(): Call<Void>
+    fun deny(): Call<Any?>
 
     @GET("/cache")
-    fun cache(@Header("If-Modified-Since") ifModifiedSince: String): Call<Void>
+    fun cache(@Header("If-Modified-Since") ifModifiedSince: String): Call<Any?>
 
     @GET("/cache/{seconds}")
-    fun cache(@Path("seconds") seconds: Int): Call<Void>
+    fun cache(@Path("seconds") seconds: Int): Call<Any?>
 
     @FormUrlEncoded
     @POST("/post")
-    fun postForm(@Field("key1") value1: String, @Field("key2") value2: String): Call<Void>
+    fun postForm(@Field("key1") value1: String, @Field("key2") value2: String): Call<Any?>
 
     class Data(val thing: String)
 }

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/LargeJson.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/LargeJson.kt
@@ -1,0 +1,908 @@
+package com.chuckerteam.chucker.sample
+
+@Suppress("MaxLineLength")
+internal const val LARGE_JSON =
+"""
+[
+  {
+    "_id": "5f13c367d3d35339e63167dc",
+    "index": 0,
+    "guid": "b575cdb8-a252-45c0-8f9e-9713e5057928",
+    "isActive": false,
+    "balance": "${'$'}3,530.69",
+    "picture": "http://placehold.it/32x32",
+    "age": 29,
+    "eyeColor": "blue",
+    "name": "Hensley Jacobs",
+    "gender": "male",
+    "company": "BEADZZA",
+    "email": "hensleyjacobs@beadzza.com",
+    "phone": "+1 (857) 400-3570",
+    "address": "743 Woodside Avenue, Crumpler, Mississippi, 9135",
+    "about": "Lorem do eiusmod enim do minim eiusmod officia. Minim occaecat anim aute mollit Lorem amet esse deserunt. Enim ut esse eiusmod minim dolore commodo amet id incididunt dolor anim velit. Laboris dolor sint sint commodo consectetur excepteur nisi. Deserunt excepteur consequat do fugiat culpa esse aliquip. Cillum id ipsum exercitation in incididunt reprehenderit ullamco qui sit est. Do elit minim minim nulla proident eu est.\r\n",
+    "registered": "2017-11-10T05:01:03 -01:00",
+    "latitude": 77.351465,
+    "longitude": -31.077751,
+    "tags": [
+      "nisi",
+      "commodo",
+      "nostrud",
+      "dolore",
+      "id",
+      "commodo",
+      "irure"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Janelle Nolan"
+      },
+      {
+        "id": 1,
+        "name": "Ellison Lucas"
+      },
+      {
+        "id": 2,
+        "name": "Reilly Ferrell"
+      }
+    ],
+    "greeting": "Hello, Hensley Jacobs! You have 5 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "5f13c36761e0c371efaa53c9",
+    "index": 1,
+    "guid": "b63c4f98-ed1e-433e-af9e-96593bd018c7",
+    "isActive": true,
+    "balance": "${'$'}1,976.61",
+    "picture": "http://placehold.it/32x32",
+    "age": 40,
+    "eyeColor": "green",
+    "name": "Elizabeth Black",
+    "gender": "female",
+    "company": "ZEDALIS",
+    "email": "elizabethblack@zedalis.com",
+    "phone": "+1 (865) 403-3419",
+    "address": "885 Beaver Street, Haena, Texas, 7594",
+    "about": "Culpa magna occaecat proident ea do labore ut. Amet adipisicing labore exercitation non. Amet sit voluptate pariatur ex tempor est id qui voluptate laborum anim aute. Sint consectetur sit dolor cillum et nulla dolor culpa velit ut.\r\n",
+    "registered": "2018-08-22T04:57:03 -02:00",
+    "latitude": -48.117642,
+    "longitude": 70.492282,
+    "tags": [
+      "ut",
+      "minim",
+      "officia",
+      "nostrud",
+      "ipsum",
+      "et",
+      "ea"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Maribel Barnes"
+      },
+      {
+        "id": 1,
+        "name": "Craig Reilly"
+      },
+      {
+        "id": 2,
+        "name": "Brittany Mckee"
+      }
+    ],
+    "greeting": "Hello, Elizabeth Black! You have 1 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "5f13c367cdec1c37dff8478b",
+    "index": 2,
+    "guid": "556877bd-571a-4509-b577-04fcc011232d",
+    "isActive": true,
+    "balance": "${'$'}2,725.61",
+    "picture": "http://placehold.it/32x32",
+    "age": 26,
+    "eyeColor": "brown",
+    "name": "Burke Leblanc",
+    "gender": "male",
+    "company": "PROWASTE",
+    "email": "burkeleblanc@prowaste.com",
+    "phone": "+1 (826) 595-2600",
+    "address": "107 Kings Place, Sunnyside, South Dakota, 6577",
+    "about": "Ex cillum reprehenderit dolor dolore mollit dolor labore fugiat minim aute pariatur quis occaecat. Ullamco consectetur dolore nulla amet aliqua incididunt occaecat et sint do veniam. Elit consequat sint eiusmod pariatur nisi in sit nisi non minim eiusmod ut sit ea. Exercitation ea voluptate in commodo aliqua culpa. Exercitation ullamco aliqua id cillum fugiat adipisicing fugiat. Ex amet labore veniam Lorem nisi adipisicing aliquip pariatur nisi nulla commodo quis non anim.\r\n",
+    "registered": "2020-05-22T12:34:20 -02:00",
+    "latitude": -13.905999,
+    "longitude": 144.904194,
+    "tags": [
+      "id",
+      "minim",
+      "ea",
+      "ut",
+      "aliquip",
+      "deserunt",
+      "proident"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Tina Ramsey"
+      },
+      {
+        "id": 1,
+        "name": "Stevens Blanchard"
+      },
+      {
+        "id": 2,
+        "name": "Lowe Armstrong"
+      }
+    ],
+    "greeting": "Hello, Burke Leblanc! You have 10 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "5f13c3676181a8f77bf10448",
+    "index": 3,
+    "guid": "cf3f1e12-a5b3-4a2f-a836-4bbaa4f82794",
+    "isActive": false,
+    "balance": "${'$'}1,073.80",
+    "picture": "http://placehold.it/32x32",
+    "age": 29,
+    "eyeColor": "blue",
+    "name": "Erin Holman",
+    "gender": "female",
+    "company": "BLURRYBUS",
+    "email": "erinholman@blurrybus.com",
+    "phone": "+1 (816) 593-2361",
+    "address": "456 Lynch Street, Salix, Idaho, 1372",
+    "about": "Sunt labore occaecat ex in ex minim incididunt sunt nulla deserunt et. Ipsum in officia irure cillum aliquip consectetur irure proident amet minim enim deserunt. Qui laborum aliquip id nostrud laborum. Reprehenderit elit ipsum minim ex fugiat nostrud sint excepteur mollit mollit eiusmod id. Enim sunt reprehenderit ad fugiat aliquip id duis Lorem duis tempor sint qui dolor eiusmod. Aute occaecat culpa aliquip qui eiusmod minim officia laboris officia cillum occaecat sit.\r\n",
+    "registered": "2016-02-26T06:55:18 -01:00",
+    "latitude": -31.497355,
+    "longitude": 13.886871,
+    "tags": [
+      "anim",
+      "id",
+      "cillum",
+      "nulla",
+      "exercitation",
+      "reprehenderit",
+      "fugiat"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Mason Ratliff"
+      },
+      {
+        "id": 1,
+        "name": "Grant Byers"
+      },
+      {
+        "id": 2,
+        "name": "Nanette Kirby"
+      }
+    ],
+    "greeting": "Hello, Erin Holman! You have 10 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "5f13c367e4fb8be58185f0f9",
+    "index": 4,
+    "guid": "b0f3362c-a455-47b4-a0ec-35e1f5e16daa",
+    "isActive": true,
+    "balance": "${'$'}2,453.43",
+    "picture": "http://placehold.it/32x32",
+    "age": 36,
+    "eyeColor": "brown",
+    "name": "Abigail Andrews",
+    "gender": "female",
+    "company": "EWEVILLE",
+    "email": "abigailandrews@eweville.com",
+    "phone": "+1 (848) 410-2743",
+    "address": "572 Banner Avenue, Kenvil, New Mexico, 3977",
+    "about": "Ut irure nisi ullamco mollit culpa aliqua Lorem adipisicing aliqua commodo eiusmod excepteur laborum ipsum. Reprehenderit ullamco sint dolore labore laborum officia deserunt do. Qui minim commodo aliqua eu quis et proident Lorem ut sunt officia sunt sit adipisicing.\r\n",
+    "registered": "2014-05-03T06:46:56 -02:00",
+    "latitude": 35.255057,
+    "longitude": 125.363119,
+    "tags": [
+      "voluptate",
+      "officia",
+      "culpa",
+      "dolore",
+      "magna",
+      "sint",
+      "aliqua"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Sybil Valenzuela"
+      },
+      {
+        "id": 1,
+        "name": "Milagros Johnston"
+      },
+      {
+        "id": 2,
+        "name": "Stuart Howe"
+      }
+    ],
+    "greeting": "Hello, Abigail Andrews! You have 1 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "5f13c367357f06110afe8664",
+    "index": 5,
+    "guid": "b67ca790-dba9-49e2-9486-5fd2174b6aff",
+    "isActive": false,
+    "balance": "${'$'}2,810.77",
+    "picture": "http://placehold.it/32x32",
+    "age": 30,
+    "eyeColor": "blue",
+    "name": "Rosanne Peters",
+    "gender": "female",
+    "company": "NORSUL",
+    "email": "rosannepeters@norsul.com",
+    "phone": "+1 (824) 407-2173",
+    "address": "703 Keen Court, Dodge, West Virginia, 5496",
+    "about": "Velit dolore labore Lorem excepteur nostrud minim velit. Ex cillum anim laborum eu esse dolor sunt nisi Lorem. Id ullamco adipisicing ea ex velit. Dolore amet officia culpa velit tempor est qui occaecat esse mollit. Minim culpa magna id qui officia sunt in irure nostrud laboris. Ea ex commodo aute ea veniam.\r\n",
+    "registered": "2016-04-19T04:27:12 -02:00",
+    "latitude": -80.899037,
+    "longitude": -95.317366,
+    "tags": [
+      "ea",
+      "ut",
+      "minim",
+      "excepteur",
+      "esse",
+      "deserunt",
+      "quis"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Helene Whitley"
+      },
+      {
+        "id": 1,
+        "name": "Diana Hughes"
+      },
+      {
+        "id": 2,
+        "name": "Dale Cross"
+      }
+    ],
+    "greeting": "Hello, Rosanne Peters! You have 2 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "5f13c36724409bfc9568cb18",
+    "index": 6,
+    "guid": "388dc333-ddde-4b9c-aa55-e7551d16d6f4",
+    "isActive": false,
+    "balance": "${'$'}2,409.58",
+    "picture": "http://placehold.it/32x32",
+    "age": 24,
+    "eyeColor": "green",
+    "name": "Imogene Mendoza",
+    "gender": "female",
+    "company": "LIMAGE",
+    "email": "imogenemendoza@limage.com",
+    "phone": "+1 (872) 486-2741",
+    "address": "212 Stockton Street, Dellview, New Hampshire, 1496",
+    "about": "Cupidatat velit sit irure magna nulla quis anim laborum commodo eu occaecat. Aliquip consequat commodo ex quis quis. Anim ipsum mollit consequat sint laborum nisi reprehenderit veniam ea. Anim deserunt ipsum consequat irure ullamco commodo est.\r\n",
+    "registered": "2017-08-31T10:34:10 -02:00",
+    "latitude": -77.334894,
+    "longitude": 19.26925,
+    "tags": [
+      "ex",
+      "incididunt",
+      "consectetur",
+      "eiusmod",
+      "nulla",
+      "consequat",
+      "est"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Compton Maldonado"
+      },
+      {
+        "id": 1,
+        "name": "Wiggins Carlson"
+      },
+      {
+        "id": 2,
+        "name": "Dianna Parsons"
+      }
+    ],
+    "greeting": "Hello, Imogene Mendoza! You have 8 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "5f13c3678b8d05b8f2812dab",
+    "index": 7,
+    "guid": "5c016786-ad0f-4654-a612-473202404796",
+    "isActive": false,
+    "balance": "${'$'}1,710.24",
+    "picture": "http://placehold.it/32x32",
+    "age": 39,
+    "eyeColor": "brown",
+    "name": "Walls Beard",
+    "gender": "male",
+    "company": "QUILITY",
+    "email": "wallsbeard@quility.com",
+    "phone": "+1 (935) 465-2704",
+    "address": "701 Rugby Road, Northchase, Ohio, 5377",
+    "about": "In ex cillum ullamco tempor magna do ad et ut irure aliqua dolor magna. Excepteur occaecat officia officia elit eu cupidatat. Eiusmod et exercitation ipsum consectetur sunt ea adipisicing laborum officia do magna.\r\n",
+    "registered": "2017-07-01T02:03:56 -02:00",
+    "latitude": -0.118375,
+    "longitude": 121.399146,
+    "tags": [
+      "occaecat",
+      "do",
+      "labore",
+      "veniam",
+      "ut",
+      "consequat",
+      "et"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "April Stokes"
+      },
+      {
+        "id": 1,
+        "name": "Sullivan Oneil"
+      },
+      {
+        "id": 2,
+        "name": "Alyce Cook"
+      }
+    ],
+    "greeting": "Hello, Walls Beard! You have 7 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "5f13c3674c2857e57dd57e5a",
+    "index": 8,
+    "guid": "ad6017d1-d46c-4d45-abc1-4e92a798ce78",
+    "isActive": false,
+    "balance": "${'$'}1,271.95",
+    "picture": "http://placehold.it/32x32",
+    "age": 37,
+    "eyeColor": "green",
+    "name": "Kellie Rush",
+    "gender": "female",
+    "company": "EXPOSA",
+    "email": "kellierush@exposa.com",
+    "phone": "+1 (988) 581-3143",
+    "address": "983 Beaumont Street, Swartzville, Guam, 3460",
+    "about": "Non sint labore dolor magna quis eu dolore sit aliquip. Esse excepteur aliquip eu culpa commodo quis qui culpa. Et elit nostrud nostrud reprehenderit. Eu excepteur laboris adipisicing in adipisicing Lorem ex. Irure elit officia in sint veniam est. Nisi eiusmod do eiusmod reprehenderit excepteur enim magna commodo est sunt. Duis cupidatat proident nulla enim dolor laborum ullamco consectetur in dolor.\r\n",
+    "registered": "2015-01-15T11:56:41 -01:00",
+    "latitude": 22.66708,
+    "longitude": -59.930754,
+    "tags": [
+      "anim",
+      "officia",
+      "minim",
+      "proident",
+      "voluptate",
+      "adipisicing",
+      "cillum"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Reyna Wolfe"
+      },
+      {
+        "id": 1,
+        "name": "Watson Horn"
+      },
+      {
+        "id": 2,
+        "name": "Freda Poole"
+      }
+    ],
+    "greeting": "Hello, Kellie Rush! You have 2 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "5f13c3673ca1ce11645c3fbb",
+    "index": 9,
+    "guid": "e34c3437-8954-49cd-8471-a2b496dcdebb",
+    "isActive": true,
+    "balance": "${'$'}1,892.96",
+    "picture": "http://placehold.it/32x32",
+    "age": 30,
+    "eyeColor": "blue",
+    "name": "Lena Bass",
+    "gender": "female",
+    "company": "FLOTONIC",
+    "email": "lenabass@flotonic.com",
+    "phone": "+1 (808) 491-2346",
+    "address": "547 Haring Street, Oberlin, Delaware, 235",
+    "about": "Non sint tempor culpa aute. Velit et cupidatat deserunt voluptate minim labore esse nisi amet veniam. Est cillum nisi enim ullamco nisi qui aliquip. Esse eu qui dolor tempor tempor aliqua aliqua ea laborum est ad laboris enim. Ipsum ex mollit nostrud laboris sint amet cupidatat sunt reprehenderit consequat tempor. Non reprehenderit velit consectetur occaecat magna qui incididunt exercitation dolore adipisicing id ipsum.\r\n",
+    "registered": "2016-02-23T06:26:08 -01:00",
+    "latitude": -36.66437,
+    "longitude": -9.375657,
+    "tags": [
+      "adipisicing",
+      "nisi",
+      "mollit",
+      "irure",
+      "sunt",
+      "velit",
+      "minim"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Shaw Cline"
+      },
+      {
+        "id": 1,
+        "name": "Lynnette Cannon"
+      },
+      {
+        "id": 2,
+        "name": "Chang Fowler"
+      }
+    ],
+    "greeting": "Hello, Lena Bass! You have 7 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "5f13c367b4375a59d354d9df",
+    "index": 10,
+    "guid": "4fdcbbe5-4fb9-48b9-a0fd-dde0814acb77",
+    "isActive": false,
+    "balance": "${'$'}3,768.02",
+    "picture": "http://placehold.it/32x32",
+    "age": 27,
+    "eyeColor": "green",
+    "name": "Veronica Pittman",
+    "gender": "female",
+    "company": "COWTOWN",
+    "email": "veronicapittman@cowtown.com",
+    "phone": "+1 (834) 560-3829",
+    "address": "791 Nevins Street, Wells, District Of Columbia, 5576",
+    "about": "Lorem commodo minim reprehenderit ea elit laborum ad laborum ex. Laboris ea in aliquip ad. Tempor id Lorem pariatur reprehenderit elit labore do ad anim.\r\n",
+    "registered": "2017-01-16T06:29:51 -01:00",
+    "latitude": 81.584164,
+    "longitude": -107.884083,
+    "tags": [
+      "sit",
+      "eu",
+      "id",
+      "minim",
+      "elit",
+      "velit",
+      "elit"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Wyatt Gamble"
+      },
+      {
+        "id": 1,
+        "name": "Cara Martin"
+      },
+      {
+        "id": 2,
+        "name": "Nannie Ray"
+      }
+    ],
+    "greeting": "Hello, Veronica Pittman! You have 7 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "5f13c367d44aedbdae77115a",
+    "index": 11,
+    "guid": "283afcea-83b4-4559-8e99-d72dcea731e8",
+    "isActive": true,
+    "balance": "${'$'}1,494.34",
+    "picture": "http://placehold.it/32x32",
+    "age": 30,
+    "eyeColor": "blue",
+    "name": "Decker Joyner",
+    "gender": "male",
+    "company": "ZIALACTIC",
+    "email": "deckerjoyner@zialactic.com",
+    "phone": "+1 (985) 584-2090",
+    "address": "274 Sandford Street, Caroline, Tennessee, 7163",
+    "about": "Tempor ex ipsum sit adipisicing nostrud proident duis dolore nostrud culpa dolore aliqua. Culpa duis commodo cillum eu sit. Enim veniam reprehenderit esse dolor dolor fugiat ut cillum. Do voluptate esse do velit aute minim velit excepteur qui eu. Aliqua mollit qui ut non et nulla nulla non anim officia duis est ex exercitation.\r\n",
+    "registered": "2014-06-27T09:00:18 -02:00",
+    "latitude": -55.112909,
+    "longitude": 24.764329,
+    "tags": [
+      "et",
+      "consequat",
+      "est",
+      "id",
+      "excepteur",
+      "in",
+      "tempor"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Allyson Justice"
+      },
+      {
+        "id": 1,
+        "name": "Vanessa Lane"
+      },
+      {
+        "id": 2,
+        "name": "Marci Cochran"
+      }
+    ],
+    "greeting": "Hello, Decker Joyner! You have 4 unread messages.",
+    "favoriteFruit": "apple"
+  },
+  {
+    "_id": "5f13c367c4991920063e612a",
+    "index": 12,
+    "guid": "a48465f2-a117-47bd-973f-382817effff1",
+    "isActive": true,
+    "balance": "${'$'}2,828.07",
+    "picture": "http://placehold.it/32x32",
+    "age": 34,
+    "eyeColor": "brown",
+    "name": "Rosetta Crane",
+    "gender": "female",
+    "company": "CORPORANA",
+    "email": "rosettacrane@corporana.com",
+    "phone": "+1 (809) 594-2432",
+    "address": "750 Dinsmore Place, Gibsonia, Alaska, 5160",
+    "about": "Est proident culpa duis sunt cupidatat culpa occaecat incididunt aliqua amet sit. Esse cillum proident consequat do. Nostrud laboris eu velit cillum proident commodo amet culpa excepteur ea ad laborum. Adipisicing ullamco dolore sint cillum commodo eu velit laboris officia.\r\n",
+    "registered": "2015-01-20T05:16:12 -01:00",
+    "latitude": 19.371373,
+    "longitude": 31.743756,
+    "tags": [
+      "sunt",
+      "reprehenderit",
+      "veniam",
+      "culpa",
+      "ullamco",
+      "voluptate",
+      "in"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Lelia Freeman"
+      },
+      {
+        "id": 1,
+        "name": "Guzman Cleveland"
+      },
+      {
+        "id": 2,
+        "name": "Pam Scott"
+      }
+    ],
+    "greeting": "Hello, Rosetta Crane! You have 9 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "5f13c367f69a2f66793ee7e0",
+    "index": 13,
+    "guid": "8f2b40df-8392-46d8-8c1f-4f18236802eb",
+    "isActive": true,
+    "balance": "${'$'}3,474.41",
+    "picture": "http://placehold.it/32x32",
+    "age": 21,
+    "eyeColor": "green",
+    "name": "Brandi Galloway",
+    "gender": "female",
+    "company": "TYPHONICA",
+    "email": "brandigalloway@typhonica.com",
+    "phone": "+1 (892) 537-3062",
+    "address": "116 Veterans Avenue, Drytown, Missouri, 439",
+    "about": "Amet ea ipsum eiusmod ipsum. Dolore reprehenderit magna ex tempor pariatur reprehenderit. Nisi minim cupidatat nisi ullamco sint irure duis ad deserunt ex nulla proident aute. Duis occaecat enim nulla do amet ullamco labore eu.\r\n",
+    "registered": "2017-11-25T08:08:17 -01:00",
+    "latitude": 23.777705,
+    "longitude": 66.242691,
+    "tags": [
+      "elit",
+      "est",
+      "esse",
+      "voluptate",
+      "anim",
+      "pariatur",
+      "do"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Meyers Castro"
+      },
+      {
+        "id": 1,
+        "name": "Miranda Mason"
+      },
+      {
+        "id": 2,
+        "name": "Kerri Pennington"
+      }
+    ],
+    "greeting": "Hello, Brandi Galloway! You have 3 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "5f13c367fed875c15657e648",
+    "index": 14,
+    "guid": "6a19331e-ab12-4bc7-bf65-72ecacfb97b6",
+    "isActive": true,
+    "balance": "${'$'}3,836.66",
+    "picture": "http://placehold.it/32x32",
+    "age": 21,
+    "eyeColor": "green",
+    "name": "Mcintyre Palmer",
+    "gender": "male",
+    "company": "ZILLIDIUM",
+    "email": "mcintyrepalmer@zillidium.com",
+    "phone": "+1 (947) 408-2359",
+    "address": "997 Prospect Place, Fontanelle, Wisconsin, 7962",
+    "about": "Sint adipisicing anim et officia cillum eu culpa adipisicing in aliquip ullamco mollit velit culpa. Laboris ex ut ullamco ea. Cupidatat eu est quis pariatur veniam id laborum. Minim consectetur adipisicing est minim exercitation adipisicing ex anim. Non occaecat adipisicing mollit nulla in culpa esse.\r\n",
+    "registered": "2018-04-28T04:39:29 -02:00",
+    "latitude": -73.15041,
+    "longitude": -41.197536,
+    "tags": [
+      "do",
+      "veniam",
+      "culpa",
+      "sunt",
+      "consectetur",
+      "amet",
+      "nulla"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Blanche Hampton"
+      },
+      {
+        "id": 1,
+        "name": "Randall Joyce"
+      },
+      {
+        "id": 2,
+        "name": "Olson Witt"
+      }
+    ],
+    "greeting": "Hello, Mcintyre Palmer! You have 9 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "5f13c367c82d51404c638285",
+    "index": 15,
+    "guid": "c7a3806d-5b2b-410f-b65d-b5c91b7eefac",
+    "isActive": true,
+    "balance": "${'$'}3,607.01",
+    "picture": "http://placehold.it/32x32",
+    "age": 34,
+    "eyeColor": "blue",
+    "name": "Levine Harmon",
+    "gender": "male",
+    "company": "EXOZENT",
+    "email": "levineharmon@exozent.com",
+    "phone": "+1 (800) 544-2677",
+    "address": "631 Elmwood Avenue, Southview, Federated States Of Micronesia, 4477",
+    "about": "Deserunt excepteur ullamco proident nostrud eiusmod pariatur elit sunt. Proident consectetur laborum officia exercitation id minim tempor anim aliquip elit. Commodo labore do excepteur aute nostrud pariatur. Do cillum id esse et amet. In in non aute labore.\r\n",
+    "registered": "2019-12-26T08:45:04 -01:00",
+    "latitude": 63.987114,
+    "longitude": -131.462186,
+    "tags": [
+      "laboris",
+      "nulla",
+      "minim",
+      "culpa",
+      "nostrud",
+      "nisi",
+      "excepteur"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Horne Cameron"
+      },
+      {
+        "id": 1,
+        "name": "Vaughan Gilbert"
+      },
+      {
+        "id": 2,
+        "name": "Collins Jacobson"
+      }
+    ],
+    "greeting": "Hello, Levine Harmon! You have 2 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "5f13c3672085bf32ad6a2453",
+    "index": 16,
+    "guid": "b9334ae2-5a1b-4f45-9252-84b656e14434",
+    "isActive": true,
+    "balance": "${'$'}2,055.55",
+    "picture": "http://placehold.it/32x32",
+    "age": 38,
+    "eyeColor": "green",
+    "name": "Santos Coffey",
+    "gender": "male",
+    "company": "SILODYNE",
+    "email": "santoscoffey@silodyne.com",
+    "phone": "+1 (842) 401-2567",
+    "address": "245 Voorhies Avenue, Comptche, Arizona, 8766",
+    "about": "Aliqua ipsum exercitation occaecat ullamco consequat incididunt eu do ex minim aliquip. Cillum magna adipisicing consectetur eu enim et incididunt mollit officia ullamco duis. Dolore est ea voluptate in. Laborum id pariatur irure cillum. Dolore aliquip ea nulla enim sit consequat occaecat velit consequat in. Id ut ad laboris voluptate tempor nisi fugiat ea elit non minim ut occaecat et. Elit pariatur exercitation ad qui incididunt ea ex in et occaecat.\r\n",
+    "registered": "2015-06-18T05:17:41 -02:00",
+    "latitude": -50.470103,
+    "longitude": -50.498084,
+    "tags": [
+      "culpa",
+      "aute",
+      "amet",
+      "nostrud",
+      "irure",
+      "quis",
+      "sint"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Norma Le"
+      },
+      {
+        "id": 1,
+        "name": "Melendez Phillips"
+      },
+      {
+        "id": 2,
+        "name": "Mcmahon Spence"
+      }
+    ],
+    "greeting": "Hello, Santos Coffey! You have 9 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "5f13c3676f4455be69c8bee0",
+    "index": 17,
+    "guid": "904c5de5-4156-42de-8aa6-ccd9f07045bc",
+    "isActive": false,
+    "balance": "${'$'}1,399.61",
+    "picture": "http://placehold.it/32x32",
+    "age": 37,
+    "eyeColor": "green",
+    "name": "Lorie Burnett",
+    "gender": "female",
+    "company": "ECRATER",
+    "email": "lorieburnett@ecrater.com",
+    "phone": "+1 (888) 527-3108",
+    "address": "798 Hausman Street, Nile, Indiana, 7584",
+    "about": "Adipisicing ex ad est do. Magna velit sunt aliqua tempor laborum cupidatat. Et pariatur amet sint dolor fugiat. Aliqua enim adipisicing irure officia aliquip anim laboris do pariatur officia. Cillum non nisi elit aliquip qui sint officia proident ullamco elit ut minim esse id. Cupidatat tempor deserunt elit occaecat est. Eiusmod quis adipisicing eiusmod dolore laborum amet quis aute Lorem elit elit.\r\n",
+    "registered": "2014-01-29T02:45:45 -01:00",
+    "latitude": -86.955923,
+    "longitude": 21.147073,
+    "tags": [
+      "laborum",
+      "est",
+      "anim",
+      "deserunt",
+      "sit",
+      "tempor",
+      "irure"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Puckett Gill"
+      },
+      {
+        "id": 1,
+        "name": "Cherry Espinoza"
+      },
+      {
+        "id": 2,
+        "name": "Mejia Schultz"
+      }
+    ],
+    "greeting": "Hello, Lorie Burnett! You have 4 unread messages.",
+    "favoriteFruit": "banana"
+  },
+  {
+    "_id": "5f13c3670151dd3a65608d00",
+    "index": 18,
+    "guid": "224ec48a-c0c7-44b3-a299-6847f5cb9a79",
+    "isActive": true,
+    "balance": "${'$'}3,703.69",
+    "picture": "http://placehold.it/32x32",
+    "age": 31,
+    "eyeColor": "green",
+    "name": "Salazar Hayden",
+    "gender": "male",
+    "company": "XELEGYL",
+    "email": "salazarhayden@xelegyl.com",
+    "phone": "+1 (940) 434-3352",
+    "address": "844 Scholes Street, Caberfae, Alabama, 4780",
+    "about": "Dolor sunt labore exercitation nostrud eiusmod ex labore esse ad sit dolore. Consectetur nulla aliquip cupidatat ad culpa laboris voluptate aute laborum do. Dolor pariatur veniam fugiat aute aliquip cupidatat aliqua laboris irure quis. Do deserunt deserunt excepteur incididunt sint proident cupidatat. Amet ea pariatur et officia ullamco cupidatat. Tempor occaecat dolor qui Lorem elit.\r\n",
+    "registered": "2016-09-07T10:17:40 -02:00",
+    "latitude": 73.91966,
+    "longitude": -43.275109,
+    "tags": [
+      "voluptate",
+      "in",
+      "tempor",
+      "velit",
+      "incididunt",
+      "et",
+      "anim"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Rosalind Saunders"
+      },
+      {
+        "id": 1,
+        "name": "Ronda Crosby"
+      },
+      {
+        "id": 2,
+        "name": "Carney Donaldson"
+      }
+    ],
+    "greeting": "Hello, Salazar Hayden! You have 1 unread messages.",
+    "favoriteFruit": "strawberry"
+  },
+  {
+    "_id": "5f13c367062df9d021856741",
+    "index": 19,
+    "guid": "470ac807-806d-4914-9c2a-af3caf38b624",
+    "isActive": false,
+    "balance": "${'$'}3,439.49",
+    "picture": "http://placehold.it/32x32",
+    "age": 24,
+    "eyeColor": "brown",
+    "name": "Patricia Sanders",
+    "gender": "female",
+    "company": "MELBACOR",
+    "email": "patriciasanders@melbacor.com",
+    "phone": "+1 (895) 547-3843",
+    "address": "208 Ainslie Street, Cornfields, Marshall Islands, 6162",
+    "about": "Ipsum laboris velit quis laboris id nostrud cupidatat sunt. Non et elit in est tempor. Ipsum non excepteur enim mollit veniam nostrud irure. Nisi officia consequat in anim. In ea sunt pariatur incididunt reprehenderit. Dolore deserunt magna eiusmod nulla laboris eu aliqua culpa pariatur fugiat laborum veniam. Occaecat dolor pariatur dolore pariatur tempor duis eu cillum sit non Lorem ipsum.\r\n",
+    "registered": "2015-07-14T11:58:31 -02:00",
+    "latitude": 71.52051,
+    "longitude": 10.079499,
+    "tags": [
+      "ut",
+      "ut",
+      "exercitation",
+      "cillum",
+      "pariatur",
+      "in",
+      "aliquip"
+    ],
+    "friends": [
+      {
+        "id": 0,
+        "name": "Clements Cortez"
+      },
+      {
+        "id": 1,
+        "name": "Vargas Patterson"
+      },
+      {
+        "id": 2,
+        "name": "Elsa Mcneil"
+      }
+    ],
+    "greeting": "Hello, Patricia Sanders! You have 9 unread messages.",
+    "favoriteFruit": "apple"
+  }
+]
+"""


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

![Screenshot_20200719-064819](https://user-images.githubusercontent.com/30936061/87867359-624c6680-c98c-11ea-99a7-e1575c1fe7da.jpg)
![Screenshot_20200719-064832](https://user-images.githubusercontent.com/30936061/87867312-008bfc80-c98c-11ea-9482-39e30ea2cd32.jpg)

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

I wanted to have a sample for a partial download of the content. It is somewhat a follow-up to #384.

## :pencil: Changes
<!-- Which code did you change? How? -->

I added a new call. It uses Postman instead of httpbin. The reason is that httpbin formats the echoed response in a really strange way as it escapes newline and quotation characters. Also, the cool thing about Postman is that it does not have the `Content-Length` header.

Additional things that I changed is the order of interceptors in the sample. Logging interceptor downloads all of the data before the Chucker can do its thing so this made partial reads impossible on the Chucker level. For this reason, I had to change all responses from `Void` to `Any?` in order to make `Retrofit` automatically read whole bodies of responses and not shortcircuit them.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

#384.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Just run the sample and find the request in the list.