### PR TITLE
Bump target and compile SDK to 30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,6 @@ task clean(type: Delete) {
 
 ext {
     minSdkVersion = 16
-    targetSdkVersion = 29
-    compileSdkVersion = 29
+    targetSdkVersion = 30
+    compileSdkVersion = 30
 }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.chuckerteam.chucker">
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.CREATE_DOCUMENT" />
+            <data android:mimeType="*/*" />
+        </intent>
+    </queries>
+
     <application>
         <activity
             android:name="com.chuckerteam.chucker.internal.ui.MainActivity"


### PR DESCRIPTION
## :page_facing_up: Context
Something that, probably, had to be done for `3.3.0` before release as well. 
Updates for targetSDK and compileSDK to 30 or Android 11. After checking the whole list of behavior changes I found out that Chucker has almost nothing to change to be compatible. The only thing was [changes for package visibility](https://medium.com/androiddevelopers/package-visibility-in-android-11-cc857f221cd9). While testing saving transaction into a file on emulator with Android 11 saw that I constantly get error. As it turned out `resolveActivity` always returns `null` if no `<queries>` element specified in app's manifest. So I modified `AndroidManifest` file as well to make app compatible with requirements. 

After this change I tested file saving on devices with SDK 19 as well and found no issues.

## :pencil: Changes
- Bumped `targetSDK` and `compileSDK` to 30.
- Added `<queries` into `AndroidManifest`.

## :no_entry_sign: Breaking
Nothing breaking detected

## :hammer_and_wrench: How to test
Try to save transaction into a file on a device/emulator with Android 11.
