### PR TITLE
Centralise all logging in Chucker

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -2,6 +2,8 @@ package com.chuckerteam.chucker.api
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
+import com.chuckerteam.chucker.internal.support.Logger
 import com.chuckerteam.chucker.internal.support.NotificationHelper
 import com.chuckerteam.chucker.internal.ui.MainActivity
 
@@ -34,5 +36,21 @@ public object Chucker {
     @JvmStatic
     public fun dismissNotifications(context: Context) {
         NotificationHelper(context).dismissNotifications()
+    }
+
+    internal var logger: Logger = object : Logger {
+        val TAG = "Chucker"
+
+        override fun info(message: String) {
+            Log.i(TAG, message)
+        }
+
+        override fun warn(message: String) {
+            Log.w(TAG, message)
+        }
+
+        override fun error(message: String, throwable: Throwable?) {
+            Log.e(TAG, message, throwable)
+        }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -7,6 +7,7 @@ import com.chuckerteam.chucker.internal.support.CacheDirectoryProvider
 import com.chuckerteam.chucker.internal.support.DepletingSource
 import com.chuckerteam.chucker.internal.support.FileFactory
 import com.chuckerteam.chucker.internal.support.IOUtils
+import com.chuckerteam.chucker.internal.support.Logger
 import com.chuckerteam.chucker.internal.support.ReportingSink
 import com.chuckerteam.chucker.internal.support.TeeSource
 import com.chuckerteam.chucker.internal.support.contentType
@@ -183,7 +184,7 @@ public class ChuckerInterceptor private constructor(
     private fun createTempTransactionFile(): File? {
         val cache = cacheDirectoryProvider.provide()
         return if (cache == null) {
-            IOException("Failed to obtain a valid cache directory for Chucker transaction file").printStackTrace()
+            Logger.warn("Failed to obtain a valid cache directory transaction file")
             null
         } else {
             FileFactory.create(cache)
@@ -245,7 +246,9 @@ public class ChuckerInterceptor private constructor(
             file?.delete()
         }
 
-        override fun onFailure(file: File?, exception: IOException) = exception.printStackTrace()
+        override fun onFailure(file: File?, exception: IOException) {
+            Logger.error("Failed to read response payload", exception)
+        }
 
         private fun readResponseBuffer(responseBody: File, isGzipped: Boolean) = try {
             val bufferedSource = responseBody.source().buffer()
@@ -256,7 +259,7 @@ public class ChuckerInterceptor private constructor(
             }
             Buffer().apply { source.use { writeAll(it) } }
         } catch (e: IOException) {
-            IOException("Response payload couldn't be processed by Chucker", e).printStackTrace()
+            Logger.error("Response payload couldn't be processed", e)
             null
         }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -184,7 +184,7 @@ public class ChuckerInterceptor private constructor(
     private fun createTempTransactionFile(): File? {
         val cache = cacheDirectoryProvider.provide()
         return if (cache == null) {
-            Logger.warn("Failed to obtain a valid cache directory transaction file")
+            Logger.warn("Failed to obtain a valid cache directory for transaction files")
             null
         } else {
             FileFactory.create(cache)

--- a/library/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
@@ -3,7 +3,7 @@ package com.chuckerteam.chucker.api
 import android.content.Context
 import android.content.SharedPreferences
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
-import com.chuckerteam.chucker.internal.support.Logger.info
+import com.chuckerteam.chucker.internal.support.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -44,7 +44,7 @@ public class RetentionManager @JvmOverloads constructor(
         if (period > 0) {
             val now = System.currentTimeMillis()
             if (isCleanupDue(now)) {
-                info("Performing data retention maintenance...")
+                Logger.info("Performing data retention maintenance...")
                 deleteSince(getThreshold(now))
                 updateLastCleanup(now)
             }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/DepletingSource.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/DepletingSource.kt
@@ -24,7 +24,7 @@ internal class DepletingSource(delegate: Source) : ForwardingSource(delegate) {
             try {
                 delegate.buffer().readAll(blackholeSink())
             } catch (e: IOException) {
-                IOException("An error occurred while depleting the source", e).printStackTrace()
+                Logger.error("An error occurred while depleting the source", e)
             }
         }
         shouldDeplete = false

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/FileFactory.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/FileFactory.kt
@@ -20,7 +20,7 @@ internal object FileFactory {
             }
         }
     } catch (e: IOException) {
-        IOException("An error occurred while creating a Chucker file", e).printStackTrace()
+        Logger.error("An error occurred while creating a file", e)
         null
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/Logger.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/Logger.kt
@@ -1,24 +1,25 @@
 package com.chuckerteam.chucker.internal.support
 
-import android.util.Log
+import com.chuckerteam.chucker.api.Chucker
 
-internal object Logger {
+internal interface Logger {
+    fun info(message: String)
 
-    private const val TAG = "Chucker"
+    fun warn(message: String)
 
-    fun info(message: String) {
-        Log.i(TAG, message)
-    }
+    fun error(message: String, throwable: Throwable? = null)
 
-    fun warn(message: String) {
-        Log.w(TAG, message)
-    }
+    companion object : Logger {
+        override fun info(message: String) {
+            Chucker.logger.info(message)
+        }
 
-    fun error(message: String, throwable: Throwable? = null) {
-        if (throwable != null) {
-            Log.e(TAG, message, throwable)
-        } else {
-            Log.e(TAG, message)
+        override fun warn(message: String) {
+            Chucker.logger.warn(message)
+        }
+
+        override fun error(message: String, throwable: Throwable?) {
+            Chucker.logger.error(message, throwable)
         }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/Sharable.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/Sharable.kt
@@ -8,7 +8,6 @@ import android.widget.Toast
 import androidx.core.app.ShareCompat
 import androidx.core.content.FileProvider
 import com.chuckerteam.chucker.R
-import com.chuckerteam.chucker.internal.support.Logger.warn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okio.BufferedSource
@@ -47,14 +46,14 @@ internal suspend fun Sharable.shareAsFile(
 ): Intent? {
     val cache = activity.cacheDir
     if (cache == null) {
-        warn("Failed to obtain a valid cache directory for Chucker file export")
+        Logger.warn("Failed to obtain a valid cache directory for file export")
         Toast.makeText(activity, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
         return null
     }
 
     val file = FileFactory.create(cache, fileName)
     if (file == null) {
-        warn("Failed to create an export file for Chucker")
+        Logger.warn("Failed to create an export file")
         Toast.makeText(activity, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
         return null
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -147,7 +147,7 @@ internal class TransactionPayloadFragment :
         if (payloadType == PayloadType.REQUEST) {
             viewModel.doesRequestBodyRequireEncoding.observe(
                 viewLifecycleOwner,
-                Observer { menu.findItem(R.id.encode_url).isVisible = it }
+                { menu.findItem(R.id.encode_url).isVisible = it }
             )
         } else {
             menu.findItem(R.id.encode_url).isVisible = false

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -26,12 +26,12 @@ import androidx.lifecycle.lifecycleScope
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionPayloadBinding
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
+import com.chuckerteam.chucker.internal.support.Logger
 import com.chuckerteam.chucker.internal.support.calculateLuminance
 import com.chuckerteam.chucker.internal.support.combineLatest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.FileNotFoundException
 import java.io.FileOutputStream
 import java.io.IOException
 
@@ -300,11 +300,8 @@ internal class TransactionPayloadFragment :
                         }
                     }
                 }
-            } catch (e: FileNotFoundException) {
-                e.printStackTrace()
-                return@withContext false
             } catch (e: IOException) {
-                e.printStackTrace()
+                Logger.error("Failed to save transaction to a file", e)
                 return@withContext false
             }
             return@withContext true

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -61,7 +61,7 @@ internal class TransactionPayloadFragment :
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         payloadBinding = ChuckerFragmentTransactionPayloadBinding.inflate(
             inflater,
             container,

--- a/library/src/test/java/com/chuckerteam/chucker/NoLoggerRule.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/NoLoggerRule.kt
@@ -1,0 +1,25 @@
+package com.chuckerteam.chucker
+
+import com.chuckerteam.chucker.api.Chucker
+import com.chuckerteam.chucker.internal.support.Logger
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+internal class NoLoggerRule : BeforeAllCallback, AfterAllCallback {
+    private val defaultLogger = Chucker.logger
+
+    override fun beforeAll(context: ExtensionContext) {
+        Chucker.logger = object : Logger {
+            override fun info(message: String) = Unit
+
+            override fun warn(message: String) = Unit
+
+            override fun error(message: String, throwable: Throwable?) = Unit
+        }
+    }
+
+    override fun afterAll(context: ExtensionContext) {
+        Chucker.logger = defaultLogger
+    }
+}

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -1,6 +1,7 @@
 package com.chuckerteam.chucker.api
 
 import com.chuckerteam.chucker.ChuckerInterceptorDelegate
+import com.chuckerteam.chucker.NoLoggerRule
 import com.chuckerteam.chucker.SEGMENT_SIZE
 import com.chuckerteam.chucker.getResourceFile
 import com.chuckerteam.chucker.readByteStringBody
@@ -19,12 +20,14 @@ import okio.ByteString
 import okio.GzipSink
 import org.junit.Rule
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import java.io.File
 import java.net.HttpURLConnection.HTTP_NO_CONTENT
 
+@ExtendWith(NoLoggerRule::class)
 internal class ChuckerInterceptorTest {
     enum class ClientFactory {
         APPLICATION {

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/DepletingSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/DepletingSourceTest.kt
@@ -1,5 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
+import com.chuckerteam.chucker.NoLoggerRule
 import com.google.common.truth.Truth.assertThat
 import okio.Buffer
 import okio.BufferedSource
@@ -10,8 +11,10 @@ import okio.buffer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import java.io.IOException
 
+@ExtendWith(NoLoggerRule::class)
 internal class DepletingSourceTest {
     @Test
     fun delegateContent_isMovedToDownstream() {


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

Some parts of the code used `printStackTrace()` to log failures. I wanted to centralise logging point that can be used in Chucker. This also gives an opportunity to let users set an external logger in the future.

## :pencil: Changes
<!-- Which code did you change? How? -->

I changed `Logger` to an interface and made an instance of it available in `Chucker` object. Companion object of `Logger` delegates then to this property.

I also added a test extension that sets no-op logger. It is needed as we can't have a centralised logger that is not static due to logging in Android components as well.

One more thing – I removed "Chucker" from log messages. It is present in the tag anyway.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

#452

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Nothing special to check. Rely on unit tests.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

N/A