### PR TITLE
Fix broken lint and add it to GH Actions

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -55,6 +55,27 @@ jobs:
     - name: Stop Gradle
       run: ./gradlew --stop
 
+  lint:
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Cache Gradle Folders
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches/
+            ~/.gradle/wrapper/
+          key: cache-gradle-${{ hashFiles('build.gradle') }}
+          restore-keys: cache-gradle-
+
+      - name: Run lint
+        run: ./gradlew lint
+
+      - name: Stop Gradle
+        run: ./gradlew --stop
+
   ktlint:
     runs-on: [ubuntu-latest]
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -41,6 +41,7 @@ android {
     lintOptions {
         warningsAsErrors true
         abortOnError true
+        disable 'AcceptsUserCertificates'
     }
 
     compileOptions {

--- a/sample/src/debug/AndroidManifest.xml
+++ b/sample/src/debug/AndroidManifest.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
+<manifest xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:networkSecurityConfig="@xml/network_security_config"
-        >
+        tools:targetApi="n">
     </application>
 </manifest>

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -1,6 +1,6 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="norm_grid_size">8dp</dimen>
+    <dimen name="norm_grid_size" tools:ignore="UnusedResources">8dp</dimen>
     <dimen name="doub_grid_size">16dp</dimen>
     <dimen name="max_width">500dp</dimen>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -2,7 +2,6 @@
     <string name="app_name">Chucker Sample</string>
     <string name="do_http_activity">Do HTTP activity</string>
     <string name="launch_chucker_directly">Launch Chucker directly</string>
-    <string name="trigger_exception">Trigger an exception</string>
 
     <string name="intro_title">Welcome to Chucker Sample App</string>
     <string name="intro_body">You can use this sample app to do some HTTP networking and to see how Chucker can help you inspect your networking calls.</string>


### PR DESCRIPTION
## :page_facing_up: Context
Lint is currently broken on `develop`. I'm fixing it and I've added a job on GH Actions to run it on pre-merge. If you happen to run `gw check` to run all the verifications, it will fail.

## :pencil: Changes
- Disabled `AcceptsUserCertificates` as we intentionally want to allow user CAs
- Fixed error on `android:networkSecurityConfig`

## :stopwatch: Next steps
I believe we should update the pre-commit hook to run `gw check`
