### PR TITLE
Use ListAdapter for TransactionsAdapter

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -10,7 +10,7 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
  * This Tuple is good to be used on List or Preview interfaces.
  */
 @Suppress("LongParameterList")
-internal class HttpTransactionTuple(
+internal data class HttpTransactionTuple(
     @ColumnInfo(name = "id") var id: Long,
     @ColumnInfo(name = "requestDate") var requestDate: Long?,
     @ColumnInfo(name = "tookMs") var tookMs: Long?,

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionDiffCallback.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionDiffCallback.kt
@@ -11,4 +11,7 @@ internal object TransactionDiffCallback : DiffUtil.ItemCallback<HttpTransactionT
     override fun areContentsTheSame(oldItem: HttpTransactionTuple, newItem: HttpTransactionTuple): Boolean {
         return oldItem == newItem
     }
+
+    // Overriding function is empty on purpose to avoid flickering by default animator
+    override fun getChangePayload(oldItem: HttpTransactionTuple, newItem: HttpTransactionTuple) {}
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionDiffCallback.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionDiffCallback.kt
@@ -13,5 +13,5 @@ internal object TransactionDiffCallback : DiffUtil.ItemCallback<HttpTransactionT
     }
 
     // Overriding function is empty on purpose to avoid flickering by default animator
-    override fun getChangePayload(oldItem: HttpTransactionTuple, newItem: HttpTransactionTuple) {}
+    override fun getChangePayload(oldItem: HttpTransactionTuple, newItem: HttpTransactionTuple) = Unit
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionDiffCallback.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionDiffCallback.kt
@@ -1,0 +1,14 @@
+package com.chuckerteam.chucker.internal.support
+
+import androidx.recyclerview.widget.DiffUtil
+import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
+
+internal object TransactionDiffCallback : DiffUtil.ItemCallback<HttpTransactionTuple>() {
+    override fun areItemsTheSame(oldItem: HttpTransactionTuple, newItem: HttpTransactionTuple): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: HttpTransactionTuple, newItem: HttpTransactionTuple): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -58,7 +58,7 @@ internal class MainActivity :
         viewModel.transactions.observe(
             this,
             { transactionTuples ->
-                transactionsAdapter.setData(transactionTuples)
+                transactionsAdapter.submitList(transactionTuples)
                 mainBinding.tutorialGroup.isVisible = transactionTuples.isEmpty()
             }
         )

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -8,19 +8,20 @@ import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.widget.ImageViewCompat
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerListItemTransactionBinding
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
+import com.chuckerteam.chucker.internal.support.TransactionDiffCallback
 import java.text.DateFormat
 import javax.net.ssl.HttpsURLConnection
 
 internal class TransactionAdapter internal constructor(
     context: Context,
     private val onTransactionClick: (Long) -> Unit,
-) : RecyclerView.Adapter<TransactionAdapter.TransactionViewHolder>() {
-    private var transactions: List<HttpTransactionTuple> = arrayListOf()
+) : ListAdapter<HttpTransactionTuple, TransactionAdapter.TransactionViewHolder>(TransactionDiffCallback) {
 
     private val colorDefault: Int = ContextCompat.getColor(context, R.color.chucker_status_default)
     private val colorRequested: Int = ContextCompat.getColor(context, R.color.chucker_status_requested)
@@ -29,20 +30,13 @@ internal class TransactionAdapter internal constructor(
     private val color400: Int = ContextCompat.getColor(context, R.color.chucker_status_400)
     private val color300: Int = ContextCompat.getColor(context, R.color.chucker_status_300)
 
-    override fun getItemCount(): Int = transactions.size
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TransactionViewHolder {
         val viewBinding = ChuckerListItemTransactionBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         return TransactionViewHolder(viewBinding)
     }
 
     override fun onBindViewHolder(holder: TransactionViewHolder, position: Int) =
-        holder.bind(transactions[position])
-
-    fun setData(httpTransactions: List<HttpTransactionTuple>) {
-        this.transactions = httpTransactions
-        notifyDataSetChanged()
-    }
+        holder.bind(getItem(position))
 
     inner class TransactionViewHolder(
         private val itemBinding: ChuckerListItemTransactionBinding


### PR DESCRIPTION
## :page_facing_up: Context
Something that I mentioned in different chats or issues (for example [here](https://github.com/ChuckerTeam/chucker/issues/286)), but never delivered - updating transactions list nicely with `DiffUtil` via `ListAdapter`

## :pencil: Changes
- Switched from regular `RecyclerView.Adapter` to `ListAdapter`

## :no_entry_sign: Breaking
Nothing breaking expected

## :hammer_and_wrench: How to test
Run the sample app and check how transactions list updates when some network activity happens and during the search
