### PR TITLE
Remove deprecated constructor and use exposed builder pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file follows [Keepachangelog](https://keepachangelog.com/) format. 
 Please add your entries according to this format.
 
+## Unreleased
+
+### Removed
+
+* Removed parametrized `ChuckerInterceptor` constructor in favour of builder pattern. Constructor that accepts only `Context` is still available.
+
 ## Version 3.4.0 *(2020-11-05)*
 
 ### Added

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -9,13 +9,14 @@ import kotlin.jvm.Throws
 /**
  * No-op implementation.
  */
-public class ChuckerInterceptor @JvmOverloads constructor(
-    context: Context,
-    collector: Any? = null,
-    maxContentLength: Any? = null,
-    headersToRedact: Any? = null,
-    alwaysReadResponseBody: Any? = null,
+public class ChuckerInterceptor private constructor(
+    builder: Builder,
 ) : Interceptor {
+
+    /**
+     * No-op implementation.
+     */
+    public constructor(context: Context) : this(Builder(context))
 
     public fun redactHeaders(vararg names: String): ChuckerInterceptor {
         return this
@@ -41,6 +42,6 @@ public class ChuckerInterceptor @JvmOverloads constructor(
 
         public fun alwaysReadResponseBody(enable: Boolean): Builder = this
 
-        public fun build(): ChuckerInterceptor = ChuckerInterceptor(context)
+        public fun build(): ChuckerInterceptor = ChuckerInterceptor(this)
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
@@ -33,14 +33,13 @@ internal class ChuckerInterceptorDelegate(
         }
     }
 
-    private val chucker = ChuckerInterceptor(
-        context = mockContext,
-        collector = mockCollector,
-        maxContentLength = maxContentLength,
-        headersToRedact = headersToRedact,
-        cacheDirectoryProvider = cacheDirectoryProvider,
-        alwaysReadResponseBody = alwaysReadResponseBody,
-    )
+    private val chucker = ChuckerInterceptor.Builder(context = mockContext)
+        .collector(mockCollector)
+        .maxContentLength(maxContentLength)
+        .redactHeaders(headersToRedact)
+        .alwaysReadResponseBody(alwaysReadResponseBody)
+        .cacheDirectorProvider(cacheDirectoryProvider)
+        .build()
 
     internal fun expectTransaction(): HttpTransaction {
         if (transactions.isEmpty()) {

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -31,12 +31,11 @@ class HttpBinClient(
         retentionPeriod = RetentionManager.Period.ONE_HOUR
     )
 
-    private val chuckerInterceptor = ChuckerInterceptor(
-        context = context,
-        collector = collector,
-        maxContentLength = 250000L,
-        headersToRedact = emptySet<String>()
-    )
+    private val chuckerInterceptor = ChuckerInterceptor.Builder(context)
+        .collector(collector)
+        .maxContentLength(250000L)
+        .redactHeaders(emptySet())
+        .build()
 
     private val httpClient =
         OkHttpClient.Builder()


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an issue - #462.

## :pencil: Changes
<!-- Which code did you change? How? -->

This implementation uses more robust builder pattern in terms of future development. It should be used with `4.x`. There is one inconvenience when it comes to default values but it is not that big of a deal. I'll describe it more in the comments to the code.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

Yes it breaks both API and ABI, but it is for `4.x`.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

~~I suggest reviewing commits separately. With 5e7d733 you can check if `ReplaceWith` works correctly.~~

Nothing special to test.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Closes #462

Helps with #466. It does not solve it, but I don't think we can fix it unfortunately. We can only make sure that in the future we don't fall into the same trap. Though suggestion with adding ABI compatibility tool would be a nice addition.

We should consider doing the same with `ChuckerCollector` and `RetentionManger`. They do not change that dynamically, so there might be no reason to switch there to the builder pattern but on the other hand it might pose at some point in the future same issues as #466.