### PR TITLE
Disable BuildConfig generation

### DIFF
--- a/library-no-op/api/library-no-op.api
+++ b/library-no-op/api/library-no-op.api
@@ -1,10 +1,3 @@
-public final class com/chuckerteam/chucker/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public final class com/chuckerteam/chucker/api/Chucker {
 	public static final field INSTANCE Lcom/chuckerteam/chucker/api/Chucker;
 	public static final fun dismissNotifications (Landroid/content/Context;)V

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -11,6 +11,10 @@ android {
         ]
     }
 
+    buildFeatures {
+        buildConfig = false
+    }
+
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
     }

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -1,10 +1,3 @@
-public final class com/chuckerteam/chucker/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public final class com/chuckerteam/chucker/api/Chucker {
 	public static final field INSTANCE Lcom/chuckerteam/chucker/api/Chucker;
 	public static final fun dismissNotifications (Landroid/content/Context;)V

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -23,6 +23,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig = false
     }
 
     lintOptions {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,6 +14,7 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig = false
     }
 
     buildTypes {


### PR DESCRIPTION
## :camera: Screenshots
Before
<img width="478" alt="Screenshot 2020-11-29 at 22 23 33" src="https://user-images.githubusercontent.com/13467769/100729818-ed754880-33d1-11eb-849d-a93ce5bb4b7a.png">

After
<img width="489" alt="Screenshot 2020-12-01 at 12 35 57" src="https://user-images.githubusercontent.com/13467769/100729734-d171a700-33d1-11eb-9942-c0799319242f.png">

## :page_facing_up: Context
Chucker has `BuildConfig` available in the public API as mentioned [here](https://github.com/ChuckerTeam/chucker/pull/509/files#r532265254), but generating this file has no value for customers. 
This PR disables `BuildConfig` generation in both `library` and `library-no-op` modules as well as in the `sample` app module.

## :pencil: Changes
- Added `buildFeatures.buildConfig = false` to every module.

## :no_entry_sign: Breaking
Yes, with this change we are breaking Chucker public API. 

## :hammer_and_wrench: How to test
Use the library from this branch and try to refer to `BuildConfig` in the app using Chucker.