### PR TITLE
Allow user specified certificates in the debug variant of the sample app.

### DIFF
--- a/sample/src/debug/AndroidManifest.xml
+++ b/sample/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:networkSecurityConfig="@xml/network_security_config"
+        >
+    </application>
+</manifest>

--- a/sample/src/debug/res/xml/network_security_config.xml
+++ b/sample/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
This allows tools like Charles Proxy to intercept/view HTTPS traffic.

## :page_facing_up: Context
I'm working on #401 and wanted to compare my progress to what Charles Proxy can see.

## :hammer_and_wrench: How to test
This only change the sample, not the library. If you'd like to test the sample, you can use a tool like Charles Proxy. See https://www.charlesproxy.com/documentation/proxying/ssl-proxying/
