### PR TITLE
Do not fail requests when side channel file cannot be used

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -246,7 +246,7 @@ class ChuckerInterceptor internal constructor(
             file.delete()
         }
 
-        override fun onFailure(file: File, exception: IOException) = Unit
+        override fun onFailure(file: File, exception: IOException) = exception.printStackTrace()
 
         private fun readResponseBuffer(responseBody: File, isGzipped: Boolean): Buffer {
             val bufferedSource = Okio.buffer(Okio.source(responseBody))

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.IOException
 import kotlin.random.Random
 
@@ -144,6 +145,21 @@ class TeeSourceTest {
         }
 
         assertThat(teeCallback.fileContent).isEqualTo(testSource.content)
+    }
+
+    @Test
+    fun exceptionWhileCreatingSideChannel_informsOfFailures_inSideChannel(@TempDir tempDir: File) {
+        assertThat(tempDir.deleteRecursively()).isTrue()
+
+        val testFile = File(tempDir, "testFile")
+
+        TeeSource(TestSource(), testFile, teeCallback)
+
+        assertThat(teeCallback.exception).apply {
+            isInstanceOf(IOException::class.java)
+            hasMessageThat().isEqualTo("Failed to use file $testFile by Chucker")
+            hasCauseThat().isInstanceOf(FileNotFoundException::class.java)
+        }
     }
 
     private class TestSource(contentLength: Int = 1_000) : Source {

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
@@ -86,7 +86,7 @@ class TeeSourceTest {
     }
 
     @Test
-    fun readException_informOfFailures_inSideChannel(@TempDir tempDir: File) {
+    fun readException_informsOfFailures_inSideChannel(@TempDir tempDir: File) {
         val testFile = File(tempDir, "testFile")
         val testSource = ThrowingSource
 


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an open issue - #394.

## :pencil: Changes
<!-- Which code did you change? How? -->

`TeeSource` guards against failures to use files. When `FileNotFoundException` occurs when opening a stream it is reported back to the caller and no payload side streaming happens. Also, any IO failures during interception are now logged.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Not really sure how to reproduce this manually without a convoluted setup. Maybe @CodeBreak524 can confirm that their issue is fixed with a dependency from my branch on JitPack (`com.github.MiSikora.chucker:library:side-channel-file-failure-SNAPSHOT`). I don't really feel that it is necessary as the description in #394 is quite clear and it is now covered with tests.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Closes #394.

To be honest I wonder now about the necessity to write to a file instead of to the memory. Responses need to be loaded to a memory at some point anyway.

https://github.com/ChuckerTeam/chucker/blob/ba2c21b4f5cf7d04363626f49a411bb7f0dfddb0/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt#L251-L259

I pushed for a file-based solution before because of parallel downloads but I didn't consider that the content of files needs to be read to the memory before it is saved to the DB. However, there is still an advantage of files that could be leveraged. Files could be saved to some non-volatile directory instead of cache and DB could just store handles to these files (processing still would be required as we need to decompress network streams). I see the pros and cons of both solutions and I'm open to suggestions.
