### PR TITLE
Remove kotlin-android-extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ Please add your entries according to this format.
 ### Changed
 
 * Bumped `targetSDK` and `compileSDK` to 30 (Android 11).
+* Removed `kotlin-android-extensions` plugin.
 
 ### Fixed
 
 * Fixed memory leak in MainActivity [#465].
+* Fixed build failure for projects with new `kotlin-parcelize` plugin [#480].
 
 ## Version 3.3.0 *(2020-09-30)*
 
@@ -450,3 +452,4 @@ Initial release.
 [#410]: https://github.com/ChuckerTeam/chucker/issues/410
 [#422]: https://github.com/ChuckerTeam/chucker/issues/422
 [#465]: https://github.com/ChuckerTeam/chucker/issues/465
+[#480]: https://github.com/ChuckerTeam/chucker/issues/480

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdkVersion
@@ -11,6 +10,10 @@ android {
         applicationId "com.chuckerteam.chucker.sample"
         versionCode 1
         versionName "1.0"
+    }
+
+    buildFeatures {
+        viewBinding = true
     }
 
     buildTypes {

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -4,9 +4,11 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.chuckerteam.chucker.api.Chucker
-import kotlinx.android.synthetic.main.activity_main_sample.*
+import com.chuckerteam.chucker.sample.databinding.ActivityMainSampleBinding
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var mainBinding: ActivityMainSampleBinding
 
     private val client: HttpBinClient by lazy {
         HttpBinClient(applicationContext)
@@ -14,14 +16,16 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main_sample)
 
-        do_http.setOnClickListener { client.doHttpActivity() }
-        trigger_exception.setOnClickListener { client.recordException() }
+        mainBinding = ActivityMainSampleBinding.inflate(layoutInflater)
 
-        with(launch_chucker_directly) {
-            visibility = if (Chucker.isOp) View.VISIBLE else View.GONE
-            setOnClickListener { launchChuckerDirectly() }
+        with(mainBinding) {
+            setContentView(root)
+            doHttp.setOnClickListener { client.doHttpActivity() }
+            triggerException.setOnClickListener { client.recordException() }
+
+            launchChuckerDirectly.visibility = if (Chucker.isOp) View.VISIBLE else View.GONE
+            launchChuckerDirectly.setOnClickListener { launchChuckerDirectly() }
         }
 
         client.initializeCrashHandler()


### PR DESCRIPTION
## :page_facing_up: Context
There is an open issue #480 . To fix it, I suggest to remove the `kotlin-android-extensions` plugin from the library.
Also, Chucker uses `ViewBinding` for quite a long time already, so we can get rid of this plugin anyway.

## :pencil: Changes
- Removed `kotlin-android-extensions` plugin from `library` module.
- Removed `kotlin-android-extensions` plugin from `sample` module.
- Enabled `ViewBinding` in `sample` module.

## :no_entry_sign: Breaking
Nothing

## :hammer_and_wrench: How to test
Run sample app and see that everything works fine.

## :stopwatch: Next steps
Closes #480 