### PR TITLE
Cleanup logging in the library

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -107,6 +107,4 @@ public object Chucker {
     @Deprecated("This param will be removed in 4.x release")
     @IntDef(value = [SCREEN_HTTP, SCREEN_ERROR])
     public annotation class Screen
-
-    internal const val LOG_TAG = "Chucker"
 }

--- a/library/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
@@ -2,9 +2,8 @@ package com.chuckerteam.chucker.api
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.util.Log
-import com.chuckerteam.chucker.api.Chucker.LOG_TAG
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
+import com.chuckerteam.chucker.internal.support.Logger.info
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -45,7 +44,7 @@ public class RetentionManager @JvmOverloads constructor(
         if (period > 0) {
             val now = System.currentTimeMillis()
             if (isCleanupDue(now)) {
-                Log.i(LOG_TAG, "Performing data retention maintenance...")
+                info("Performing data retention maintenance...")
                 deleteSince(getThreshold(now))
                 updateLastCleanup(now)
             }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/Logger.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/Logger.kt
@@ -1,0 +1,24 @@
+package com.chuckerteam.chucker.internal.support
+
+import android.util.Log
+
+internal object Logger {
+
+    private const val TAG = "Chucker"
+
+    fun info(message: String) {
+        Log.i(TAG, message)
+    }
+
+    fun warn(message: String) {
+        Log.w(TAG, message)
+    }
+
+    fun error(message: String, throwable: Throwable? = null) {
+        if (throwable != null) {
+            Log.e(TAG, message, throwable)
+        } else {
+            Log.e(TAG, message)
+        }
+    }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/Sharable.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/Sharable.kt
@@ -8,6 +8,7 @@ import android.widget.Toast
 import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
 import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.internal.support.Logger.warn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okio.BufferedSource
@@ -45,14 +46,14 @@ internal suspend fun Sharable.shareAsFile(
 ): Intent? {
     val cache = activity.cacheDir
     if (cache == null) {
-        println("Failed to obtain a valid cache directory for Chucker file export")
+        warn("Failed to obtain a valid cache directory for Chucker file export")
         Toast.makeText(activity, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
         return null
     }
 
     val file = FileFactory.create(cache, fileName)
     if (file == null) {
-        println("Failed to create an export file for Chucker")
+        warn("Failed to create an export file for Chucker")
         Toast.makeText(activity, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
         return null
     }


### PR DESCRIPTION
## :page_facing_up: Context
When going through #451, I noticed we have some orphan `println` that we should avoid. I'm cleaning up the logging infra we have for Chucker a bit.

## :pencil: Changes
Introduced a small `Logger` object that will serve for future logging.

## :stopwatch: Next steps
n/a
