### PR TITLE
Update Kotlin to 1.4.0

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -11,15 +11,6 @@ on:
 jobs:
   test:
     runs-on: [ubuntu-latest]
-    strategy:
-      fail-fast: false
-      matrix:
-        kotlin-version:
-          - 1.3.72
-          - 1.4.0-rc
-
-    env:
-      KOTLIN_VERSION: ${{ matrix.kotlin-version }}
 
     steps:
     - name: Checkout Repo

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlinVersion = System.getenv("KOTLIN_VERSION") ?: '1.3.72'
+        kotlinVersion = '1.4.0'
         androidGradleVersion = '4.0.1'
         coroutineVersion = '1.3.8'
 
@@ -40,7 +40,6 @@ buildscript {
         jcenter()
         google()
         gradlePluginPortal()
-        maven { url("https://dl.bintray.com/kotlin/kotlin-eap") }
     }
 
     dependencies {
@@ -60,7 +59,6 @@ allprojects {
     repositories {
         jcenter()
         google()
-        maven { url("https://dl.bintray.com/kotlin/kotlin-eap") }
     }
 
     tasks.withType(Test) {


### PR DESCRIPTION
## :page_facing_up: Context
Update Chucker to use Kotlin 1.4.0. It seems that after this update we don't need different Kotlin versions in our workflow anymore.

## :pencil: Changes
- Update Kotlin to 1.4.0
- Remove environment variable for different Kotlin versions from Github Actions workflow.

## :paperclip: Related PR
Unblocks #363 

## :no_entry_sign: Breaking
Nothing expected.

## :stopwatch: Next steps
Update coroutines dependency to 1.3.9, which already switched to Kotlin 1.4.0