### PR TITLE
Fix setting request body plain text in transaction

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -113,7 +113,7 @@ public class ChuckerInterceptor private constructor(
                 val content = io.readFromBuffer(buffer, charset, maxContentLength)
                 transaction.requestBody = content
             } else {
-                transaction.isResponseBodyPlainText = false
+                transaction.isRequestBodyPlainText = false
             }
         }
     }

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -410,7 +410,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun nonPlainTextBody_isRecognizedNotToBePlainText(factory: ClientFactory) {
+    fun nonPlainTextRequestBody_isRecognizedNotToBePlainText(factory: ClientFactory) {
         server.enqueue(MockResponse())
         val client = factory.create(chuckerInterceptor)
 

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -13,10 +13,13 @@ import com.google.gson.stream.JsonReader
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okio.Buffer
 import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
 import okio.GzipSink
 import org.junit.Rule
 import org.junit.jupiter.api.assertThrows
@@ -404,4 +407,19 @@ internal class ChuckerInterceptorTest {
     }
 
     private data class Expected(val string: String, val boolean: Boolean, val secondString: String)
+
+    @ParameterizedTest
+    @EnumSource(value = ClientFactory::class)
+    fun nonPlainTextBody_isRecognizedNotToBePlainText(factory: ClientFactory) {
+        server.enqueue(MockResponse())
+        val client = factory.create(chuckerInterceptor)
+
+        val request = "\u0080".encodeUtf8().toRequestBody().toServerRequest()
+        client.newCall(request).execute().body!!.close()
+
+        val transaction = chuckerInterceptor.expectTransaction()
+        assertThat(transaction.isRequestBodyPlainText).isFalse()
+    }
+
+    private fun RequestBody.toServerRequest() = Request.Builder().url(serverUrl).post(this).build()
 }


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is a bug while processing requests.

## :pencil: Changes
<!-- Which code did you change? How? -->

I set a correct property on a transaction. Previously it used response, now it uses request.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

#527

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

I added a test that covers the bug.