### PR TITLE
Minor improvement for transaction saving

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -181,20 +181,18 @@ internal class TransactionPayloadFragment :
     @RequiresApi(Build.VERSION_CODES.KITKAT)
     @SuppressLint("DefaultLocale")
     private fun viewBodyExternally() {
-        viewModel.transaction.value?.let {
-            val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-                addCategory(Intent.CATEGORY_OPENABLE)
-                putExtra(Intent.EXTRA_TITLE, "$DEFAULT_FILE_PREFIX${System.currentTimeMillis()}")
-                type = "*/*"
-            }
-            if (intent.resolveActivity(requireActivity().packageManager) != null) {
-                startActivityForResult(intent, GET_FILE_FOR_SAVING_REQUEST_CODE)
-            } else {
-                Toast.makeText(
-                    requireContext(), R.string.chucker_save_failed_to_open_document,
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
+        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            putExtra(Intent.EXTRA_TITLE, "$DEFAULT_FILE_PREFIX${System.currentTimeMillis()}")
+            type = "*/*"
+        }
+        if (intent.resolveActivity(requireActivity().packageManager) != null) {
+            startActivityForResult(intent, GET_FILE_FOR_SAVING_REQUEST_CODE)
+        } else {
+            Toast.makeText(
+                requireContext(), R.string.chucker_save_failed_to_open_document,
+                Toast.LENGTH_SHORT
+            ).show()
         }
     }
 
@@ -212,6 +210,8 @@ internal class TransactionPayloadFragment :
                     }
                     Toast.makeText(context, toastMessageId, Toast.LENGTH_SHORT).show()
                 }
+            } else {
+                Toast.makeText(context, R.string.chucker_file_not_saved, Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -137,7 +137,7 @@ internal class TransactionPayloadFragment :
             menu.findItem(R.id.save_body).apply {
                 isVisible = true
                 setOnMenuItemClickListener {
-                    viewBodyExternally()
+                    createFileToSaveBody()
                     true
                 }
             }
@@ -179,8 +179,7 @@ internal class TransactionPayloadFragment :
     }
 
     @RequiresApi(Build.VERSION_CODES.KITKAT)
-    @SuppressLint("DefaultLocale")
-    private fun viewBodyExternally() {
+    private fun createFileToSaveBody() {
         val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
             putExtra(Intent.EXTRA_TITLE, "$DEFAULT_FILE_PREFIX${System.currentTimeMillis()}")

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="chucker_share_as_curl">Share as curl command</string>
     <string name="chucker_save">Save body to file</string>
     <string name="chucker_save_failed_to_open_document">Failed to open file chooser</string>
-    <string name="chucker_file_saved">File was saved successfully!</string>
+    <string name="chucker_file_saved">File saved successfully!</string>
     <string name="chucker_file_not_saved">Failed to save file</string>
     <string name="chucker_body_empty">(body is empty)</string>
     <string name="chucker_body_omitted">(encoded or binary body omitted)</string>


### PR DESCRIPTION
## :page_facing_up: Context
While playing with the new [Activity Results API](https://developer.android.com/training/basics/intents/result) I found out that code for saving body to a file is quite verbose with redundant null check. 
Particularly there is a check if transaction is null in a place where it makes no sense to check, since in `onActivityResult()` we already have another check for transaction being null before trying to write its body into a file. 

Additionally, we might want to show toast about saving failure in case `uri` or `transaction` are null in `onActivityResult()`.

## :pencil: Changes
- Removed `null` check done via `?.let { }` in file creation function.
- Added missing toast for possible cases of failure during file saving.
- Renamed function `viewBodyExternally()` to `createFileToSaveBody()` to match its responsibility.

## :no_entry_sign: Breaking
Nothing breaking

## :hammer_and_wrench: How to test
No need for special testing. Just normal saving to file flow should be enough to test. 

## :stopwatch: Next steps
Wait for Activity to reach 1.2.0 stable and Fragment to reach 1.3.0, so we could switch to mentioned `Activity Results API`. 
The code becomes much shorter and nicer with that. 
Here is a commit with file saving functionality in Chucker migrated to this API: https://github.com/vbuberen/chucker/commit/02a5aa28d09bc0fbc78831d80460dbdacaea7048
