### PR TITLE
Update Material to 1.3.0, switch to new CircularProgressIndicator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         // Google libraries
         appCompatVersion = '1.2.0'
         constraintLayoutVersion = '2.0.4'
-        materialComponentsVersion = '1.2.1'
+        materialComponentsVersion = '1.3.0'
         roomVersion = '2.2.6'
         fragmentVersion = '1.2.5'
         lifecycleVersion = '2.2.0'

--- a/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
@@ -7,9 +7,8 @@
     android:animateLayoutChanges="true"
     tools:context="com.chuckerteam.chucker.internal.ui.transaction.TransactionPayloadFragment">
 
-    <androidx.core.widget.ContentLoadingProgressBar
+    <com.google.android.material.progressindicator.CircularProgressIndicator
         android:id="@+id/loadingProgress"
-        style="@style/Widget.AppCompat.ProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/chucker_doub_grid"
@@ -38,12 +37,12 @@
         android:id="@+id/emptyPayloadTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="@string/chucker_response_is_empty"
         android:textSize="18sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:text="@string/chucker_response_is_empty" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/payloadRecyclerView"


### PR DESCRIPTION
## :page_facing_up: Context
Material 1.3.0 has some [new components for progress indicators ](https://github.com/material-components/material-components-android/blob/master/docs/components/ProgressIndicator.md). This PR updates Material to 1.3.0 and switches loading indicator used on transaction payload fragment to such new component.

## :pencil: Changes
- Updated Material to 1.3.0
- Switched to `CircularProgressIndicator` component

## :no_entry_sign: Breaking
Nothing