### PR TITLE
Update team members list

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ This will make sure your CI checks will pass.
 
 Chucker is currently developed and maintained by the [ChuckerTeam](https://github.com/ChuckerTeam). When submitting a new PR, please ping one of:
 
-- [@olivierperez](https://github.com/olivierperez)
 - [@cortinico](https://github.com/cortinico)
-- [@redwarp](https://github.com/redwarp)
+- [@MiSikora](https://github.com/MiSikora)
+- [@olivierperez](https://github.com/olivierperez)
 - [@vbuberen](https://github.com/vbuberen)
 
 ### Thanks


### PR DESCRIPTION
## :page_facing_up: Context
Found out that we need to update list of people to ping in `Contributing` section.

## :pencil: Changes
- Removed inactive maintainer 
- Added new team member
- Ordered team in alphabetical order

## :stopwatch: Next steps
Will update gifs next, since our sample app has updated UI since `3.3.0`