### PR TITLE
Add manual trigger for Github Actions workflows

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,5 @@
 name: Validate Gradle Wrapper
-on: 
+on:
   push:
       branches:
       - develop 
@@ -7,7 +7,9 @@ on:
   pull_request:
     branches: 
       - '*'
-  workflow_dispatch
+  workflow_dispatch:
+    branches:
+      - '*'
 
 jobs:
   validation:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -7,7 +7,9 @@ on:
   pull_request:
     branches: 
       - '*'
-  workflow_dispatch
+  workflow_dispatch:
+    branches:
+      - '*'
 
 jobs:
   test:


### PR DESCRIPTION
## :page_facing_up: Context
In some cases, like in #363, Github Actions workflows don't run automatically as they should. [Manual triggering ](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)of required workflows might help here.


## :pencil: Changes
- Added new event types for triggering workflows

## :no_entry_sign: Breaking
Nothing

## :hammer_and_wrench: How to test
Github UI should show `Run workflow` for particular workflows when it is opened in `Actions` tab.
