### PR TITLE
Fix HTTP response test names

### DIFF
--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -57,7 +57,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun imageResponse_isAvailableToChucker(factory: ClientFactory) {
+    fun imageResponseBody_isAvailableToChucker(factory: ClientFactory) {
         val image = getResourceFile("sample_image.png")
         server.enqueue(MockResponse().addHeader("Content-Type: image/jpeg").setBody(image))
         val request = Request.Builder().url(serverUrl).build()
@@ -72,7 +72,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun imageResponse_isAvailableToTheEndConsumer(factory: ClientFactory) {
+    fun imageResponseBody_isAvailableToTheEndConsumer(factory: ClientFactory) {
         val image = getResourceFile("sample_image.png")
         server.enqueue(MockResponse().addHeader("Content-Type: image/jpeg").setBody(image))
         val request = Request.Builder().url(serverUrl).build()
@@ -86,7 +86,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun gzippedBody_isGunzippedForChucker(factory: ClientFactory) {
+    fun gzippedResponseBody_isGunzippedForChucker(factory: ClientFactory) {
         val bytes = Buffer().apply { writeUtf8("Hello, world!") }
         val gzippedBytes = Buffer().apply {
             GzipSink(this).use { sink -> sink.write(bytes, bytes.size) }
@@ -104,7 +104,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun gzippedBody_isGunzippedForTheEndConsumer(factory: ClientFactory) {
+    fun gzippedResponseBody_isGunzippedForTheEndConsumer(factory: ClientFactory) {
         val bytes = Buffer().apply { writeUtf8("Hello, world!") }
         val gzippedBytes = Buffer().apply {
             GzipSink(this).use { sink -> sink.write(bytes, bytes.size) }
@@ -120,7 +120,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun gzippedBody_withNoContent_isTransparentForChucker(factory: ClientFactory) {
+    fun gzippedResponseBody_withNoContent_isTransparentForChucker(factory: ClientFactory) {
         server.enqueue(MockResponse().addHeader("Content-Encoding: gzip").setResponseCode(HTTP_NO_CONTENT))
         val request = Request.Builder().url(serverUrl).build()
 
@@ -133,7 +133,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun gzippedBody_withNoContent_isTransparentForEndConsumer(factory: ClientFactory) {
+    fun gzippedResponseBody_withNoContent_isTransparentForEndConsumer(factory: ClientFactory) {
         server.enqueue(MockResponse().addHeader("Content-Encoding: gzip").setResponseCode(HTTP_NO_CONTENT))
         val request = Request.Builder().url(serverUrl).build()
 
@@ -145,7 +145,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun regularBody_isAvailableForChucker(factory: ClientFactory) {
+    fun plainTextResponseBody_isAvailableForChucker(factory: ClientFactory) {
         val body = Buffer().apply { writeUtf8("Hello, world!") }
         server.enqueue(MockResponse().setBody(body))
         val request = Request.Builder().url(serverUrl).build()
@@ -160,7 +160,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun regularBody_isAvailableForTheEndConsumer(factory: ClientFactory) {
+    fun plainTextResponseBody_isAvailableForTheEndConsumer(factory: ClientFactory) {
         val body = Buffer().apply { writeUtf8("Hello, world!") }
         server.enqueue(MockResponse().setBody(body))
         val request = Request.Builder().url(serverUrl).build()
@@ -173,7 +173,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun regularBody_withNoContent_isAvailableForChucker(factory: ClientFactory) {
+    fun plainTextResponseBody_withNoContent_isAvailableForChucker(factory: ClientFactory) {
         server.enqueue(MockResponse().setResponseCode(HTTP_NO_CONTENT))
         val request = Request.Builder().url(serverUrl).build()
 
@@ -187,7 +187,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun regularBody_withNoContent_isAvailableForTheEndConsumer(factory: ClientFactory) {
+    fun plainTextResponseBody_withNoContent_isAvailableForTheEndConsumer(factory: ClientFactory) {
         server.enqueue(MockResponse().setResponseCode(HTTP_NO_CONTENT))
         val request = Request.Builder().url(serverUrl).build()
 
@@ -199,7 +199,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun payloadSize_dependsOnTheAmountOfDataDownloaded(factory: ClientFactory) {
+    fun responsePayloadSize_dependsOnTheAmountOfDataDownloaded(factory: ClientFactory) {
         val body = Buffer().apply {
             repeat(10 * SEGMENT_SIZE.toInt()) { writeUtf8("!") }
         }
@@ -220,7 +220,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun contentLength_isProperlyReadFromHeader_andNotFromAmountOfData(factory: ClientFactory) {
+    fun responseContentLength_isProperlyReadFromHeader_andNotFromAmountOfData(factory: ClientFactory) {
         val body = Buffer().apply {
             repeat(10 * SEGMENT_SIZE.toInt()) { writeUtf8("!") }
         }
@@ -263,7 +263,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun payloadSize_isNotLimitedByInterceptorMaxContentLength(factory: ClientFactory) {
+    fun responsePayloadSize_isNotLimitedByInterceptorMaxContentLength(factory: ClientFactory) {
         val body = Buffer().apply {
             repeat(10_000) { writeUtf8("!") }
         }


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

`ChuckerInterceptor` response tests had incorrect naming.

## :pencil: Changes
<!-- Which code did you change? How? -->

Changed test names to convey better what they check.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

#527

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.
