### PR TITLE
Add binary-compatibility-validator to Chucker

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -76,6 +76,27 @@ jobs:
     - name: Stop Gradle
       run: ./gradlew --stop
 
+  api-check:
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Cache Gradle Folders
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ hashFiles('build.gradle') }}
+          restore-keys: cache-gradle-
+
+      - name: Run apiCheck
+        run: ./gradlew apiCheck
+
+      - name: Stop Gradle
+        run: ./gradlew --stop
+
   publish-artifact:
     runs-on: [ubuntu-latest]
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
         retrofitVersion = '2.9.0'
 
         // Debug and quality control
+        binaryCompatibilityValidator = '0.2.4'
         detektVersion = '1.14.0'
         dokkaVersion = '1.4.10.2'
         ktLintVersion = '0.39.0'
@@ -49,7 +50,17 @@ buildscript {
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktLintGradleVersion"
+        classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binaryCompatibilityValidator"
     }
+}
+apply plugin: 'binary-compatibility-validator'
+
+apiValidation {
+    ignoredProjects += ["sample"]
+    ignoredPackages += [
+            "com.chuckerteam.chucker.internal",
+            "com.chuckerteam.chucker.databinding"
+    ]
 }
 
 allprojects {

--- a/library-no-op/api/library-no-op.api
+++ b/library-no-op/api/library-no-op.api
@@ -1,0 +1,56 @@
+public final class com/chuckerteam/chucker/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class com/chuckerteam/chucker/api/Chucker {
+	public static final field INSTANCE Lcom/chuckerteam/chucker/api/Chucker;
+	public static final fun dismissNotifications (Landroid/content/Context;)V
+	public static final fun getLaunchIntent (Landroid/content/Context;)Landroid/content/Intent;
+	public final fun isOp ()Z
+}
+
+public final class com/chuckerteam/chucker/api/ChuckerCollector {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Z)V
+	public fun <init> (Landroid/content/Context;ZLcom/chuckerteam/chucker/api/RetentionManager$Period;)V
+	public synthetic fun <init> (Landroid/content/Context;ZLcom/chuckerteam/chucker/api/RetentionManager$Period;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getShowNotification ()Z
+	public final fun setShowNotification (Z)V
+}
+
+public final class com/chuckerteam/chucker/api/ChuckerInterceptor : okhttp3/Interceptor {
+	public fun <init> (Landroid/content/Context;)V
+	public synthetic fun <init> (Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
+	public final fun redactHeaders ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor;
+}
+
+public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
+	public fun <init> (Landroid/content/Context;)V
+	public final fun alwaysReadResponseBody (Z)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun build ()Lcom/chuckerteam/chucker/api/ChuckerInterceptor;
+	public final fun collector (Lcom/chuckerteam/chucker/api/ChuckerCollector;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun maxContentLength (J)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun redactHeaders (Ljava/lang/Iterable;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun redactHeaders ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+}
+
+public final class com/chuckerteam/chucker/api/RetentionManager {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/Object;)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun doMaintenance ()V
+}
+
+public final class com/chuckerteam/chucker/api/RetentionManager$Period : java/lang/Enum {
+	public static final field FOREVER Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static final field ONE_DAY Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static final field ONE_HOUR Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static final field ONE_WEEK Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static fun valueOf (Ljava/lang/String;)Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static fun values ()[Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+}
+

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -1,0 +1,55 @@
+public final class com/chuckerteam/chucker/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class com/chuckerteam/chucker/api/Chucker {
+	public static final field INSTANCE Lcom/chuckerteam/chucker/api/Chucker;
+	public static final fun dismissNotifications (Landroid/content/Context;)V
+	public static final fun getLaunchIntent (Landroid/content/Context;)Landroid/content/Intent;
+	public final fun isOp ()Z
+}
+
+public final class com/chuckerteam/chucker/api/ChuckerCollector {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Z)V
+	public fun <init> (Landroid/content/Context;ZLcom/chuckerteam/chucker/api/RetentionManager$Period;)V
+	public synthetic fun <init> (Landroid/content/Context;ZLcom/chuckerteam/chucker/api/RetentionManager$Period;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getShowNotification ()Z
+	public final fun setShowNotification (Z)V
+}
+
+public final class com/chuckerteam/chucker/api/ChuckerInterceptor : okhttp3/Interceptor {
+	public fun <init> (Landroid/content/Context;)V
+	public synthetic fun <init> (Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun intercept (Lokhttp3/Interceptor$Chain;)Lokhttp3/Response;
+	public final fun redactHeader ([Ljava/lang/String;)V
+}
+
+public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
+	public fun <init> (Landroid/content/Context;)V
+	public final fun alwaysReadResponseBody (Z)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun build ()Lcom/chuckerteam/chucker/api/ChuckerInterceptor;
+	public final fun collector (Lcom/chuckerteam/chucker/api/ChuckerCollector;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun maxContentLength (J)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun redactHeaders (Ljava/lang/Iterable;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun redactHeaders ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+}
+
+public final class com/chuckerteam/chucker/api/RetentionManager {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Lcom/chuckerteam/chucker/api/RetentionManager$Period;)V
+	public synthetic fun <init> (Landroid/content/Context;Lcom/chuckerteam/chucker/api/RetentionManager$Period;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/chuckerteam/chucker/api/RetentionManager$Period : java/lang/Enum {
+	public static final field FOREVER Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static final field ONE_DAY Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static final field ONE_HOUR Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static final field ONE_WEEK Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static fun valueOf (Ljava/lang/String;)Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+	public static fun values ()[Lcom/chuckerteam/chucker/api/RetentionManager$Period;
+}
+


### PR DESCRIPTION
## :page_facing_up: Context
To prevent problems like #466 in the future, I'm introducing https://github.com/Kotlin/binary-compatibility-validator to Chucker.

This will force any PR that touches the public API, to also include a change to the corresponding `.api` file. To recompute the `.api` file, developers should just call `gw apiDump`.

## :pencil: Changes
- Introduced `binary-compatibility-validator` plugin
- Added a new GH Actions job for running `apiCheck` before merging
- Excluded project `sample` and non public packages from the API surface.

## :paperclip: Related PR
Follow-up from #466

## :no_entry_sign: Breaking
None

## :hammer_and_wrench: How to test
Please take a look at the `.api` file and let me know if you agree on it.
If the CI is green, we should be good to go.

## :stopwatch: Next steps
n/a
