### PR TITLE
Switch to OkHttp BOM in the library module

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -63,7 +63,10 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion"
 
     implementation "com.google.code.gson:gson:$gsonVersion"
-    api "com.squareup.okhttp3:okhttp:$okhttpVersion"
+
+    api platform("com.squareup.okhttp3:okhttp-bom:$okhttpVersion")
+    api "com.squareup.okhttp3:okhttp"
+    testImplementation "com.squareup.okhttp3:mockwebserver"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
@@ -71,7 +74,6 @@ dependencies {
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$vintageJunitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     testImplementation "io.mockk:mockk:$mockkVersion"
-    testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
     testImplementation "androidx.test:core:$androidxTestCoreVersion"
     testImplementation "androidx.arch.core:core-testing:$androidXCoreVersion"
     testImplementation "com.google.truth:truth:$truthVersion"


### PR DESCRIPTION
## :page_facing_up: Context
Since we are going to add more OkHttp packages, for example, to implement #202 I suggest us to switch to BOM for OkHttp.
I think that we are fine with using BOM only in the `library` module, since in `library-no-op` and in `sample` we use only one package from OkHttp set.

## :pencil: Changes
- Switched to BOM for OkHttp dependencies in `build.gradle` file

## :no_entry_sign: Breaking
Nothing breaking expected 