### PR TITLE
Update branch name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ dependencies {
 
 ⚠️ Please note that the latest snapshot might be **unstable**. Use it at your own risk ⚠️
 
-If you're looking for the **latest stable version**, you can always find it on the top of the `release` branch.
+If you're looking for the **latest stable version**, you can always find it on the top of the `main` branch.
 
 ## FAQ ❓
 


### PR DESCRIPTION
## :page_facing_up: Context
The branch name `release` is stale as we updated to use `main`. I'm updating in the README

## :stopwatch: Next steps
n/a
