### PR TITLE
Update Coroutines to 1.3.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         kotlinVersion = '1.4.0'
         androidGradleVersion = '4.0.1'
-        coroutineVersion = '1.3.8'
+        coroutineVersion = '1.3.9'
 
         // Google libraries
         appCompatVersion = '1.2.0'


### PR DESCRIPTION
## :page_facing_up: Context
Since Chucker already uses Kotlin 1.4.0 we can safely update Coroutines to 1.3.9 as well.
Doing this update manually, since Dependabot picks wrong dependency (like in #426)

## :pencil: Changes
- Update Coroutines to 1.3.9.

## :no_entry_sign: Breaking
Nothing
