### PR TITLE
Refactor IO utils

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -63,14 +63,13 @@ public class ChuckerInterceptor private constructor(
     @Throws(IOException::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
-        val response: Response
         val transaction = HttpTransaction()
 
         processRequest(request, transaction)
         collector.onRequestSent(transaction)
 
-        try {
-            response = chain.proceed(request)
+        val response = try {
+            chain.proceed(request)
         } catch (e: IOException) {
             transaction.error = e.toString()
             collector.onResponseReceived(transaction)

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -26,7 +26,7 @@ import okio.buffer
 import okio.source
 import java.io.File
 import java.io.IOException
-import java.nio.charset.Charset
+import kotlin.text.Charsets.UTF_8
 
 /**
  * An OkHttp Interceptor which persists and displays HTTP activity
@@ -104,11 +104,7 @@ public class ChuckerInterceptor private constructor(
             val source = io.getNativeSource(Buffer(), request.isGzipped)
             val buffer = source.buffer
             requestBody.writeTo(buffer)
-            var charset: Charset = UTF8
-            val contentType = requestBody.contentType()
-            if (contentType != null) {
-                charset = contentType.charset(UTF8) ?: UTF8
-            }
+            val charset = requestBody.contentType()?.charset() ?: UTF_8
             if (buffer.isProbablyPlainText) {
                 val content = io.readFromBuffer(buffer, charset, maxContentLength)
                 transaction.requestBody = content
@@ -199,7 +195,7 @@ public class ChuckerInterceptor private constructor(
         val responseBody = response.body ?: return
 
         val contentType = responseBody.contentType()
-        val charset = contentType?.charset(UTF8) ?: UTF8
+        val charset = contentType?.charset() ?: UTF_8
 
         if (responseBodyBuffer.isProbablyPlainText) {
             transaction.isResponseBodyPlainText = true
@@ -335,8 +331,6 @@ public class ChuckerInterceptor private constructor(
     }
 
     private companion object {
-        private val UTF8 = Charset.forName("UTF-8")
-
         private const val MAX_CONTENT_LENGTH = 250_000L
         private const val MAX_BLOB_SIZE = 1_000_000L
 

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -13,6 +13,7 @@ import com.chuckerteam.chucker.internal.support.TeeSource
 import com.chuckerteam.chucker.internal.support.contentType
 import com.chuckerteam.chucker.internal.support.hasBody
 import com.chuckerteam.chucker.internal.support.isGzipped
+import com.chuckerteam.chucker.internal.support.isProbablyPlainText
 import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.Request
@@ -26,7 +27,6 @@ import okio.source
 import java.io.File
 import java.io.IOException
 import java.nio.charset.Charset
-import kotlin.jvm.Throws
 
 /**
  * An OkHttp Interceptor which persists and displays HTTP activity
@@ -109,7 +109,7 @@ public class ChuckerInterceptor private constructor(
             if (contentType != null) {
                 charset = contentType.charset(UTF8) ?: UTF8
             }
-            if (io.isPlaintext(buffer)) {
+            if (buffer.isProbablyPlainText) {
                 val content = io.readFromBuffer(buffer, charset, maxContentLength)
                 transaction.requestBody = content
             } else {
@@ -201,7 +201,7 @@ public class ChuckerInterceptor private constructor(
         val contentType = responseBody.contentType()
         val charset = contentType?.charset(UTF8) ?: UTF8
 
-        if (io.isPlaintext(responseBodyBuffer)) {
+        if (responseBodyBuffer.isProbablyPlainText) {
             transaction.isResponseBodyPlainText = true
             if (responseBodyBuffer.size != 0L) {
                 transaction.responseBody = responseBodyBuffer.readString(charset)

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -12,6 +12,7 @@ import com.chuckerteam.chucker.internal.support.ReportingSink
 import com.chuckerteam.chucker.internal.support.TeeSource
 import com.chuckerteam.chucker.internal.support.contentType
 import com.chuckerteam.chucker.internal.support.hasBody
+import com.chuckerteam.chucker.internal.support.hasSupportedContentEncoding
 import com.chuckerteam.chucker.internal.support.isGzipped
 import com.chuckerteam.chucker.internal.support.isProbablyPlainText
 import okhttp3.Headers
@@ -86,7 +87,7 @@ public class ChuckerInterceptor private constructor(
     private fun processRequest(request: Request, transaction: HttpTransaction) {
         val requestBody = request.body
 
-        val encodingIsSupported = io.bodyHasSupportedEncoding(request.headers[CONTENT_ENCODING])
+        val encodingIsSupported = request.headers.hasSupportedContentEncoding
 
         transaction.apply {
             setRequestHeaders(request.headers)
@@ -120,7 +121,7 @@ public class ChuckerInterceptor private constructor(
         response: Response,
         transaction: HttpTransaction
     ) {
-        val responseEncodingIsSupported = io.bodyHasSupportedEncoding(response.headers[CONTENT_ENCODING])
+        val responseEncodingIsSupported = response.headers.hasSupportedContentEncoding
 
         transaction.apply {
             // includes headers added later in the chain
@@ -334,6 +335,5 @@ public class ChuckerInterceptor private constructor(
         private const val MAX_BLOB_SIZE = 1_000_000L
 
         private const val CONTENT_TYPE_IMAGE = "image"
-        private const val CONTENT_ENCODING = "Content-Encoding"
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
@@ -34,9 +34,4 @@ internal class IOUtils(private val context: Context) {
     } else {
         input
     }
-
-    fun bodyHasSupportedEncoding(contentEncoding: String?) =
-        contentEncoding.isNullOrEmpty() ||
-            contentEncoding.equals("identity", ignoreCase = true) ||
-            contentEncoding.equals("gzip", ignoreCase = true)
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/IOUtils.kt
@@ -10,34 +10,7 @@ import java.io.EOFException
 import java.nio.charset.Charset
 import kotlin.math.min
 
-private const val PREFIX_SIZE = 64L
-private const val CODE_POINT_SIZE = 16
-
 internal class IOUtils(private val context: Context) {
-
-    /**
-     * Returns true if the body in question probably contains human readable text. Uses a small sample
-     * of code points to detect unicode control characters commonly used in binary file signatures.
-     */
-    fun isPlaintext(buffer: Buffer): Boolean {
-        try {
-            val prefix = Buffer()
-            val byteCount = if (buffer.size < PREFIX_SIZE) buffer.size else PREFIX_SIZE
-            buffer.copyTo(prefix, 0, byteCount)
-            for (i in 0 until CODE_POINT_SIZE) {
-                if (prefix.exhausted()) {
-                    break
-                }
-                val codePoint = prefix.readUtf8CodePoint()
-                if (Character.isISOControl(codePoint) && !Character.isWhitespace(codePoint)) {
-                    return false
-                }
-            }
-            return true
-        } catch (e: EOFException) {
-            return false // Truncated UTF-8 sequence.
-        }
-    }
 
     fun readFromBuffer(buffer: Buffer, charset: Charset, maxContentLength: Long): String {
         val bufferSize = buffer.size

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
@@ -3,6 +3,8 @@ package com.chuckerteam.chucker.internal.support
 import okhttp3.Headers
 import okhttp3.Request
 import okhttp3.Response
+import okio.Source
+import okio.gzip
 import java.net.HttpURLConnection.HTTP_NOT_MODIFIED
 import java.net.HttpURLConnection.HTTP_NO_CONTENT
 import java.net.HttpURLConnection.HTTP_OK
@@ -69,3 +71,9 @@ internal val Headers.hasSupportedContentEncoding: Boolean
         ?.takeIf { it.isNotEmpty() }
         ?.let { it.toLowerCase(Locale.ROOT) in supportedEncodings }
         ?: true
+
+internal fun Source.uncompress(headers: Headers) = if (headers.containsGzip) {
+    gzip()
+} else {
+    this
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
@@ -6,6 +6,7 @@ import okhttp3.Response
 import java.net.HttpURLConnection.HTTP_NOT_MODIFIED
 import java.net.HttpURLConnection.HTTP_NO_CONTENT
 import java.net.HttpURLConnection.HTTP_OK
+import java.util.Locale
 
 private const val HTTP_CONTINUE = 100
 
@@ -60,3 +61,11 @@ private val Headers.containsGzip: Boolean
     get() {
         return this["Content-Encoding"].equals("gzip", ignoreCase = true)
     }
+
+private val supportedEncodings = listOf("identity", "gzip")
+
+internal val Headers.hasSupportedContentEncoding: Boolean
+    get() = get("Content-Encoding")
+        ?.takeIf { it.isNotEmpty() }
+        ?.let { it.toLowerCase(Locale.ROOT) in supportedEncodings }
+        ?: true

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
@@ -18,8 +18,9 @@ internal val Buffer.isProbablyPlainText
         copyTo(prefix, 0, byteCount)
         sequence { while (!prefix.exhausted()) yield(prefix.readUtf8CodePoint()) }
             .take(CODE_POINT_SIZE)
-            .any { codePoint -> Character.isISOControl(codePoint) && !Character.isWhitespace(codePoint) }
-            .not()
+            .all { codePoint -> codePoint.isPlainTextChar() }
     } catch (_: EOFException) {
         false // Truncated UTF-8 sequence
     }
+
+private fun Int.isPlainTextChar() = Character.isWhitespace(this) || !Character.isISOControl(this)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
@@ -8,7 +8,7 @@ private const val MAX_PREFIX_SIZE = 64L
 private const val CODE_POINT_SIZE = 16
 
 /**
- * Returns true if the body in question probably contains human readable text. Uses a small sample
+ * Returns true if the [Buffer] contains human readable text. Uses a small sample
  * of code points to detect unicode control characters commonly used in binary file signatures.
  */
 internal val Buffer.isProbablyPlainText

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
@@ -2,6 +2,7 @@ package com.chuckerteam.chucker.internal.support
 
 import okio.Buffer
 import java.io.EOFException
+import kotlin.math.min
 
 private const val MAX_PREFIX_SIZE = 64L
 private const val CODE_POINT_SIZE = 16
@@ -13,7 +14,7 @@ private const val CODE_POINT_SIZE = 16
 internal val Buffer.isProbablyPlainText
     get() = try {
         val prefix = Buffer()
-        val byteCount = if (size < MAX_PREFIX_SIZE) size else MAX_PREFIX_SIZE
+        val byteCount = min(size, MAX_PREFIX_SIZE)
         copyTo(prefix, 0, byteCount)
         sequence { while (!prefix.exhausted()) yield(prefix.readUtf8CodePoint()) }
             .take(CODE_POINT_SIZE)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
@@ -1,0 +1,24 @@
+package com.chuckerteam.chucker.internal.support
+
+import okio.Buffer
+import java.io.EOFException
+
+private const val MAX_PREFIX_SIZE = 64L
+private const val CODE_POINT_SIZE = 16
+
+/**
+ * Returns true if the body in question probably contains human readable text. Uses a small sample
+ * of code points to detect unicode control characters commonly used in binary file signatures.
+ */
+internal val Buffer.isProbablyPlainText
+    get() = try {
+        val prefix = Buffer()
+        val byteCount = if (size < MAX_PREFIX_SIZE) size else MAX_PREFIX_SIZE
+        copyTo(prefix, 0, byteCount)
+        sequence { while (!prefix.exhausted()) yield(prefix.readUtf8CodePoint()) }
+            .take(CODE_POINT_SIZE)
+            .any { codePoint -> Character.isISOControl(codePoint) && !Character.isWhitespace(codePoint) }
+            .not()
+    } catch (_: EOFException) {
+        false // Truncated UTF-8 sequence
+    }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
@@ -22,46 +22,6 @@ internal class IOUtilsTest {
     private val ioUtils = IOUtils(mockContext)
 
     @Test
-    fun isPlaintext_withEmptyBuffer_returnsTrue() {
-        val buffer = Buffer()
-
-        assertThat(buffer.isProbablyPlainText).isTrue()
-    }
-
-    @Test
-    fun isPlaintext_withWhiteSpace_returnsTrue() {
-        val buffer = Buffer()
-        buffer.writeString(" ", Charset.defaultCharset())
-
-        assertThat(buffer.isProbablyPlainText).isTrue()
-    }
-
-    @Test
-    fun isPlaintext_withPlainText_returnsTrue() {
-        val buffer = Buffer()
-        buffer.writeString("just a string", Charset.defaultCharset())
-
-        assertThat(buffer.isProbablyPlainText).isTrue()
-    }
-
-    @Test
-    fun isPlaintext_withCodepoint_returnsFalse() {
-        val buffer = Buffer()
-        buffer.writeByte(0x11000000)
-
-        assertThat(buffer.isProbablyPlainText).isFalse()
-    }
-
-    @Test
-    fun isPlaintext_withEOF_returnsFalse() {
-        val mockBuffer = mockk<Buffer>()
-        every { mockBuffer.size } returns 100L
-        every { mockBuffer.copyTo(any<Buffer>(), any(), any()) } throws EOFException()
-
-        assertThat(mockBuffer.isProbablyPlainText).isFalse()
-    }
-
-    @Test
     fun readFromBuffer_contentNotTruncated() {
         val mockBuffer = mockk<Buffer>()
         every { mockBuffer.size } returns 100L

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
@@ -7,14 +7,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import okio.Buffer
-import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import java.io.EOFException
 import java.nio.charset.Charset
-import java.util.stream.Stream
 
 internal class IOUtilsTest {
 
@@ -72,27 +67,5 @@ internal class IOUtilsTest {
 
         val nativeSource = ioUtils.getNativeSource(buffer, true)
         assertThat(nativeSource).isNotEqualTo(buffer)
-    }
-
-    @ParameterizedTest(name = "{0} must be supported? {1}")
-    @MethodSource("supportedEncodingSource")
-    @DisplayName("Check if body encoding is supported")
-    fun bodyHasSupportedEncoding(encoding: String?, isSupported: Boolean) {
-        val result = ioUtils.bodyHasSupportedEncoding(encoding)
-
-        assertThat(result).isEqualTo(isSupported)
-    }
-
-    companion object {
-        @JvmStatic
-        fun supportedEncodingSource(): Stream<Arguments> {
-            return Stream.of(
-                Arguments.of(null, true),
-                Arguments.of("", true),
-                Arguments.of("identity", true),
-                Arguments.of("gzip", true),
-                Arguments.of("other", false)
-            )
-        }
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/IOUtilsTest.kt
@@ -25,7 +25,7 @@ internal class IOUtilsTest {
     fun isPlaintext_withEmptyBuffer_returnsTrue() {
         val buffer = Buffer()
 
-        assertThat(ioUtils.isPlaintext(buffer)).isTrue()
+        assertThat(buffer.isProbablyPlainText).isTrue()
     }
 
     @Test
@@ -33,7 +33,7 @@ internal class IOUtilsTest {
         val buffer = Buffer()
         buffer.writeString(" ", Charset.defaultCharset())
 
-        assertThat(ioUtils.isPlaintext(buffer)).isTrue()
+        assertThat(buffer.isProbablyPlainText).isTrue()
     }
 
     @Test
@@ -41,7 +41,7 @@ internal class IOUtilsTest {
         val buffer = Buffer()
         buffer.writeString("just a string", Charset.defaultCharset())
 
-        assertThat(ioUtils.isPlaintext(buffer)).isTrue()
+        assertThat(buffer.isProbablyPlainText).isTrue()
     }
 
     @Test
@@ -49,7 +49,7 @@ internal class IOUtilsTest {
         val buffer = Buffer()
         buffer.writeByte(0x11000000)
 
-        assertThat(ioUtils.isPlaintext(buffer)).isFalse()
+        assertThat(buffer.isProbablyPlainText).isFalse()
     }
 
     @Test
@@ -58,7 +58,7 @@ internal class IOUtilsTest {
         every { mockBuffer.size } returns 100L
         every { mockBuffer.copyTo(any<Buffer>(), any(), any()) } throws EOFException()
 
-        assertThat(ioUtils.isPlaintext(mockBuffer)).isFalse()
+        assertThat(mockBuffer.isProbablyPlainText).isFalse()
     }
 
     @Test

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
@@ -3,10 +3,16 @@ package com.chuckerteam.chucker.internal.support
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
+import okhttp3.Headers
 import okhttp3.Headers.Companion.headersOf
 import okhttp3.Request
 import okhttp3.Response
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
 internal class OkHttpUtilsTest {
 
@@ -65,5 +71,26 @@ internal class OkHttpUtilsTest {
         every { mockRequest.headers } returns headersOf("Content-Encoding", "identity")
 
         assertThat(mockRequest.isGzipped).isFalse()
+    }
+
+    @ParameterizedTest(name = "\"{0}\" must be supported: {1}")
+    @MethodSource("supportedEncodingSource")
+    @DisplayName("Check if body encoding is supported")
+    fun headersHaveSupportedEncoding(headers: Headers, isSupported: Boolean) {
+        val result = headers.hasSupportedContentEncoding
+
+        assertThat(result).isEqualTo(isSupported)
+    }
+
+    companion object {
+        @JvmStatic
+        fun supportedEncodingSource(): Stream<Arguments> = Stream.of(
+            "" to true,
+            "identity" to true,
+            "gzip" to true,
+            "other" to false,
+        ).map { (encoding, result) ->
+            Arguments.of(headersOf("Content-Encoding", encoding), result)
+        }
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkHttpUtilsTest.kt
@@ -114,12 +114,14 @@ internal class OkHttpUtilsTest {
     companion object {
         @JvmStatic
         fun supportedEncodingSource(): Stream<Arguments> = Stream.of(
+            null to true,
             "" to true,
             "identity" to true,
             "gzip" to true,
             "other" to false,
         ).map { (encoding, result) ->
-            Arguments.of(headersOf("Content-Encoding", encoding), result)
+            val headers = if (encoding == null) headersOf() else headersOf("Content-Encoding", encoding)
+            Arguments.of(headers, result)
         }
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
@@ -1,6 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
 import org.junit.jupiter.api.Test
@@ -11,7 +11,7 @@ internal class OkioUtilsTest {
     fun isPlaintext_withEmptyBuffer_returnsTrue() {
         val buffer = Buffer()
 
-        Truth.assertThat(buffer.isProbablyPlainText).isTrue()
+        assertThat(buffer.isProbablyPlainText).isTrue()
     }
 
     @Test
@@ -19,7 +19,7 @@ internal class OkioUtilsTest {
         val buffer = Buffer()
         buffer.writeString(" ", Charset.defaultCharset())
 
-        Truth.assertThat(buffer.isProbablyPlainText).isTrue()
+        assertThat(buffer.isProbablyPlainText).isTrue()
     }
 
     @Test
@@ -27,7 +27,7 @@ internal class OkioUtilsTest {
         val buffer = Buffer()
         buffer.writeString("just a string", Charset.defaultCharset())
 
-        Truth.assertThat(buffer.isProbablyPlainText).isTrue()
+        assertThat(buffer.isProbablyPlainText).isTrue()
     }
 
     @Test
@@ -35,7 +35,7 @@ internal class OkioUtilsTest {
         val buffer = Buffer()
         buffer.writeByte(0x11000000)
 
-        Truth.assertThat(buffer.isProbablyPlainText).isFalse()
+        assertThat(buffer.isProbablyPlainText).isFalse()
     }
 
     @Test
@@ -43,7 +43,7 @@ internal class OkioUtilsTest {
         val buffer = Buffer()
         buffer.writeString("ą", Charset.defaultCharset())
 
-        Truth.assertThat(buffer.isProbablyPlainText).isTrue()
+        assertThat(buffer.isProbablyPlainText).isTrue()
     }
 
     @Test
@@ -51,6 +51,6 @@ internal class OkioUtilsTest {
         val bytes = "ą".encodeUtf8().let { it.substring(0, it.size - 1) }
         val buffer = Buffer().write(bytes)
 
-        Truth.assertThat(buffer.isProbablyPlainText).isFalse()
+        assertThat(buffer.isProbablyPlainText).isFalse()
     }
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
@@ -1,0 +1,51 @@
+package com.chuckerteam.chucker.internal.support
+
+import com.google.common.truth.Truth
+import io.mockk.every
+import io.mockk.mockk
+import okio.Buffer
+import org.junit.jupiter.api.Test
+import java.io.EOFException
+import java.nio.charset.Charset
+
+internal class OkioUtilsTest {
+    @Test
+    fun isPlaintext_withEmptyBuffer_returnsTrue() {
+        val buffer = Buffer()
+
+        Truth.assertThat(buffer.isProbablyPlainText).isTrue()
+    }
+
+    @Test
+    fun isPlaintext_withWhiteSpace_returnsTrue() {
+        val buffer = Buffer()
+        buffer.writeString(" ", Charset.defaultCharset())
+
+        Truth.assertThat(buffer.isProbablyPlainText).isTrue()
+    }
+
+    @Test
+    fun isPlaintext_withPlainText_returnsTrue() {
+        val buffer = Buffer()
+        buffer.writeString("just a string", Charset.defaultCharset())
+
+        Truth.assertThat(buffer.isProbablyPlainText).isTrue()
+    }
+
+    @Test
+    fun isPlaintext_withCodePoint_returnsFalse() {
+        val buffer = Buffer()
+        buffer.writeByte(0x11000000)
+
+        Truth.assertThat(buffer.isProbablyPlainText).isFalse()
+    }
+
+    @Test
+    fun isPlaintext_withEOF_returnsFalse() {
+        val mockBuffer = mockk<Buffer>()
+        every { mockBuffer.size } returns 100L
+        every { mockBuffer.copyTo(any<Buffer>(), any(), any()) } throws EOFException()
+
+        Truth.assertThat(mockBuffer.isProbablyPlainText).isFalse()
+    }
+}

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
@@ -15,7 +15,7 @@ internal class OkioUtilsTest {
     }
 
     @Test
-    fun isPlaintext_withWhiteSpace_returnsTrue() {
+    fun isProbablyPlainText_withWhiteSpace_returnsTrue() {
         val buffer = Buffer()
         buffer.writeString(" ", Charset.defaultCharset())
 
@@ -23,7 +23,7 @@ internal class OkioUtilsTest {
     }
 
     @Test
-    fun isPlaintext_withPlainText_returnsTrue() {
+    fun isProbablyPlainText_withPlainText_returnsTrue() {
         val buffer = Buffer()
         buffer.writeString("just a string", Charset.defaultCharset())
 
@@ -31,7 +31,7 @@ internal class OkioUtilsTest {
     }
 
     @Test
-    fun isPlaintext_withCodePoint_returnsFalse() {
+    fun isProbablyPlainText_withCodePoint_returnsFalse() {
         val buffer = Buffer()
         buffer.writeByte(0x11000000)
 
@@ -39,7 +39,7 @@ internal class OkioUtilsTest {
     }
 
     @Test
-    fun isPlaintext_withNonAsciiText_returnsTrue() {
+    fun isProbablyPlainText_withNonAsciiText_returnsTrue() {
         val buffer = Buffer()
         buffer.writeString("ą", Charset.defaultCharset())
 
@@ -47,7 +47,7 @@ internal class OkioUtilsTest {
     }
 
     @Test
-    fun isPlaintext_withTruncatedUtf_returnsFalse() {
+    fun isProbablyPlainText_withTruncatedUtf_returnsFalse() {
         val bytes = "ą".encodeUtf8().let { it.substring(0, it.size - 1) }
         val buffer = Buffer().write(bytes)
 

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
@@ -8,7 +8,7 @@ import java.nio.charset.Charset
 
 internal class OkioUtilsTest {
     @Test
-    fun isPlaintext_withEmptyBuffer_returnsTrue() {
+    fun isProbablyPlainText_withEmptyBuffer_returnsTrue() {
         val buffer = Buffer()
 
         assertThat(buffer.isProbablyPlainText).isTrue()

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/OkioUtilsTest.kt
@@ -1,11 +1,9 @@
 package com.chuckerteam.chucker.internal.support
 
 import com.google.common.truth.Truth
-import io.mockk.every
-import io.mockk.mockk
 import okio.Buffer
+import okio.ByteString.Companion.encodeUtf8
 import org.junit.jupiter.api.Test
-import java.io.EOFException
 import java.nio.charset.Charset
 
 internal class OkioUtilsTest {
@@ -41,11 +39,18 @@ internal class OkioUtilsTest {
     }
 
     @Test
-    fun isPlaintext_withEOF_returnsFalse() {
-        val mockBuffer = mockk<Buffer>()
-        every { mockBuffer.size } returns 100L
-        every { mockBuffer.copyTo(any<Buffer>(), any(), any()) } throws EOFException()
+    fun isPlaintext_withNonAsciiText_returnsTrue() {
+        val buffer = Buffer()
+        buffer.writeString("ą", Charset.defaultCharset())
 
-        Truth.assertThat(mockBuffer.isProbablyPlainText).isFalse()
+        Truth.assertThat(buffer.isProbablyPlainText).isTrue()
+    }
+
+    @Test
+    fun isPlaintext_withTruncatedUtf_returnsFalse() {
+        val bytes = "ą".encodeUtf8().let { it.substring(0, it.size - 1) }
+        val buffer = Buffer().write(bytes)
+
+        Truth.assertThat(buffer.isProbablyPlainText).isFalse()
     }
 }


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

Just some cleanup of IO utils that was done along the way of #527. Moving methods out of `IOUtils` class to some extensions functions etc.

## :pencil: Changes
<!-- Which code did you change? How? -->

As mentioned. It is mostly moving internal parts that are about IO and HTTP to separate classes.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

#527

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Nothing changed in that regard. Tests were adjusted accordingly.