### PR TITLE
Fix classes visibility

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ChuckerFileProvider.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ChuckerFileProvider.kt
@@ -6,4 +6,4 @@ import androidx.core.content.FileProvider
  * We need our own subclass so we don't conflict with other [FileProvider]s
  * See: https://github.com/ChuckerTeam/chucker/issues/409
  */
-class ChuckerFileProvider : FileProvider()
+internal class ChuckerFileProvider : FileProvider()

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/ProtocolResources.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/ProtocolResources.kt
@@ -4,7 +4,7 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import com.chuckerteam.chucker.R
 
-sealed class ProtocolResources(@DrawableRes val icon: Int, @ColorRes val color: Int) {
+internal sealed class ProtocolResources(@DrawableRes val icon: Int, @ColorRes val color: Int) {
     class Http : ProtocolResources(R.drawable.chucker_ic_http, R.color.chucker_color_error)
     class Https : ProtocolResources(R.drawable.chucker_ic_https, R.color.chucker_color_primary)
 }


### PR DESCRIPTION
## :camera: Screenshots
<img width="413" alt="Screenshot 2020-09-15 at 10 43 41" src="https://user-images.githubusercontent.com/13467769/93202815-03bd2200-f75c-11ea-8de6-9e5f65482068.png">


## :page_facing_up: Context
Found out that in docs generated by Dokka we have more than `api` package available (see the attached screenshot). These packages inside `internal` package shouldn't be visible to users, as well as classes in it. And such classes shouldn't be in docs as well.

## :pencil: Changes
- Updated visibility modifier for 2 classes.

## :hammer_and_wrench: How to test
Run `dokkaHtml` command and see that generated doc has only `api` package.

## :stopwatch: Next steps
Documentation rework is on me, so I will improve documentation when I get back to these tasks soon.
