### PR TITLE
Fix for not closed GzipSource

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
@@ -57,7 +57,7 @@ internal class IOUtils(private val context: Context) {
 
     fun getNativeSource(input: BufferedSource, isGzipped: Boolean): BufferedSource = if (isGzipped) {
         val source = GzipSource(input)
-        Okio.buffer(source)
+        source.use { Okio.buffer(it) }
     } else {
         input
     }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
@@ -100,19 +100,18 @@ internal class IOUtilsTest {
 
     @Test
     fun getNativeSource_withNotGzipped() {
-        val mockBuffer = mockk<Buffer>()
+        val buffer = Buffer()
 
-        val nativeSource = ioUtils.getNativeSource(mockBuffer, false)
-
-        assertThat(nativeSource).isEqualTo(mockBuffer)
+        val nativeSource = ioUtils.getNativeSource(buffer, false)
+        assertThat(nativeSource).isEqualTo(buffer)
     }
 
     @Test
     fun getNativeSource_withGzipped() {
-        val mockBuffer = mockk<Buffer>()
+        val buffer = Buffer()
 
-        val nativeSource = ioUtils.getNativeSource(mockBuffer, true)
-        assertThat(nativeSource).isNotEqualTo(mockBuffer)
+        val nativeSource = ioUtils.getNativeSource(buffer, true)
+        assertThat(nativeSource).isNotEqualTo(buffer)
     }
 
     @ParameterizedTest(name = "{0} must be supported? {1}")

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinApi.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinApi.kt
@@ -7,6 +7,7 @@ import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.Headers
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -61,7 +62,11 @@ internal interface HttpBinApi {
     fun image(@Header("Accept") accept: String): Call<Any?>
 
     @GET("/gzip")
-    fun gzip(): Call<Any?>
+    fun gzipResponse(): Call<Any?>
+
+    @POST("/post")
+    @Headers("Content-Encoding: gzip")
+    fun gzipRequest(@Body body: Data): Call<Any?>
 
     @GET("/xml")
     fun xml(): Call<Any?>

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -82,7 +82,8 @@ class HttpBinClient(
             stream(500).enqueue(cb)
             streamBytes(2048).enqueue(cb)
             image("image/png").enqueue(cb)
-            gzip().enqueue(cb)
+            gzipResponse().enqueue(cb)
+            gzipRequest(Data("Some gzip request")).enqueue(cb)
             xml().enqueue(cb)
             utf8().enqueue(cb)
             deflate().enqueue(cb)
@@ -99,7 +100,6 @@ class HttpBinClient(
         downloadSampleImage(colorHex = "fff")
         downloadSampleImage(colorHex = "000")
         getResponsePartially()
-        fakeGzipRequest()
     }
 
     internal fun initializeCrashHandler() {
@@ -116,24 +116,6 @@ class HttpBinClient(
         val request = Request.Builder()
             .url("https://dummyimage.com/200x200/$colorHex/$colorHex.png")
             .get()
-            .build()
-        httpClient.newCall(request).enqueue(
-            object : okhttp3.Callback {
-                override fun onFailure(call: okhttp3.Call, e: IOException) = Unit
-
-                override fun onResponse(call: okhttp3.Call, response: okhttp3.Response) {
-                    response.body()?.source()?.use { it.readByteString() }
-                }
-            }
-        )
-    }
-
-    private fun fakeGzipRequest() {
-        val body = RequestBody.create(MediaType.get("application/json"), "Some invalid fake gzip request")
-        val request = Request.Builder()
-            .header("Content-Encoding", "gzip")
-            .url("$BASE_URL/gzip")
-            .post(body)
             .build()
         httpClient.newCall(request).enqueue(
             object : okhttp3.Callback {

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.chuckerteam.chucker.sample
 
 import android.os.Bundle
+import android.os.StrictMode
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.chuckerteam.chucker.api.Chucker
@@ -29,6 +30,14 @@ class MainActivity : AppCompatActivity() {
         }
 
         client.initializeCrashHandler()
+
+        StrictMode.setVmPolicy(
+            StrictMode.VmPolicy.Builder()
+                .detectLeakedClosableObjects()
+                .penaltyLog()
+                .penaltyDeath()
+                .build()
+        )
     }
 
     private fun launchChuckerDirectly() {


### PR DESCRIPTION
## :page_facing_up: Context
There is an issue #472 
Issue appears with StrictMode enabled. We couldn't catch the issue earlier, because sample app has no gzip request with body, so code with error wasn't reachable.

## :pencil: Changes
- Fixed the issue by adding `use { }` function to GzipSource in `getNativeSource()` function.
- Updated tests to use real `Buffer()`, since Mockk can't properly react to `close()` call.
- Added a fake Gzip request which I fill with some dummy request body and header telling that response is with gzip encoding. It returns 405, but allows to reproduce the issue.
- Added StrictMode to the sample app, because this is not the first time we have issues reported by people with this mode enabled (for example #421)
- (UPD: after review) Renamed existing gzip request to explicitly mention that it returns just gzip response.

## :hammer_and_wrench: How to test
To reproduce the issue remove `use` from `getNativeSource()` and use just GzipSource directly. With StrictMode enabled sample will crash when `fakeGzipRequest()` is called.

## :stopwatch: Next steps
We might want to improve the part of request processing and cover it with some more tests.
Closes #472 
