### PR TITLE
Add a flag to always read response body fully

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ val chuckerInterceptor = ChuckerInterceptor(
         // The max body content length in bytes, after this responses will be truncated.
         maxContentLength = 250000L,
         // List of headers to replace with ** in the Chucker UI
-        headersToRedact = setOf("Auth-Token"))
+        headersToRedact = setOf("Auth-Token"),
+        // Read response bodies fully even in case of not consuming all of the bytes by the client.
+        // This is useful in case of parsing errors or when the response body
+        // is closed before being read like in Retrofit with Void and Unit types.
+        alwaysReadResponseBody = true
+)
 
 // Don't forget to plug the ChuckerInterceptor inside the OkHttpClient
 val client = OkHttpClient.Builder()

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ val chuckerInterceptor = ChuckerInterceptor(
         maxContentLength = 250000L,
         // List of headers to replace with ** in the Chucker UI
         headersToRedact = setOf("Auth-Token"),
-        // Read response bodies fully even in case of not consuming all of the bytes by the client.
+        // Read the whole response body even when the client does not consume the response completely.
         // This is useful in case of parsing errors or when the response body
         // is closed before being read like in Retrofit with Void and Unit types.
         alwaysReadResponseBody = true

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -12,7 +12,8 @@ class ChuckerInterceptor @JvmOverloads constructor(
     context: Context,
     collector: Any? = null,
     maxContentLength: Any? = null,
-    headersToRedact: Any? = null
+    headersToRedact: Any? = null,
+    alwaysReadResponseBody: Any? = null,
 ) : Interceptor {
 
     fun redactHeaders(vararg names: String): ChuckerInterceptor {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/DepletingSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/DepletingSource.kt
@@ -1,0 +1,33 @@
+package com.chuckerteam.chucker.internal.support
+
+import okio.Buffer
+import okio.ForwardingSource
+import okio.Okio
+import okio.Source
+import java.io.IOException
+
+internal class DepletingSource(delegate: Source) : ForwardingSource(delegate) {
+    private var shouldDeplete = true
+
+    override fun read(sink: Buffer, byteCount: Long) = try {
+        val bytesRead = super.read(sink, byteCount)
+        if (bytesRead == -1L) shouldDeplete = false
+        bytesRead
+    } catch (e: IOException) {
+        shouldDeplete = false
+        throw e
+    }
+
+    override fun close() {
+        if (shouldDeplete) {
+            try {
+                Okio.buffer(delegate()).readAll(Okio.blackhole())
+            } catch (e: IOException) {
+                IOException("An error occurred while depleting the source", e).printStackTrace()
+            }
+        }
+        shouldDeplete = false
+
+        super.close()
+    }
+}

--- a/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicLong
 internal class ChuckerInterceptorDelegate(
     maxContentLength: Long = 250000L,
     headersToRedact: Set<String> = emptySet(),
+    alwaysReadResponseBody: Boolean = false,
     cacheDirectoryProvider: CacheDirectoryProvider,
 ) : Interceptor {
     private val idGenerator = AtomicLong()
@@ -37,12 +38,13 @@ internal class ChuckerInterceptorDelegate(
         collector = mockCollector,
         maxContentLength = maxContentLength,
         headersToRedact = headersToRedact,
-        cacheDirectoryProvider = cacheDirectoryProvider
+        cacheDirectoryProvider = cacheDirectoryProvider,
+        alwaysReadResponseBody = alwaysReadResponseBody,
     )
 
     internal fun expectTransaction(): HttpTransaction {
         if (transactions.isEmpty()) {
-            throw AssertionError("Expected transaction but was empty.")
+            throw AssertionError("Expected transaction but was empty")
         }
         return transactions.removeAt(0)
     }

--- a/library/src/test/java/com/chuckerteam/chucker/TestUtils.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/TestUtils.kt
@@ -9,6 +9,8 @@ import okio.ByteString
 import okio.Okio
 import java.io.File
 
+const val SEGMENT_SIZE = 8_192L
+
 fun getResourceFile(file: String): Buffer {
     return Buffer().apply {
         writeAll(Okio.buffer(Okio.source(File("./src/test/resources/$file"))))

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/DepletingSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/DepletingSourceTest.kt
@@ -1,0 +1,98 @@
+package com.chuckerteam.chucker.internal.support
+
+import com.google.common.truth.Truth.assertThat
+import okio.Buffer
+import okio.BufferedSource
+import okio.ByteString
+import okio.Okio
+import okio.Source
+import okio.Timeout
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
+
+class DepletingSourceTest {
+    @Test
+    fun delegateContent_isMovedToDownstream() {
+        val delegate = Buffer().writeUtf8("Hello, world!")
+        val depletingSource = DepletingSource(delegate)
+
+        val content = Okio.buffer(depletingSource).use(BufferedSource::readByteString)
+
+        assertThat(content.utf8()).isEqualTo("Hello, world!")
+    }
+
+    @Test
+    fun delegateIsNotDepleted_whenReadingFails() {
+        val delegate = ThrowOnFirstReadSource("Hello, world!")
+        val depletingSource = DepletingSource(delegate)
+
+        val exception = assertThrows<IOException> {
+            // Because delegate throws only on a first read, this also checks if DepletingSource
+            // does not try to read during close if a failure happened while reading.
+            depletingSource.use { it.read(Buffer(), 1) }
+        }
+        assertThat(exception.message).isEqualTo("Hello there!")
+
+        assertThat(delegate.content).isEqualTo("Hello, world!")
+    }
+
+    @Test
+    fun delegateIsDepleted_whenSourceIsClosed() {
+        val delegate = Buffer().writeUtf8("Hello, world!")
+        val depletingSource = DepletingSource(delegate)
+
+        depletingSource.close()
+
+        assertThat(delegate.snapshot()).isEqualTo(ByteString.EMPTY)
+    }
+
+    @Test
+    fun readingFailures_areNotPropagated_whenSourceIsClosed() {
+        val delegate = ThrowOnFirstReadSource("Hello, world!")
+        val depletingSource = DepletingSource(delegate)
+
+        assertDoesNotThrow(depletingSource::close)
+    }
+
+    @Test
+    fun delegateIsNotDepleted_whenReadingFails_duringClose() {
+        val delegate = ThrowOnFirstReadSource("Hello, world!")
+        val depletingSource = DepletingSource(delegate)
+
+        depletingSource.close()
+
+        assertThat(delegate.content).isEqualTo("Hello, world!")
+    }
+
+    @Test
+    fun delegateCannotBeDepleted_multipleTimes() {
+        val delegate = Buffer().writeUtf8("Hello, world!")
+        val depletingSource = DepletingSource(delegate)
+
+        depletingSource.close()
+        delegate.writeUtf8("And goodnight!")
+        depletingSource.close()
+
+        assertThat(delegate.snapshot().utf8()).isEqualTo("And goodnight!")
+    }
+
+    private class ThrowOnFirstReadSource(content: String) : Source {
+        private val source = Buffer().writeUtf8(content)
+        val content: String get() = source.snapshot().utf8()
+        private var shouldThrow = true
+
+        override fun read(sink: Buffer, byteCount: Long): Long {
+            if (shouldThrow) {
+                shouldThrow = false
+                throw IOException("Hello there!")
+            }
+            return source.read(sink, byteCount)
+        }
+
+        override fun close() = Unit
+
+        override fun timeout(): Timeout = Timeout.NONE
+    }
+}

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
@@ -1,5 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
+import com.chuckerteam.chucker.SEGMENT_SIZE
 import com.google.common.truth.Truth.assertThat
 import okio.Buffer
 import okio.BufferedSource
@@ -37,16 +38,15 @@ class TeeSourceTest {
     @Test
     fun bytesPulledFromUpstream_arePulledToSideChannel_alongTheDownstream() {
         val repetitions = Random.nextInt(1, 100)
-        // Okio uses 8KiB as a single size read.
-        val testSource = TestSource(8_192 * repetitions)
+        val testSource = TestSource(repetitions * SEGMENT_SIZE.toInt())
         val sideStream = Buffer()
 
         val teeSource = TeeSource(testSource, sideStream)
         Okio.buffer(teeSource).use { source ->
             repeat(repetitions) { index ->
-                source.readByteString(8_192)
+                source.readByteString(SEGMENT_SIZE)
 
-                val subContent = testSource.content.substring(0, (index + 1) * 8_192)
+                val subContent = testSource.content.substring(0, (index + 1) * SEGMENT_SIZE.toInt())
                 assertThat(sideStream.snapshot()).isEqualTo(subContent)
             }
         }


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an issue - #432.

## :pencil: Changes
<!-- Which code did you change? How? -->

I added `alwaysReadResponseBody` flag to `ChuckerInterceptor` that lets users decide if they want to consume the whole body from responses. It is an opt-in feature because it can drastically change the behavior of an application between QA and production builds.

Sources are depleted with a new `DepeletingSource` class that is added conditionally based on the flag.

I also did some housekeeping on tests.
* The temporary directory is now a property of `ChuckerInterceptorTest` instead of an input argument of test functions.
* Okio's segment size is now a test constant.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

There are unit tests to cover this functionality. To tests this manually you can use the sample app, turn on the flag, and see that the response body from Postman call is fully available.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Closes #432.
I'm not sure about #425. It should not happen in the first place given the info from the author. This PR helps if the response body is longer than 8 KiB and parsing error happens before reading the last segment.
