### PR TITLE
Auto cancel workflow when new push happens

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -15,8 +15,14 @@ jobs:
     runs-on: [ubuntu-latest]
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
+
     - name: Checkout Repo
       uses: actions/checkout@v2
+
     - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
@@ -40,6 +46,7 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+
     - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
@@ -61,6 +68,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+
       - name: Cache Gradle Folders
         uses: actions/cache@v2
         with:
@@ -82,6 +90,7 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+
     - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:
@@ -103,6 +112,7 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+
       - name: Cache Gradle Folders
         uses: actions/cache@v2
         with:
@@ -124,6 +134,7 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+
     - name: Cache Gradle Folders
       uses: actions/cache@v2
       with:

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
     - name: Cancel Previous Runs
+      if: github.event_name == 'pull_request'
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -2,7 +2,7 @@ name: Publish Snapshot
 on:
   push:
     branches:
-      - develop 
+      - develop
 
 jobs:
   publish:
@@ -10,6 +10,11 @@ jobs:
     runs-on: [ubuntu-latest]
 
     steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.7.0
+      with:
+        access_token: ${{ github.token }}
+
     - name: Checkout Repo
       uses: actions/checkout@v2
 


### PR DESCRIPTION
## :page_facing_up: Context
Github Actions has no feature to cancel previous workflow execution if some new push even happens triggering the same workflow again. In Chucker case it happens when somebody merges multiple PRs to `develop` one after another firing multiple runs of checks and snapshot publishing. It is not a big deal, but not efficient.
With suggested action: https://github.com/styfle/cancel-workflow-action we can improve efficiency by cancelling previous running builds.

## :pencil: Changes
- Modified `pre-merge` and `publish-snapshot` actions to automatically cancel workflows if new trigger event happened.
- Added a few empty lines to separate steps in workflows.

## :no_entry_sign: Breaking
It might be that pushing code to different PRs quite fast will cancel `pre-merge` running for some other build, but not sure if we have such cases.

## :hammer_and_wrench: How to test
- Open some PR and push some update to it while `pre-merge` is still running.
- Merge a few PRs into `develop` one after another and see that only latest merged gets to completion.

