### PR TITLE
Add Unreleased section to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-This file follows [Keepchangelog](https://keepachangelog.com/) format. 
+This file follows [Keepachangelog](https://keepachangelog.com/) format. 
 Please add your entries according to this format.
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## UNRELEASED
+## Unreleased
 
 ### Changed
 
@@ -446,4 +446,4 @@ Initial release.
 [#394]: https://github.com/ChuckerTeam/chucker/issues/394
 [#410]: https://github.com/ChuckerTeam/chucker/issues/410
 [#422]: https://github.com/ChuckerTeam/chucker/issues/422
-[#465]: https://github.com/ChuckerTeam/chucker/issues/422
+[#465]: https://github.com/ChuckerTeam/chucker/issues/465

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+This file follows [Keepchangelog](https://keepachangelog.com/) format. 
+Please add your entries according to this format.
+
 ## Unreleased
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## UNRELEASED
+
+### Changed
+
+* Bumped `targetSDK` and `compileSDK` to 30 (Android 11).
+
+### Fixed
+
+* Fixed memory leak in MainActivity [#465].
+
 ## Version 3.3.0 *(2020-09-30)*
 
 This is a new minor release with multiple fixes and improvements. 
@@ -436,3 +446,4 @@ Initial release.
 [#394]: https://github.com/ChuckerTeam/chucker/issues/394
 [#410]: https://github.com/ChuckerTeam/chucker/issues/410
 [#422]: https://github.com/ChuckerTeam/chucker/issues/422
+[#465]: https://github.com/ChuckerTeam/chucker/issues/422


### PR DESCRIPTION
## :page_facing_up: Context
To ease the changelog support and to let our users know what changed in current snapshot versions this PR adds `Unreleased` section, which should be updated as more features/fixes merged into `develop` branch. 

Also, this PR also has slightly different format and titles to describe changes. I suggest such change to follow https://keepachangelog.com/en/1.0.0/ style as we move forward.

## :pencil: Changes
- Added `Unreleased` section to `Changelod.md`
- Changed the style of changes description in `Changelog.md`.
