### PR TITLE
Add a Building section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ _A fork of [Chuck](https://github.com/jgilfelt/chuck)_
 * [Snapshots](#snapshots-)
 * [FAQ](#faq-)
 * [Contributing](#contributing-)
+  * [Building](#building-)
 * [Acknowledgments](#acknowledgments-)
 * [License](#license-)
 
@@ -187,6 +188,27 @@ Short `TODO` List for new contributors:
 
 - Increment the test coverage.
 - [Issues marked as `Help wanted`](https://github.com/ChuckerTeam/chucker/labels/help%20wanted)
+
+### Building 🛠
+
+In order to start working on Chucker, you need to fork the project and open it in Android Studio/IntelliJ IDEA.
+
+Before committing we suggest you install the pre-commit hooks with the following command:
+
+```
+./gradlew installGitHook
+```
+
+This will make sure your code is validated against KtLint and Detekt before every commit.
+
+Before submitting a PR please run:
+
+```
+./gradlew build
+```
+
+This will build the library and will run all the verification tasks (ktlint, detekt, lint, unit tests) locally.
+This will make sure your CI checks will pass.
 
 ## Acknowledgments 🌸
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Before committing we suggest you install the pre-commit hooks with the following
 ```
 
 This will make sure your code is validated against KtLint and Detekt before every commit.
+The command will run automatically before the `clean` task, so you should have the pre-commit installed by then.
 
 Before submitting a PR please run:
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Before committing we suggest you install the pre-commit hooks with the following
 ```
 
 This will make sure your code is validated against KtLint and Detekt before every commit.
-The command will run automatically before the `clean` task, so you should have the pre-commit installed by then.
+The command will run automatically before the `clean` task, so you should have the pre-commit hook installed by then.
 
 Before submitting a PR please run:
 


### PR DESCRIPTION
## :page_facing_up: Context
This is related to #248, I'm adding a Building section to the README to clarify how to setup the local environment for developing the library.

## :pencil: Changes
- Added the `Building` with a mention on the ktlint pre-commit hook
- Added the `gradlew build` suggested command in order to run all the tests locally
- Disabled `GradleDependency` lint check as `gradlew build` is failing on master due to obsolete OkHTTP dependency (that's intentional).