### PR TITLE
Fix FileProvider issues.

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -22,8 +22,8 @@
             android:exported="false" />
     
         <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="@string/chucker_provider_authority"
+            android:name="com.chuckerteam.chucker.internal.support.ChuckerFileProvider"
+            android:authorities="${applicationId}.com.chuckerteam.chucker.provider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ChuckerFileProvider.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ChuckerFileProvider.kt
@@ -1,0 +1,9 @@
+package com.chuckerteam.chucker.internal.support
+
+import androidx.core.content.FileProvider
+
+/**
+ * We need our own subclass so we don't conflict with other [FileProvider]s
+ * See: https://github.com/ChuckerTeam/chucker/issues/409
+ */
+class ChuckerFileProvider : FileProvider()

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
@@ -142,7 +142,7 @@ internal class TransactionListFragment :
                 val file = viewModel.createExportFile(filecontent, cacheFileFactory)
                 val uri = FileProvider.getUriForFile(
                     requireContext(),
-                    getString(R.string.chucker_provider_authority),
+                    "${requireContext().packageName}.com.chuckerteam.chucker.provider",
                     file
                 )
                 shareFile(uri)

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -62,5 +62,4 @@
     <string name="chucker_request_not_ready">The request isn\'t ready for sharing or saving</string>
     <string name="chucker_request_is_empty">This request is empty</string>
     <string name="chucker_response_is_empty">This response is empty</string>
-    <string name="chucker_provider_authority">com.chuckerteam.chucker.provider</string>
 </resources>


### PR DESCRIPTION
This prevents conflicts with other apps that already use the generic androidx.core.content.FileProvider as a name.
This also allows multiple apps with chucker to be installed on a device at one time.

Fixes #409