### PR TITLE
Fix compiler flag for explicit API mode

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,7 +9,7 @@ android {
     compileOptions {
         kotlinOptions.freeCompilerArgs += [
             '-module-name', "com.github.ChuckerTeam.Chucker.library",
-            "-Xexplicit-apistrict"
+            "-Xexplicit-api=strict"
         ]
     }
 

--- a/library/src/test/java/com/chuckerteam/chucker/TestTransactionFactory.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/TestTransactionFactory.kt
@@ -3,7 +3,7 @@ package com.chuckerteam.chucker
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import java.util.Date
 
-object TestTransactionFactory {
+internal object TestTransactionFactory {
 
     internal fun createTransaction(method: String): HttpTransaction {
         return HttpTransaction(

--- a/library/src/test/java/com/chuckerteam/chucker/TestUtils.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/TestUtils.kt
@@ -9,15 +9,15 @@ import okio.ByteString
 import okio.Okio
 import java.io.File
 
-const val SEGMENT_SIZE = 8_192L
+internal const val SEGMENT_SIZE = 8_192L
 
-fun getResourceFile(file: String): Buffer {
+internal fun getResourceFile(file: String): Buffer {
     return Buffer().apply {
         writeAll(Okio.buffer(Okio.source(File("./src/test/resources/$file"))))
     }
 }
 
-fun Response.readByteStringBody(length: Long? = null): ByteString? {
+internal fun Response.readByteStringBody(length: Long? = null): ByteString? {
     return if (hasBody()) {
         body()?.source()?.use { source ->
             if (length == null) {
@@ -31,7 +31,7 @@ fun Response.readByteStringBody(length: Long? = null): ByteString? {
     }
 }
 
-fun <T> LiveData<T>.test(test: LiveDataRecord<T>.() -> Unit) {
+internal fun <T> LiveData<T>.test(test: LiveDataRecord<T>.() -> Unit) {
     val observer = RecordingObserver<T>()
     observeForever(observer)
     LiveDataRecord(observer).test()
@@ -39,7 +39,7 @@ fun <T> LiveData<T>.test(test: LiveDataRecord<T>.() -> Unit) {
     observer.records.clear()
 }
 
-class LiveDataRecord<T> internal constructor(
+internal class LiveDataRecord<T> internal constructor(
     private val observer: RecordingObserver<T>
 ) {
     fun expectData(): T {

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.EnumSource
 import java.io.File
 import java.net.HttpURLConnection.HTTP_NO_CONTENT
 
-class ChuckerInterceptorTest {
+internal class ChuckerInterceptorTest {
     enum class ClientFactory {
         APPLICATION {
             override fun create(interceptor: Interceptor): OkHttpClient {

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
@@ -3,7 +3,7 @@ package com.chuckerteam.chucker.internal.data.entity
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-class HttpTransactionTupleTest {
+internal class HttpTransactionTupleTest {
     @Test
     fun schemeIsSSL() {
         assertThat(createTuple(scheme = "https").isSsl).isTrue()

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class HttpTransactionDatabaseRepositoryTest {
+internal class HttpTransactionDatabaseRepositoryTest {
     @Rule
     @JvmField
     val instantExecutorRule = InstantTaskExecutorRule()

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProviderTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/RepositoryProviderTest.kt
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class RepositoryProviderTest {
+internal class RepositoryProviderTest {
     private lateinit var db: ChuckerDatabase
     private lateinit var context: Context
 

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -20,7 +20,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class HttpTransactionDaoTest {
+internal class HttpTransactionDaoTest {
     @Rule
     @JvmField
     val instantExecutorRule = InstantTaskExecutorRule()

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/ChuckerCrashHandlerTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/ChuckerCrashHandlerTest.kt
@@ -6,7 +6,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 
-class ChuckerCrashHandlerTest {
+internal class ChuckerCrashHandlerTest {
 
     @Test
     fun uncaughtException_isReportedCorrectly() {

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/DepletingSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/DepletingSourceTest.kt
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.io.IOException
 
-class DepletingSourceTest {
+internal class DepletingSourceTest {
     @Test
     fun delegateContent_isMovedToDownstream() {
         val delegate = Buffer().writeUtf8("Hello, world!")

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/FormatUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/FormatUtilsTest.kt
@@ -4,7 +4,7 @@ import com.chuckerteam.chucker.internal.data.entity.HttpHeader
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
-class FormatUtilsTest {
+internal class FormatUtilsTest {
 
     private val exampleHeadersList = listOf(
         HttpHeader("Accept", "text/html"),

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/FormattedUrlTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/FormattedUrlTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import okhttp3.HttpUrl
 import org.junit.Test
 
-class FormattedUrlTest {
+internal class FormattedUrlTest {
     @Test
     fun encodedUrl_withAllParams_isFormattedProperly() {
         val url = HttpUrl.get("https://www.example.com/path/to some/resource?q=\"Hello, world!\"")

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
@@ -16,7 +16,7 @@ import java.io.EOFException
 import java.nio.charset.Charset
 import java.util.stream.Stream
 
-class IOUtilsTest {
+internal class IOUtilsTest {
 
     private val mockContext = mockk<Context>()
     private val ioUtils = IOUtils(mockContext)

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/JsonConverterTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/JsonConverterTest.kt
@@ -3,7 +3,7 @@ package com.chuckerteam.chucker.internal.support
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
-class JsonConverterTest {
+internal class JsonConverterTest {
 
     @Test
     fun testInstance_sameInstance() {

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataCombineLatestTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataCombineLatestTest.kt
@@ -7,7 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
 
-class LiveDataCombineLatestTest {
+internal class LiveDataCombineLatestTest {
     @get:Rule val instantExecutorRule = InstantTaskExecutorRule()
 
     private val inputA = MutableLiveData<Boolean>()

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
@@ -8,7 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test
 
-class LiveDataDistinctUntilChangedTest {
+internal class LiveDataDistinctUntilChangedTest {
     @get:Rule val instantExecutorRule = InstantTaskExecutorRule()
 
     @Test

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
@@ -8,7 +8,7 @@ import okhttp3.Request
 import okhttp3.Response
 import org.junit.jupiter.api.Test
 
-class OkHttpUtilsTest {
+internal class OkHttpUtilsTest {
 
     @Test
     fun isChunked_withNotChunked() {

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/ReportingSinkTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/ReportingSinkTest.kt
@@ -14,7 +14,7 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import kotlin.random.Random
 
-class ReportingSinkTest {
+internal class ReportingSinkTest {
     private val reportingCallback = TestReportingCallback()
 
     @Test

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import java.io.IOException
 import kotlin.random.Random
 
-class TeeSourceTest {
+internal class TeeSourceTest {
     @Test
     fun bytesReadFromUpstream_areAvailableDownstream() {
         val testSource = TestSource()

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharableTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharableTest.kt
@@ -10,7 +10,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class TransactionCurlCommandSharableTest {
+internal class TransactionCurlCommandSharableTest {
     private val context: Context get() = ApplicationProvider.getApplicationContext()
 
     private val requestMethods = listOf("GET", "POST", "PUT", "DELETE")

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionDetailsSharableTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionDetailsSharableTest.kt
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class TransactionDetailsSharableTest {
+internal class TransactionDetailsSharableTest {
     private val context: Context get() = ApplicationProvider.getApplicationContext()
 
     @Test

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionListDetailsSharableTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionListDetailsSharableTest.kt
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class TransactionListDetailsSharableTest {
+internal class TransactionListDetailsSharableTest {
     private val context: Context get() = ApplicationProvider.getApplicationContext()
 
     @Test


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

The explicit API mode compiler flag had a typo in the library module.

## :pencil: Changes
<!-- Which code did you change? How? -->

I fixed the typo. I also added explicit visibility modifiers to tests. I used `internal` because it's less work than to mark everything as `public`.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

#363

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.
