### PR TITLE
Kotlin variant in pre-merge to 1.4.0-rc

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         kotlin-version:
           - 1.3.72
-          - 1.4-M3
+          - 1.4.0-rc
 
     env:
       KOTLIN_VERSION: ${{ matrix.kotlin-version }}


### PR DESCRIPTION
## :page_facing_up: Context
Keeping our Kotlin variant up to date. Version 1.4.0-rc was released yesterday:
https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-rc-released/

## :no_entry_sign: Breaking
None

## :hammer_and_wrench: How to test
Let's wait for CI tests
