### PR TITLE
Fix leaking MainActivity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         dokkaVersion = '1.4.10'
         ktLintVersion = '0.39.0'
         ktLintGradleVersion = '9.4.0'
-        leakcanaryVersion = '2.4'
+        leakcanaryVersion = '2.5'
 
         // Testing
         androidxTestCoreVersion = '1.3.0'

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProvider.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProvider.kt
@@ -29,9 +29,9 @@ internal object RepositoryProvider {
     /**
      * Idempotent method. Must be called before accessing the repositories.
      */
-    fun initialize(context: Context) {
+    fun initialize(applicationContext: Context) {
         if (transactionRepository == null || throwableRepository == null) {
-            val db = ChuckerDatabase.create(context)
+            val db = ChuckerDatabase.create(applicationContext)
             transactionRepository = HttpTransactionDatabaseRepository(db)
             throwableRepository = RecordedThrowableDatabaseRepository(db)
         }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
@@ -17,11 +17,11 @@ internal abstract class ChuckerDatabase : RoomDatabase() {
         private const val OLD_DB_NAME = "chuck.db"
         private const val DB_NAME = "chucker.db"
 
-        fun create(context: Context): ChuckerDatabase {
+        fun create(applicationContext: Context): ChuckerDatabase {
             // We eventually delete the old DB if a previous version of Chuck/Chucker was used.
-            context.getDatabasePath(OLD_DB_NAME).delete()
+            applicationContext.getDatabasePath(OLD_DB_NAME).delete()
 
-            return Room.databaseBuilder(context, ChuckerDatabase::class.java, DB_NAME)
+            return Room.databaseBuilder(applicationContext, ChuckerDatabase::class.java, DB_NAME)
                 .fallbackToDestructiveMigration()
                 .build()
         }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/BaseChuckerActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/BaseChuckerActivity.kt
@@ -9,7 +9,7 @@ internal abstract class BaseChuckerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        RepositoryProvider.initialize(this)
+        RepositoryProvider.initialize(applicationContext)
     }
 
     override fun onResume() {


### PR DESCRIPTION
## :camera: Screenshots
![Screenshot 2020-10-02 at 14 27 01](https://user-images.githubusercontent.com/13467769/94919200-c88d5380-04bc-11eb-9bc1-e3a488fde681.png)
![Screenshot 2020-10-02 at 14 26 32](https://user-images.githubusercontent.com/13467769/94919209-cc20da80-04bc-11eb-84c6-2f2698affd6b.png)

## :page_facing_up: Context
Recently saw a leak reported by LeakCanary and investigated the reason. In some cases Room database initialises with activity context instead of application and it leads to leaks. 


## :pencil: Changes
- Replaced `this` with `applicationContext` in `BaseActivity` to provide proper `Context` object.
- Renamed params to avoid confusion on which `Context` is required.
- Updated LeakCanary to 2.5.

## :no_entry_sign: Breaking
Nothing

## :hammer_and_wrench: How to test
Just launch sample app and try to play around with the app to see if LeakCanary reports something.

## :stopwatch: Next steps
Probably, we could redo the way repositories initialisation happen. But it is not the top priority now.
