### PR TITLE
Make some dependencies api in library build.gradle

### DIFF
--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -19,8 +19,8 @@ android {
 }
 
 dependencies {
-    implementation "com.squareup.okhttp3:okhttp:$okhttp3Version"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    api "com.squareup.okhttp3:okhttp:$okhttp3Version"
+    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     api "com.squareup.okhttp3:okhttp:$okhttp3Version"
-    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation "com.google.android.material:material:$materialComponentsVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
@@ -57,7 +57,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion"
 
     implementation "com.google.code.gson:gson:$gsonVersion"
-    implementation "com.squareup.okhttp3:okhttp:$okhttp3Version"
+    api "com.squareup.okhttp3:okhttp:$okhttp3Version"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation "com.google.android.material:material:$materialComponentsVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"


### PR DESCRIPTION
Fixes #415

These are the only 2 dependencies that have their types exposed by Chucker public types. This ensures that downstream apps that use these APIs will compile.
