### PR TITLE
Add pre-commit hook and task to automatically install it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,14 @@ allprojects {
     }
 }
 
+task installGitHook(type: Copy) {
+    from new File(rootProject.rootDir, 'pre-commit')
+    into { new File(rootProject.rootDir, '.git/hooks') }
+    fileMode 0777
+}
+
 task clean(type: Delete) {
+    dependsOn(installGitHook)
     delete rootProject.buildDir
 }
 

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/bash
+echo "Running pre-commit checks..."
+
+OUTPUT="/tmp/analysis-result"
+./gradlew detekt ktlintCheck > ${OUTPUT}
+EXIT_CODE=$?
+if [ ${EXIT_CODE} -ne 0 ]; then
+    cat ${OUTPUT}
+    rm ${OUTPUT}
+    echo "*********************************************"
+    echo "               Checks Failed!                 "
+    echo "    Resolve found issues before committing   "
+    echo "*********************************************"
+    exit ${EXIT_CODE}
+else
+    rm ${OUTPUT}
+    echo "*********************************************"
+    echo "          Checks Passed Successfully!        "
+    echo "*********************************************"
+fi

--- a/pre-commit
+++ b/pre-commit
@@ -8,7 +8,7 @@ if [ ${EXIT_CODE} -ne 0 ]; then
     cat ${OUTPUT}
     rm ${OUTPUT}
     echo "*********************************************"
-    echo "               Checks Failed!                 "
+    echo "               Checks Failed!                "
     echo "    Resolve found issues before committing   "
     echo "*********************************************"
     exit ${EXIT_CODE}


### PR DESCRIPTION
## :page_facing_up: Context
This PR implements enhancement #248 to run code checks before commiting the code. Except adding the hook itself I have also added a task to install hook which runs whenever clean task is fired. It means that with such hack every contributor will have hook installed automatically.

## :pencil: Changes
- Added `pre-commit` script file
- Added task to install this script file
- Set `clean` task to depend on install task.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
Nothing

## :hammer_and_wrench: How to test
Run `Clean` or `Rebuild` task and see that `installGitHook` task is executed as well.
After that hook should run on every commit attempt.

## :stopwatch: Next steps
We might consider integrating formatting task into the hook as well after adding #249 
