### PR TITLE
Update PR template with a comment about release notes 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,7 +6,7 @@
 
 ## :pencil: Changes
 <!-- Which code did you change? How? -->
-<!-- If your changes affect users somehow be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file.
+<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file.
 
 ## :paperclip: Related PR
 <!-- PR that blocks this one, or the ones blocked by this PR -->

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,6 +6,7 @@
 
 ## :pencil: Changes
 <!-- Which code did you change? How? -->
+<!-- If your changes affect users somehow be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file.
 
 ## :paperclip: Related PR
 <!-- PR that blocks this one, or the ones blocked by this PR -->


### PR DESCRIPTION
## :page_facing_up: Context
Looks like we need to add a reminder for everyone contributing to Chucker about keeping changelog up to date.
The PR addresses a similar suggestion from #545.

## :pencil: Changes
- Added a comment into a PR template reminding to update changelogs.