### PR TITLE
Use builder pattern for ChuckerInterceptor in a backwards compatible way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+### Added
+
+* `ChuckerInterceptor.Builder` for fluent creation of the interceptor. It will also help us with preserving binary compatibility in future releases of `4.x`. [#462]
+
 ### Changed
 
 * Bumped `targetSDK` and `compileSDK` to 30 (Android 11).
@@ -14,6 +18,10 @@ Please add your entries according to this format.
 
 * Fixed memory leak in MainActivity [#465].
 * Fixed build failure for projects with new `kotlin-parcelize` plugin [#480].
+
+### Deprecated
+
+* `ChuckerInterceptor` constructor is now deprecated. Unless `Context` is the only parameter that you pass into the constructor you should migrate to builder.
 
 ## Version 3.3.0 *(2020-09-30)*
 

--- a/README.md
+++ b/README.md
@@ -88,18 +88,18 @@ val chuckerCollector = ChuckerCollector(
 )
 
 // Create the Interceptor
-val chuckerInterceptor = ChuckerInterceptor(
-        context = this,
+val chuckerInterceptor = ChuckerInterceptor.Builder(context)
         // The previously created Collector
-        collector = chuckerCollector,
+        .collector(chuckerCollector)
         // The max body content length in bytes, after this responses will be truncated.
-        maxContentLength = 250000L,
+        .maxContentLength(250_000L)
         // List of headers to replace with ** in the Chucker UI
-        headersToRedact = setOf("Auth-Token"),
+        .redactHeaders("Auth-Token", "Bearer")
         // Read the whole response body even when the client does not consume the response completely.
         // This is useful in case of parsing errors or when the response body
         // is closed before being read like in Retrofit with Void and Unit types.
-        alwaysReadResponseBody = true
+        .alwaysReadResponseBody(true)
+        .build()
 )
 
 // Don't forget to plug the ChuckerInterceptor inside the OkHttpClient

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -26,4 +26,21 @@ public class ChuckerInterceptor @JvmOverloads constructor(
         val request = chain.request()
         return chain.proceed(request)
     }
+
+    /**
+     * No-op implementation.
+     */
+    public class Builder(private val context: Context) {
+        public fun collector(collector: ChuckerCollector): Builder = this
+
+        public fun maxContentLength(length: Long): Builder = this
+
+        public fun redactHeaders(headerNames: Iterable<String>): Builder = this
+
+        public fun redactHeaders(vararg headerNames: String): Builder = this
+
+        public fun alwaysReadResponseBody(enable: Boolean): Builder = this
+
+        public fun build(): ChuckerInterceptor = ChuckerInterceptor(context)
+    }
 }


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

It is a follow up to the discussion in #483. It also addresses #462 and #466.

## :pencil: Changes
<!-- Which code did you change? How? -->

I added a builder pattern in a `3.x` compatible way. This way users will be informed of changes and have more time to adjust their code. Unfortunately, `ReplaceWith` is not ideal. `imports` do no work properly with default arguments but IMHO it is a minor inconvenience (basically, only `ChuckerCollector` needs to be manually imported). Also, it will create builder with all fields. I've tried to split constructor into different ones with different `ReplaceWith` strategies but it is not possible due to named arguments and source compatibility in Kotlin.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

#462

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

You can check if `ReplaceWith` works correctly.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Prepare `3.4.0` release and `3.x` branch.
