### PR TITLE
Release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Change Log
 
+** Version 3.3.0 *(2020-09-30)*
+
+This is a new minor release with multiple fixes and improvements. 
+Note, this release is the last one with minSDK 16. In next versions Chucker will bump minSDK 21 in order to use newer OkHttp versions.
+
+### Summary of changes
+
+* Added a new flag `alwaysReadResponseBody` into Chucker configuration to read the whole response body even if consumer fails to consume it.
+* Added port numbers as part of the URL. Numbers appear if they are different from default 80 or 443.
+* Chucker now shows partially read application responses properly. Earlier in 3.2.0 such responses didn't appear in the UI. 
+* Transaction size is defined by actual payload size now, not by `Content-length` header.
+* Added empty state UI for payloads, so no more guessing if there is some error or the payload is really empty.
+* Added feature to export list of transactions.
+* Added ability to format URL encoded forms with button to switch between encoded/decoded URLs.
+* Added generation of contrast background for image payload to distinguish Chucker UI from the image itself.
+* Switched OkHttp dependency from `implementation` to `api`, since it is available in the public API.
+* List items are now focusable on Android TV devices.
+* Further improved test coverage.
+
+### Deprecations
+
+* Throwables capturing feature is officially deprecated and will be removed in next releases. More info in [#321].
+
+### Bugfixes
+
+* Fixed [#311] with leaking Closable resource.
+* Fixed [#314] with overlapping UI on some device.
+* Fixed [#367] with empty shared text when `Don't keep activities` is turned on.
+* Fixed [#366] with crash when process dies.
+* Fixed [#394] with failing requests when FileNotFound error happens.
+* Fixed [#410] with conflicts when other apps already use generic FileProvider.
+* Fixed [#422] with IOException.
+
+### Dependency updates
+
+* Added Fragment-ktx 1.2.5
+* Added Palette-ktx 1.0.0
+* Updated Kotlin to 1.4.10
+* Updated Android Gradle plugin to 4.0.1
+* Updated Coroutine to 1.3.9
+* Updated AppCompat to 1.2.0
+* Updated ConstraintLayout to 2.0.1
+* Updated MaterialComponents to 1.2.1
+* Updated Gradle to 6.6.1
+
+### Credits
+
+This release was possible thanks to the contribution of:
+
+@adb-shell
+@cortinico
+@djrausch
+@gm-vm
+@JayNewstrom
+@MiSikora
+@vbuberen
+@psh
+
 ## Version 3.2.0 *(2020-04-04)*
 
 This is a new minor release with numerous internal changes.
@@ -159,7 +217,6 @@ This is a hotfix release for Chucker `3.0.0`.
 ### Credits
 
 This release was possible thanks to the contribution of: @redwarp
-
 
 ## Version 3.0.0 *(2019-08-12)*
 
@@ -368,3 +425,11 @@ Initial release.
 [#254]: https://github.com/ChuckerTeam/chucker/issues/254
 [#255]: https://github.com/ChuckerTeam/chucker/issues/255
 [#241]: https://github.com/ChuckerTeam/chucker/issues/241
+[#311]: https://github.com/ChuckerTeam/chucker/issues/311
+[#314]: https://github.com/ChuckerTeam/chucker/issues/314
+[#321]: https://github.com/ChuckerTeam/chucker/issues/321
+[#367]: https://github.com/ChuckerTeam/chucker/issues/367
+[#366]: https://github.com/ChuckerTeam/chucker/issues/366
+[#394]: https://github.com/ChuckerTeam/chucker/issues/394
+[#410]: https://github.com/ChuckerTeam/chucker/issues/410
+[#422]: https://github.com/ChuckerTeam/chucker/issues/422

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Version 3.3.0 *(2020-09-30)*
 
 This is a new minor release with multiple fixes and improvements. 
-Note, this release is the last one with minSDK 16. In next versions Chucker will bump minSDK to 21 in order to use newer OkHttp versions.
+After this release we are starting to work on a new major release 4.x with minSDK 21. 
+Bumping minSDK to 21 is required to keep up with [newer versions of OkHttp](https://medium.com/square-corner-blog/okhttp-3-13-requires-android-5-818bb78d07ce).
+Versions 3.x will be supported for 6 months (till March 2021) getting bugfixes and minor improvements.
 
 ### Summary of changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-** Version 3.3.0 *(2020-09-30)*
+## Version 3.3.0 *(2020-09-30)*
 
 This is a new minor release with multiple fixes and improvements. 
 Note, this release is the last one with minSDK 16. In next versions Chucker will bump minSDK 21 in order to use newer OkHttp versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Version 3.3.0 *(2020-09-30)*
 
 This is a new minor release with multiple fixes and improvements. 
-Note, this release is the last one with minSDK 16. In next versions Chucker will bump minSDK 21 in order to use newer OkHttp versions.
+Note, this release is the last one with minSDK 16. In next versions Chucker will bump minSDK to 21 in order to use newer OkHttp versions.
 
 ### Summary of changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ Note, this release is the last one with minSDK 16. In next versions Chucker will
 * Chucker now shows partially read application responses properly. Earlier in 3.2.0 such responses didn't appear in the UI. 
 * Transaction size is defined by actual payload size now, not by `Content-length` header.
 * Added empty state UI for payloads, so no more guessing if there is some error or the payload is really empty.
-* Added feature to export list of transactions.
+* Added ability to export list of transactions.
+* Added ability to save single transaction as file.
 * Added ability to format URL encoded forms with button to switch between encoded/decoded URLs.
 * Added generation of contrast background for image payload to distinguish Chucker UI from the image itself.
 * Switched OkHttp dependency from `implementation` to `api`, since it is available in the public API.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Please note that you should add both the `library` and the the `library-no-op` v
 
 ```groovy
 dependencies {
-  debugImplementation "com.github.chuckerteam.chucker:library:3.2.0"
-  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.2.0"
+  debugImplementation "com.github.chuckerteam.chucker:library:3.3.0"
+  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.3.0"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,8 @@ org.gradle.parallel=true
 
 android.useAndroidX=true
 
-VERSION_NAME=3.3.0-SNAPSHOT
-# 3*100*100 + 2*100 + 0 => 30200
+VERSION_NAME=3.3.0
+# 3*100*100 + 3*100 + 0 => 30300
 VERSION_CODE=30300
 GROUP=com.github.chuckerteam.chucker
 


### PR DESCRIPTION
Changelog and version bumps for 3.3.0 release.

Tried to capture all the changes and fixes, but might have missed some. 
Changelog is formed based on 2 sources:
1). [List of PRs](https://github.com/ChuckerTeam/chucker/pulls?page=1&q=is%3Apr+is%3Aclosed+merged%3A2020-04-04..2020-09-29)
2). [3.3.0 milestone](https://github.com/ChuckerTeam/chucker/milestone/9?closed=1)

In updates for dependencies I decided to not include info about updates for things like KtLint and other quality control or debugging tools, since they are meaningless for the library users.