### PR TITLE
Do not process one shot and duplex request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+### Fixed
+
+* Fixed wrongful processing of one shot and duplex requests [#544].
+
 ### Removed
 
 * Removed parametrized `ChuckerInterceptor` constructor in favour of builder pattern. Constructor that accepts only `Context` is still available.

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
@@ -35,6 +35,14 @@ internal class RequestProcessor(
 
     private fun processBody(request: Request, transaction: HttpTransaction) {
         val body = request.body ?: return
+        if (body.isOneShot()) {
+            Logger.info("Skipping one shot request body")
+            return
+        }
+        if (body.isDuplex()) {
+            Logger.info("Skipping duplex request body")
+            return
+        }
 
         val isEncodingSupported = request.headers.hasSupportedContentEncoding
         if (!isEncodingSupported) {

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -516,7 +516,6 @@ internal class ChuckerInterceptorTest {
         client.newCall(oneShotRequest).execute().readByteStringBody()
 
         val transaction = chuckerInterceptor.expectTransaction()
-        assertThat(transaction.isRequestBodyPlainText).isFalse()
         assertThat(transaction.requestBody).isNull()
     }
 

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -11,6 +11,7 @@ import com.google.gson.Gson
 import com.google.gson.JsonParseException
 import com.google.gson.stream.JsonReader
 import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -503,11 +504,13 @@ internal class ChuckerInterceptorTest {
         server.enqueue(MockResponse())
         val client = factory.create(chuckerInterceptor)
 
-        val requestBody = "Hello, world!".toRequestBody()
         val oneShotRequest = object : RequestBody() {
+            private val content = Buffer().writeUtf8("Hello, world!")
             override fun isOneShot() = true
-            override fun contentType() = requestBody.contentType()
-            override fun writeTo(sink: BufferedSink) = requestBody.writeTo(sink)
+            override fun contentType() = "text/plain".toMediaType()
+            override fun writeTo(sink: BufferedSink) {
+                content.readAll(sink)
+            }
         }.toServerRequest()
 
         client.newCall(oneShotRequest).execute().readByteStringBody()
@@ -523,11 +526,13 @@ internal class ChuckerInterceptorTest {
         server.enqueue(MockResponse())
         val client = factory.create(chuckerInterceptor)
 
-        val requestBody = "Hello, world!".toRequestBody()
         val oneShotRequest = object : RequestBody() {
+            private val content = Buffer().writeUtf8("Hello, world!")
             override fun isOneShot() = true
-            override fun contentType() = requestBody.contentType()
-            override fun writeTo(sink: BufferedSink) = requestBody.writeTo(sink)
+            override fun contentType() = "text/plain".toMediaType()
+            override fun writeTo(sink: BufferedSink) {
+                content.readAll(sink)
+            }
         }.toServerRequest()
 
         client.newCall(oneShotRequest).execute().readByteStringBody()

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinApi.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinApi.kt
@@ -1,5 +1,6 @@
 package com.chuckerteam.chucker.sample
 
+import okhttp3.RequestBody
 import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -106,6 +107,9 @@ internal interface HttpBinApi {
     @FormUrlEncoded
     @POST("/post")
     fun postForm(@Field("key1") value1: String, @Field("key2") value2: String): Call<Any?>
+
+    @POST("/post")
+    fun postRawRequestBody(@Body body: RequestBody): Call<Any?>
 
     class Data(val thing: String)
 }

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -8,8 +8,11 @@ import com.chuckerteam.chucker.sample.HttpBinApi.Data
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.logging.HttpLoggingInterceptor
+import okio.Buffer
+import okio.BufferedSink
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -94,10 +97,20 @@ class HttpBinClient(
             redirectTo("https://ascii.cl?parameter=%22Click+on+%27URL+Encode%27%21%22").enqueue(cb)
             redirectTo("https://ascii.cl?parameter=\"Click on 'URL Encode'!\"").enqueue(cb)
             postForm("Value 1", "Value with symbols &$%").enqueue(cb)
+            postRawRequestBody(oneShotRequestBody()).enqueue(cb)
         }
         downloadSampleImage(colorHex = "fff")
         downloadSampleImage(colorHex = "000")
         getResponsePartially()
+    }
+
+    private fun oneShotRequestBody() = object : RequestBody() {
+        private val content = Buffer().writeUtf8("Hello, world!")
+        override fun isOneShot() = true
+        override fun contentType() = "text/plain".toMediaType()
+        override fun writeTo(sink: BufferedSink) {
+            content.readAll(sink)
+        }
     }
 
     private fun downloadSampleImage(colorHex: String) {


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

Processing one shot request bodies is a bug as it means that after we process them, they cannot reach the server. Processing duplex request bodies is problematic as the bytes can be intertwined and out of order for us to process them.

One thing that is not that obvious is the message that users see in the Chucker UI as the body processing was omitted for a different reason.

![Screenshot 2021-01-30 at 10 59 40](https://user-images.githubusercontent.com/30936061/106353532-96b1bf80-62eb-11eb-9c2e-0aeec7a83159.png)

We could add new fields to the database model and show appropriate information based on that or we can change the single message that we have. I'm open to both propositions.

## :pencil: Changes
<!-- Which code did you change? How? -->

I added two conditions that check if a request body should be processed. If they are positive the event is logged and request processing is stopped. I also added a sample that utilises a one shot request body.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

#527

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Tests were added. Unfortunately only for one shot requests. Setting up an HTTP2 server for duplex test is too problematic and there wouldn't be much gain there compared to the effort. Alternatively tests for `RequestProcessor` could be written where we check if it processed a duplex request body.

Also you can run the sample and see that one shot requests are not being processed.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

This can wait with merging after #543 is resolved.