### PR TITLE
Redact request headers in case of HTTP failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+### Fixed
+
+* Fixed request headers not being redacted in case of failures [#545].
+
 ### Removed
 
 * Removed parametrized `ChuckerInterceptor` constructor in favour of builder pattern. Constructor that accepts only `Context` is still available.

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -14,8 +14,8 @@ import com.chuckerteam.chucker.internal.support.contentType
 import com.chuckerteam.chucker.internal.support.hasBody
 import com.chuckerteam.chucker.internal.support.hasSupportedContentEncoding
 import com.chuckerteam.chucker.internal.support.isProbablyPlainText
+import com.chuckerteam.chucker.internal.support.redact
 import com.chuckerteam.chucker.internal.support.uncompress
-import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
@@ -52,7 +52,7 @@ public class ChuckerInterceptor private constructor(
     private val cacheDirectoryProvider = builder.cacheDirectoryProvider ?: CacheDirectoryProvider { context.filesDir }
     private val alwaysReadResponseBody = builder.alwaysReadResponseBody
     private val headersToRedact = builder.headersToRedact.toMutableSet()
-    private val requestProcessor = RequestProcessor(context, collector, maxContentLength)
+    private val requestProcessor = RequestProcessor(context, collector, maxContentLength, headersToRedact)
 
     /** Adds [headerName] into [headersToRedact] */
     public fun redactHeader(vararg headerName: String) {
@@ -87,8 +87,8 @@ public class ChuckerInterceptor private constructor(
 
         transaction.apply {
             // includes headers added later in the chain
-            setRequestHeaders(filterHeaders(response.request.headers))
-            setResponseHeaders(filterHeaders(response.headers))
+            setRequestHeaders(response.request.headers.redact(headersToRedact))
+            setResponseHeaders(response.headers.redact(headersToRedact))
 
             isResponseBodyPlainText = responseEncodingIsSupported
             requestDate = response.sentRequestAtMillis
@@ -174,17 +174,6 @@ public class ChuckerInterceptor private constructor(
                 transaction.responseImageData = payload.readByteArray()
             }
         }
-    }
-
-    /** Overrides all headers from [headersToRedact] with `**` */
-    private fun filterHeaders(headers: Headers): Headers {
-        val builder = headers.newBuilder()
-        for (name in headers.names()) {
-            if (headersToRedact.any { userHeader -> userHeader.equals(name, ignoreCase = true) }) {
-                builder.set(name, "**")
-            }
-        }
-        return builder.build()
     }
 
     private inner class ChuckerTransactionReportingSinkCallback(

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkHttpUtils.kt
@@ -64,3 +64,13 @@ internal fun Source.uncompress(headers: Headers) = if (headers.containsGzip) {
 } else {
     this
 }
+
+internal fun Headers.redact(names: Iterable<String>): Headers {
+    val builder = newBuilder()
+    for (name in names()) {
+        if (names.any { userHeader -> userHeader.equals(name, ignoreCase = true) }) {
+            builder[name] = "**"
+        }
+    }
+    return builder.build()
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
@@ -13,6 +13,7 @@ internal class RequestProcessor(
     private val context: Context,
     private val collector: ChuckerCollector,
     private val maxContentLength: Long,
+    private val headersToRedact: Set<String>,
 ) {
     fun process(request: Request, transaction: HttpTransaction): Request {
         processMetadata(request, transaction)
@@ -23,7 +24,7 @@ internal class RequestProcessor(
 
     private fun processMetadata(request: Request, transaction: HttpTransaction) {
         transaction.apply {
-            setRequestHeaders(request.headers)
+            setRequestHeaders(request.headers.redact(headersToRedact))
             populateUrl(request.url)
 
             requestDate = System.currentTimeMillis()


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

Request headers were not redacted if there were communication failures.

## :pencil: Changes
<!-- Which code did you change? How? -->

Request headers are redacted also in a request processing pipeline.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

#527

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

I added unit tests.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

This can wait with merging after #543 is resolved.