### PR TITLE
Fixed typo on DialogData

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/model/DialogData.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/model/DialogData.kt
@@ -3,6 +3,6 @@ package com.chuckerteam.chucker.internal.data.model
 internal data class DialogData(
     val title: String,
     val message: String,
-    val postiveButtonText: String?,
+    val positiveButtonText: String?,
     val negativeButtonText: String?
 )

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ContextExt.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ContextExt.kt
@@ -12,7 +12,7 @@ internal fun Context.showDialog(
     MaterialAlertDialogBuilder(this)
         .setTitle(dialogData.title)
         .setMessage(dialogData.message)
-        .setPositiveButton(dialogData.postiveButtonText) { _, _ ->
+        .setPositiveButton(dialogData.positiveButtonText) { _, _ ->
             onPositiveClick?.invoke()
         }
         .setNegativeButton(dialogData.negativeButtonText) { _, _ ->

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionListFragment.kt
@@ -146,14 +146,14 @@ internal class TransactionListFragment :
     private fun getClearDialogData(): DialogData = DialogData(
         title = getString(R.string.chucker_clear),
         message = getString(R.string.chucker_clear_http_confirmation),
-        postiveButtonText = getString(R.string.chucker_clear),
+        positiveButtonText = getString(R.string.chucker_clear),
         negativeButtonText = getString(R.string.chucker_cancel)
     )
 
     private fun getExportDialogData(): DialogData = DialogData(
         title = getString(R.string.chucker_export),
         message = getString(R.string.chucker_export_http_confirmation),
-        postiveButtonText = getString(R.string.chucker_export),
+        positiveButtonText = getString(R.string.chucker_export),
         negativeButtonText = getString(R.string.chucker_cancel)
     )
 


### PR DESCRIPTION
## :page_facing_up: Context
We had a typo in the `DialogData` class.

## :pencil: Changes
Updating the property name from `postiveButtonText` to `positiveButtonText`

## :stopwatch: Next steps
n/a
