### PR TITLE
Custom body decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change Log
 
-This file follows [Keepachangelog](https://keepachangelog.com/) format. 
+This file follows [Keepachangelog](https://keepachangelog.com/) format.
 Please add your entries according to this format.
 
 ## Unreleased
+
+### Added
+* Decoding of request and response bodies can now be customized. In order to do this a `BodyDecoder` interface needs to be implemented and installed in the `ChuckerInterceptor` via `ChuckerInterceptor.addBinaryDecoder(decoder)` method. Decoded bodies are then displayed in the Chucker UI.
 
 ### Fixed
 
@@ -46,8 +49,8 @@ Please add your entries according to this format.
 
 ## Version 3.3.0 *(2020-09-30)*
 
-This is a new minor release with multiple fixes and improvements. 
-After this release we are starting to work on a new major release 4.x with minSDK 21. 
+This is a new minor release with multiple fixes and improvements.
+After this release we are starting to work on a new major release 4.x with minSDK 21.
 Bumping minSDK to 21 is required to keep up with [newer versions of OkHttp](https://medium.com/square-corner-blog/okhttp-3-13-requires-android-5-818bb78d07ce).
 Versions 3.x will be supported for 6 months (till March 2021) getting bugfixes and minor improvements.
 
@@ -55,7 +58,7 @@ Versions 3.x will be supported for 6 months (till March 2021) getting bugfixes a
 
 * Added a new flag `alwaysReadResponseBody` into Chucker configuration to read the whole response body even if consumer fails to consume it.
 * Added port numbers as part of the URL. Numbers appear if they are different from default 80 or 443.
-* Chucker now shows partially read application responses properly. Earlier in 3.2.0 such responses didn't appear in the UI. 
+* Chucker now shows partially read application responses properly. Earlier in 3.2.0 such responses didn't appear in the UI.
 * Transaction size is defined by actual payload size now, not by `Content-length` header.
 * Added empty state UI for payloads, so no more guessing if there is some error or the payload is really empty.
 * Added ability to export list of transactions.
@@ -198,7 +201,7 @@ This release was possible thanks to the contribution of:
 
 ### This version shouldn't be used as dependency due to [#203](https://github.com/ChuckerTeam/chucker/issues/203). Use 3.1.1 instead.
 
-This is a new minor release of Chucker. Please note that this minor release contains multiple new features (see below) as well as multiple bugfixes. 
+This is a new minor release of Chucker. Please note that this minor release contains multiple new features (see below) as well as multiple bugfixes.
 
 ### Summary of Changes
 
@@ -235,11 +238,11 @@ This is a new minor release of Chucker. Please note that this minor release cont
 This release was possible thanks to the contribution of:
 
 @christopherniksch
-@yoavst 
+@yoavst
 @psh
 @kmayoral
 @vbuberen
-@dcampogiani 
+@dcampogiani
 @ullas-jain
 @rakshit444
 @olivierperez
@@ -249,8 +252,8 @@ This release was possible thanks to the contribution of:
 @koral--
 @redwarp
 @uOOOO
-@sprohaszka 
-@PaulWoitaschek 
+@sprohaszka
+@PaulWoitaschek
 
 
 ## Version 3.0.1 *(2019-08-16)*

--- a/README.md
+++ b/README.md
@@ -146,11 +146,15 @@ Chucker by default handles only plain text bodies. If you use a binary format li
 object ProtoDecoder : BinaryDecoder {
     fun decodeRequest(request: Request, body: ByteString): String? = if (request.isExpectedProtoRequest) {
         decodeProtoBody(body)
-    } else null
+    } else {
+        null
+    }
 
     fun decodeResponse(request: Response, body: ByteString): String? = if (request.isExpectedProtoResponse) {
         decodeProtoBody(body)
-    } else null
+    } else {
+        null
+    }
 }
 interceptorBuilder.addBodyDecoder(ProtoDecoder).build()
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ _A fork of [Chuck](https://github.com/jgilfelt/chuck)_
   * [Multi-Window](#multi-window-)
 * [Configure](#configure-)
   * [Redact-Header️](#redact-header-️)
+  * [Decode-Body](#decode-body-)
 * [Migrating](#migrating-)
 * [Snapshots](#snapshots-)
 * [FAQ](#faq-)
@@ -65,7 +66,7 @@ android {
 
 **That's it!** 🎉 Chucker will now record all HTTP interactions made by your OkHttp client.
 
-Historically, Chucker was distributed through JitPack. 
+Historically, Chucker was distributed through JitPack.
 You can find older version of Chucker here: [![JitPack](https://jitpack.io/v/ChuckerTeam/chucker.svg)](https://jitpack.io/#ChuckerTeam/chucker).
 
 ## Features 🧰
@@ -79,6 +80,7 @@ Don't forget to check the [changelog](CHANGELOG.md) to have a look at all the ch
 * **Empty release artifact** 🧼 (no traces of Chucker in your final APK).
 * Support for body text search with **highlighting** 🕵️‍♂️
 * Support for showing **images** in HTTP Responses 🖼
+* Support for custom decoding of HTTP bodies
 
 ### Multi-Window 🚪
 
@@ -112,6 +114,9 @@ val chuckerInterceptor = ChuckerInterceptor.Builder(context)
         // This is useful in case of parsing errors or when the response body
         // is closed before being read like in Retrofit with Void and Unit types.
         .alwaysReadResponseBody(true)
+        // Use decoder when processing request and response bodies. When multiple decoders are installed they
+        // are applied in an order they were added.
+        .addBodyDecoder(decoder)
         .build()
 
 // Don't forget to plug the ChuckerInterceptor inside the OkHttpClient
@@ -128,8 +133,26 @@ It is intended for **use during development**, and not in release builds or othe
 
 You can redact headers that contain sensitive information by calling `redactHeader(String)` on the `ChuckerInterceptor`.
 
+
 ```kotlin
 interceptor.redactHeader("Auth-Token", "User-Session");
+```
+
+### Decode-Body 📖
+
+Chucker by default handles only plain text bodies. If you use a binary format like, for example, Protobuf or Thrift it won't be automatically handled by Chucker. You can, however, install a custom decoder that is capable to read data from different encodings.
+
+```kotlin
+object ProtoDecoder : BinaryDecoder {
+    fun decodeRequest(request: Request, body: ByteString): String? = if (request.isExpectedProtoRequest) {
+        decodeProtoBody(body)
+    } else null
+
+    fun decodeResponse(request: Response, body: ByteString): String? = if (request.isExpectedProtoResponse) {
+        decodeProtoBody(body)
+    } else null
+}
+interceptorBuilder.addBodyDecoder(ProtoDecoder).build()
 ```
 
 ## Migrating 🚗

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ buildscript {
         gsonVersion = '2.8.6'
         okhttpVersion = '4.9.1'
         retrofitVersion = '2.9.0'
+        wireVersion = '3.6.0'
 
         // Debug and quality control
         binaryCompatibilityValidator = '0.2.4'
@@ -51,6 +52,7 @@ buildscript {
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktLintGradleVersion"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binaryCompatibilityValidator"
+        classpath "com.squareup.wire:wire-gradle-plugin:$wireVersion"
     }
 }
 apply plugin: 'binary-compatibility-validator'

--- a/gradle/kotlin-static-analysis.gradle
+++ b/gradle/kotlin-static-analysis.gradle
@@ -13,7 +13,7 @@ ktlint {
         include fileTree("scripts/")
     }
     filter {
-        exclude("**/generated/**")
+        exclude { element -> element.file.path.contains("generated/") }
         include("**/kotlin/**")
     }
 }

--- a/library-no-op/api/library-no-op.api
+++ b/library-no-op/api/library-no-op.api
@@ -1,3 +1,8 @@
+public abstract interface class com/chuckerteam/chucker/api/BodyDecoder {
+	public abstract fun decodeRequest (Lokhttp3/Request;Lokio/ByteString;)Ljava/lang/String;
+	public abstract fun decodeResponse (Lokhttp3/Response;Lokio/ByteString;)Ljava/lang/String;
+}
+
 public final class com/chuckerteam/chucker/api/Chucker {
 	public static final field INSTANCE Lcom/chuckerteam/chucker/api/Chucker;
 	public static final fun dismissNotifications (Landroid/content/Context;)V
@@ -23,6 +28,7 @@ public final class com/chuckerteam/chucker/api/ChuckerInterceptor : okhttp3/Inte
 
 public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
 	public fun <init> (Landroid/content/Context;)V
+	public final fun addBodyDecoder (Ljava/lang/Object;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun alwaysReadResponseBody (Z)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun build ()Lcom/chuckerteam/chucker/api/ChuckerInterceptor;
 	public final fun collector (Lcom/chuckerteam/chucker/api/ChuckerCollector;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/BodyDecoder.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/BodyDecoder.kt
@@ -1,0 +1,17 @@
+package com.chuckerteam.chucker.api
+
+import okhttp3.Request
+import okhttp3.Response
+import okio.ByteString
+import okio.IOException
+
+/**
+ * No-op declaration
+ */
+public interface BodyDecoder {
+    @Throws(IOException::class)
+    public fun decodeRequest(request: Request, body: ByteString): String?
+
+    @Throws(IOException::class)
+    public fun decodeResponse(response: Response, body: ByteString): String?
+}

--- a/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/java/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -42,6 +42,8 @@ public class ChuckerInterceptor private constructor(
 
         public fun alwaysReadResponseBody(enable: Boolean): Builder = this
 
+        public fun addBodyDecoder(decoder: Any): Builder = this
+
         public fun build(): ChuckerInterceptor = ChuckerInterceptor(this)
     }
 }

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -1,3 +1,8 @@
+public abstract interface class com/chuckerteam/chucker/api/BodyDecoder {
+	public abstract fun decodeRequest (Lokhttp3/Request;Lokio/ByteString;)Ljava/lang/String;
+	public abstract fun decodeResponse (Lokhttp3/Response;Lokio/ByteString;)Ljava/lang/String;
+}
+
 public final class com/chuckerteam/chucker/api/Chucker {
 	public static final field INSTANCE Lcom/chuckerteam/chucker/api/Chucker;
 	public static final fun dismissNotifications (Landroid/content/Context;)V
@@ -23,6 +28,7 @@ public final class com/chuckerteam/chucker/api/ChuckerInterceptor : okhttp3/Inte
 
 public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
 	public fun <init> (Landroid/content/Context;)V
+	public final fun addBodyDecoder (Lcom/chuckerteam/chucker/api/BodyDecoder;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun alwaysReadResponseBody (Z)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun build ()Lcom/chuckerteam/chucker/api/ChuckerInterceptor;
 	public final fun collector (Lcom/chuckerteam/chucker/api/ChuckerCollector;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;

--- a/library/src/main/java/com/chuckerteam/chucker/api/BodyDecoder.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/BodyDecoder.kt
@@ -1,0 +1,29 @@
+package com.chuckerteam.chucker.api
+
+import okhttp3.Request
+import okhttp3.Response
+import okio.ByteString
+import okio.IOException
+
+/**
+ * Decodes HTTP request and response bodies to human–readable texts.
+ */
+public interface BodyDecoder {
+    /**
+     * Returns a text representation of [body] that will be displayed in Chucker UI transaction,
+     * or `null` if [request] cannot be handled by this decoder. [Body][body] is no longer than
+     * [max content length][ChuckerInterceptor.Builder.maxContentLength] and is guaranteed to be
+     * gunzipped even if [request] has gzip header.
+     */
+    @Throws(IOException::class)
+    public fun decodeRequest(request: Request, body: ByteString): String?
+
+    /**
+     * Returns a text representation of [body] that will be displayed in Chucker UI transaction,
+     * or `null` if [response] cannot be handled by this decoder. [Body][body] is no longer than
+     * [max content length][ChuckerInterceptor.Builder.maxContentLength] and is guaranteed to be
+     * gunzipped even if [response] has gzip header.
+     */
+    @Throws(IOException::class)
+    public fun decodeResponse(response: Response, body: ByteString): String?
+}

--- a/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Chucker.kt
@@ -41,12 +41,12 @@ public object Chucker {
     internal var logger: Logger = object : Logger {
         val TAG = "Chucker"
 
-        override fun info(message: String) {
-            Log.i(TAG, message)
+        override fun info(message: String, throwable: Throwable?) {
+            Log.i(TAG, message, throwable)
         }
 
-        override fun warn(message: String) {
-            Log.w(TAG, message)
+        override fun warn(message: String, throwable: Throwable?) {
+            Log.w(TAG, message, throwable)
         }
 
         override fun error(message: String, throwable: Throwable?) {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/Logger.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/Logger.kt
@@ -3,19 +3,19 @@ package com.chuckerteam.chucker.internal.support
 import com.chuckerteam.chucker.api.Chucker
 
 internal interface Logger {
-    fun info(message: String)
+    fun info(message: String, throwable: Throwable? = null)
 
-    fun warn(message: String)
+    fun warn(message: String, throwable: Throwable? = null)
 
     fun error(message: String, throwable: Throwable? = null)
 
     companion object : Logger {
-        override fun info(message: String) {
-            Chucker.logger.info(message)
+        override fun info(message: String, throwable: Throwable?) {
+            Chucker.logger.info(message, throwable)
         }
 
-        override fun warn(message: String) {
-            Chucker.logger.warn(message)
+        override fun warn(message: String, throwable: Throwable?) {
+            Chucker.logger.warn(message, throwable)
         }
 
         override fun error(message: String, throwable: Throwable?) {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/OkioUtils.kt
@@ -1,6 +1,7 @@
 package com.chuckerteam.chucker.internal.support
 
 import okio.Buffer
+import okio.ByteString
 import java.io.EOFException
 import kotlin.math.min
 
@@ -21,6 +22,12 @@ internal val Buffer.isProbablyPlainText
             .all { codePoint -> codePoint.isPlainTextChar() }
     } catch (_: EOFException) {
         false // Truncated UTF-8 sequence
+    }
+
+internal val ByteString.isProbablyPlainText: Boolean
+    get() {
+        val byteCount = min(size, MAX_PREFIX_SIZE.toInt())
+        return Buffer().write(this, offset = 0, byteCount).isProbablyPlainText
     }
 
 private fun Int.isPlainTextChar() = Character.isWhitespace(this) || !Character.isISOControl(this)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/PlainTextDecoder.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/PlainTextDecoder.kt
@@ -1,0 +1,28 @@
+package com.chuckerteam.chucker.internal.support
+
+import com.chuckerteam.chucker.api.BodyDecoder
+import okhttp3.Headers
+import okhttp3.MediaType
+import okhttp3.Request
+import okhttp3.Response
+import okio.ByteString
+import kotlin.text.Charsets.UTF_8
+
+internal object PlainTextDecoder : BodyDecoder {
+    override fun decodeRequest(
+        request: Request,
+        body: ByteString,
+    ) = body.tryDecodeAsPlainText(request.headers, request.body?.contentType())
+
+    override fun decodeResponse(
+        response: Response,
+        body: ByteString,
+    ) = body.tryDecodeAsPlainText(response.headers, response.body?.contentType())
+
+    private fun ByteString.tryDecodeAsPlainText(
+        headers: Headers,
+        contentType: MediaType?,
+    ) = if (headers.hasSupportedContentEncoding && isProbablyPlainText) {
+        string(contentType?.charset() ?: UTF_8)
+    } else null
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/PlainTextDecoder.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/PlainTextDecoder.kt
@@ -24,5 +24,7 @@ internal object PlainTextDecoder : BodyDecoder {
         contentType: MediaType?,
     ) = if (headers.hasSupportedContentEncoding && isProbablyPlainText) {
         string(contentType?.charset() ?: UTF_8)
-    } else null
+    } else {
+        null
+    }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
@@ -2,22 +2,24 @@ package com.chuckerteam.chucker.internal.support
 
 import android.content.Context
 import com.chuckerteam.chucker.R
+import com.chuckerteam.chucker.api.BodyDecoder
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import okhttp3.Request
 import okio.Buffer
+import okio.ByteString
 import okio.IOException
-import kotlin.text.Charsets.UTF_8
 
 internal class RequestProcessor(
     private val context: Context,
     private val collector: ChuckerCollector,
     private val maxContentLength: Long,
     private val headersToRedact: Set<String>,
+    private val bodyDecoders: List<BodyDecoder>,
 ) {
     fun process(request: Request, transaction: HttpTransaction) {
         processMetadata(request, transaction)
-        processBody(request, transaction)
+        processPayload(request, transaction)
         collector.onRequestSent(transaction)
     }
 
@@ -33,7 +35,7 @@ internal class RequestProcessor(
         }
     }
 
-    private fun processBody(request: Request, transaction: HttpTransaction) {
+    private fun processPayload(request: Request, transaction: HttpTransaction) {
         val body = request.body ?: return
         if (body.isOneShot()) {
             Logger.info("Skipping one shot request body")
@@ -41,10 +43,6 @@ internal class RequestProcessor(
         }
         if (body.isDuplex()) {
             Logger.info("Skipping duplex request body")
-            return
-        }
-
-        if (!request.headers.hasSupportedContentEncoding) {
             return
         }
 
@@ -57,18 +55,24 @@ internal class RequestProcessor(
         val limitingSource = LimitingSource(requestSource.uncompress(request.headers), maxContentLength)
 
         val contentBuffer = Buffer().apply { limitingSource.use { writeAll(it) } }
-        if (!contentBuffer.isProbablyPlainText) {
-            return
-        }
+        transaction.isRequestBodyPlainText = contentBuffer.isProbablyPlainText
 
-        transaction.isRequestBodyPlainText = true
-        try {
-            transaction.requestBody = contentBuffer.readString(body.contentType()?.charset() ?: UTF_8)
-        } catch (e: IOException) {
-            Logger.error("Failed to process request payload", e)
-        }
-        if (limitingSource.isThresholdReached) {
+        val decodedContent = decodePayload(request, contentBuffer.readByteString())
+        Logger.info("$decodedContent")
+        transaction.requestBody = decodedContent
+        if (decodedContent != null && limitingSource.isThresholdReached) {
             transaction.requestBody += context.getString(R.string.chucker_body_content_truncated)
         }
     }
+
+    private fun decodePayload(request: Request, body: ByteString) = bodyDecoders.asSequence()
+        .mapNotNull { decoder ->
+            try {
+                Logger.info("Decoding with: $decoder")
+                decoder.decodeRequest(request, body)
+            } catch (e: IOException) {
+                Logger.error("Failed to process request payload", e)
+                null
+            }
+        }.firstOrNull()
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
@@ -70,7 +70,7 @@ internal class RequestProcessor(
                 Logger.info("Decoding with: $decoder")
                 decoder.decodeRequest(request, body)
             } catch (e: IOException) {
-                Logger.error("Failed to process request payload", e)
+                Logger.warn("Decoder $decoder failed to process request payload", e)
                 null
             }
         }.firstOrNull()

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
@@ -58,7 +58,6 @@ internal class RequestProcessor(
         transaction.isRequestBodyPlainText = contentBuffer.isProbablyPlainText
 
         val decodedContent = decodePayload(request, contentBuffer.readByteString())
-        Logger.info("$decodedContent")
         transaction.requestBody = decodedContent
         if (decodedContent != null && limitingSource.isThresholdReached) {
             transaction.requestBody += context.getString(R.string.chucker_body_content_truncated)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ResponseProcessor.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ResponseProcessor.kt
@@ -103,7 +103,7 @@ internal class ResponseProcessor(
             try {
                 decoder.decodeResponse(response, body)
             } catch (e: IOException) {
-                Logger.error("Failed to process response payload", e)
+                Logger.warn("Decoder $decoder failed to process response payload", e)
                 null
             }
         }.firstOrNull()

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionDetailsSharable.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionDetailsSharable.kt
@@ -37,14 +37,15 @@ internal class TransactionDetailsSharable(
         }
 
         writeUtf8(
-            if (transaction.isRequestBodyPlainText) {
-                if (transaction.requestBody.isNullOrBlank()) {
-                    context.getString(R.string.chucker_body_empty)
+            if (transaction.requestBody.isNullOrBlank()) {
+                val resId = if (!transaction.isRequestBodyPlainText) {
+                    R.string.chucker_body_omitted
                 } else {
-                    transaction.getFormattedRequestBody()
+                    R.string.chucker_body_empty
                 }
+                context.getString(resId)
             } else {
-                context.getString(R.string.chucker_body_omitted)
+                transaction.getFormattedRequestBody()
             }
         )
 
@@ -59,14 +60,15 @@ internal class TransactionDetailsSharable(
         }
 
         writeUtf8(
-            if (transaction.isResponseBodyPlainText) {
-                if (transaction.responseBody.isNullOrBlank()) {
-                    context.getString(R.string.chucker_body_empty)
+            if (transaction.responseBody.isNullOrBlank()) {
+                val resId = if (!transaction.isResponseBodyPlainText) {
+                    R.string.chucker_body_omitted
                 } else {
-                    transaction.getFormattedResponseBody()
+                    R.string.chucker_body_empty
                 }
+                context.getString(resId)
             } else {
-                context.getString(R.string.chucker_body_omitted)
+                transaction.getFormattedResponseBody()
             }
         )
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -268,15 +268,15 @@ internal class TransactionPayloadFragment :
             if (type == PayloadType.RESPONSE && responseBitmap != null) {
                 val bitmapLuminance = responseBitmap.calculateLuminance()
                 result.add(TransactionPayloadItem.ImageItem(responseBitmap, bitmapLuminance))
-            } else if (!isBodyPlainText) {
-                requireContext().getString(R.string.chucker_body_omitted).let {
-                    result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
-                }
-            } else {
-                if (bodyString.isNotBlank()) {
-                    bodyString.lines().forEach {
+            } else if (bodyString.isBlank()) {
+                if (!isBodyPlainText) {
+                    requireContext().getString(R.string.chucker_body_omitted).let {
                         result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
                     }
+                }
+            } else {
+                bodyString.lines().forEach {
+                    result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
                 }
             }
             return@withContext result

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -245,22 +245,22 @@ internal class TransactionPayloadFragment :
                 )
             }
 
-            // The body could either be an image, binary encoded or plain text.
+            // The body could either be an image, plain text, decoded binary or not decoded binary.
             val responseBitmap = transaction.responseImageBitmap
-            if (type == PayloadType.RESPONSE && responseBitmap != null) {
-                val bitmapLuminance = responseBitmap.calculateLuminance()
-                result.add(TransactionPayloadItem.ImageItem(responseBitmap, bitmapLuminance))
-            } else if (bodyString.isBlank()) {
-                if (!isBodyPlainText) {
-                    requireContext().getString(R.string.chucker_body_omitted).let {
-                        result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
-                    }
+            when {
+                type == PayloadType.RESPONSE && responseBitmap != null -> {
+                    val bitmapLuminance = responseBitmap.calculateLuminance()
+                    result.add(TransactionPayloadItem.ImageItem(responseBitmap, bitmapLuminance))
                 }
-            } else {
-                bodyString.lines().forEach {
+                bodyString.isNotBlank() -> bodyString.lines().forEach {
                     result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
                 }
+                !isBodyPlainText -> {
+                    val text = requireContext().getString(R.string.chucker_body_omitted)
+                    result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(text)))
+                }
             }
+
             return@withContext result
         }
     }

--- a/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/ChuckerInterceptorDelegate.kt
@@ -1,6 +1,7 @@
 package com.chuckerteam.chucker
 
 import android.content.Context
+import com.chuckerteam.chucker.api.BodyDecoder
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
@@ -17,6 +18,7 @@ internal class ChuckerInterceptorDelegate(
     headersToRedact: Set<String> = emptySet(),
     alwaysReadResponseBody: Boolean = false,
     cacheDirectoryProvider: CacheDirectoryProvider,
+    decoders: List<BodyDecoder> = emptyList(),
 ) : Interceptor {
     private val idGenerator = AtomicLong()
     private val transactions = CopyOnWriteArrayList<HttpTransaction>()
@@ -39,6 +41,7 @@ internal class ChuckerInterceptorDelegate(
         .redactHeaders(headersToRedact)
         .alwaysReadResponseBody(alwaysReadResponseBody)
         .cacheDirectorProvider(cacheDirectoryProvider)
+        .apply { decoders.forEach(::addBodyDecoder) }
         .build()
 
     internal fun expectTransaction(): HttpTransaction {

--- a/library/src/test/java/com/chuckerteam/chucker/NoLoggerRule.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/NoLoggerRule.kt
@@ -11,9 +11,9 @@ internal class NoLoggerRule : BeforeAllCallback, AfterAllCallback {
 
     override fun beforeAll(context: ExtensionContext) {
         Chucker.logger = object : Logger {
-            override fun info(message: String) = Unit
+            override fun info(message: String, throwable: Throwable?) = Unit
 
-            override fun warn(message: String) = Unit
+            override fun warn(message: String, throwable: Throwable?) = Unit
 
             override fun error(message: String, throwable: Throwable?) = Unit
         }

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorDecodingTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorDecodingTest.kt
@@ -1,0 +1,206 @@
+package com.chuckerteam.chucker.api
+
+import com.chuckerteam.chucker.util.ChuckerInterceptorDelegate
+import com.chuckerteam.chucker.util.ClientFactory
+import com.chuckerteam.chucker.util.NoLoggerRule
+import com.chuckerteam.chucker.util.readByteStringBody
+import com.chuckerteam.chucker.util.toServerRequest
+import com.google.common.truth.Truth.assertThat
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
+import okio.ByteString
+import okio.IOException
+import org.junit.Rule
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.io.File
+
+@ExtendWith(NoLoggerRule::class)
+internal class ChuckerInterceptorDecodingTest {
+    @get:Rule val server = MockWebServer()
+
+    private val serverUrl = server.url("/") // Starts server implicitly
+
+    @TempDir lateinit var tempDir: File
+
+    @ParameterizedTest
+    @EnumSource
+    fun customBodyDecoder_doesNotChangeRequestBody(factory: ClientFactory) {
+        val chuckerInterceptor = ChuckerInterceptorDelegate(
+            cacheDirectoryProvider = { tempDir },
+            decoders = listOf(ReversingDecoder()),
+        )
+        val client = factory.create(chuckerInterceptor)
+        server.enqueue(MockResponse())
+
+        val request = "Hello, world!".toRequestBody().toServerRequest(serverUrl)
+        client.newCall(request).execute().readByteStringBody()
+        val serverRequestContent = server.takeRequest().body.readByteString()
+
+        assertThat(serverRequestContent.utf8()).isEqualTo("Hello, world!")
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    fun customBodyDecoder_doesNotChangeResponseBody(factory: ClientFactory) {
+        val chuckerInterceptor = ChuckerInterceptorDelegate(
+            cacheDirectoryProvider = { tempDir },
+            decoders = listOf(ReversingDecoder()),
+        )
+        val client = factory.create(chuckerInterceptor)
+
+        val body = Buffer().apply { writeUtf8("Hello, world!") }
+        server.enqueue(MockResponse().setBody(body))
+        val request = Request.Builder().url(serverUrl).build()
+
+        val responseBody = client.newCall(request).execute().readByteStringBody()!!
+
+        assertThat(responseBody.utf8()).isEqualTo("Hello, world!")
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ClientFactory::class)
+    fun customBodyDecoder_isUsedForDecoding(factory: ClientFactory) {
+        val chuckerInterceptor = ChuckerInterceptorDelegate(
+            cacheDirectoryProvider = { tempDir },
+            decoders = listOf(LiteralBodyDecoder()),
+        )
+        val client = factory.create(chuckerInterceptor)
+        val request = Request.Builder().url(serverUrl)
+            .post("Hello".toRequestBody())
+            .build()
+        server.enqueue(MockResponse().setBody("Goodbye"))
+
+        client.newCall(request).execute().readByteStringBody()
+
+        val transaction = chuckerInterceptor.expectTransaction()
+
+        assertThat(transaction.requestBody).isEqualTo("Request")
+        assertThat(transaction.responseBody).isEqualTo("Response")
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ClientFactory::class)
+    fun bodyDecoders_areUsedInAppliedOrder(factory: ClientFactory) {
+        val chuckerInterceptor = ChuckerInterceptorDelegate(
+            cacheDirectoryProvider = { tempDir },
+            decoders = listOf(ReversingDecoder(), LiteralBodyDecoder()),
+        )
+        val client = factory.create(chuckerInterceptor)
+        val request = Request.Builder().url(serverUrl)
+            .post("Hello".toRequestBody())
+            .build()
+        server.enqueue(MockResponse().setBody("Goodbye"))
+
+        client.newCall(request).execute().readByteStringBody()
+
+        val transaction = chuckerInterceptor.expectTransaction()
+
+        assertThat(transaction.requestBody).isEqualTo("olleH")
+        assertThat(transaction.responseBody).isEqualTo("eybdooG")
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ClientFactory::class)
+    fun nextBodyDecoder_isUsed_whenPreviousDoesNotDecode(factory: ClientFactory) {
+        val chuckerInterceptor = ChuckerInterceptorDelegate(
+            cacheDirectoryProvider = { tempDir },
+            decoders = listOf(NoOpDecoder(), LiteralBodyDecoder()),
+        )
+        val client = factory.create(chuckerInterceptor)
+        val request = Request.Builder().url(serverUrl)
+            .post("Hello".toRequestBody())
+            .build()
+        server.enqueue(MockResponse().setBody("Goodbye"))
+
+        client.newCall(request).execute().readByteStringBody()
+
+        val transaction = chuckerInterceptor.expectTransaction()
+
+        assertThat(transaction.requestBody).isEqualTo("Request")
+        assertThat(transaction.responseBody).isEqualTo("Response")
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ClientFactory::class)
+    fun bodyDecoder_canThrowIoExceptions(factory: ClientFactory) {
+        val chuckerInterceptor = ChuckerInterceptorDelegate(
+            cacheDirectoryProvider = { tempDir },
+            decoders = listOf(IoThrowingDecoder(), LiteralBodyDecoder()),
+        )
+        val client = factory.create(chuckerInterceptor)
+        val request = Request.Builder().url(serverUrl)
+            .post("Hello".toRequestBody())
+            .build()
+        server.enqueue(MockResponse().setBody("Goodbye"))
+
+        client.newCall(request).execute().readByteStringBody()
+
+        val transaction = chuckerInterceptor.expectTransaction()
+
+        assertThat(transaction.requestBody).isEqualTo("Request")
+        assertThat(transaction.responseBody).isEqualTo("Response")
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ClientFactory::class)
+    fun bodyDecoders_areAppliedLazily(factory: ClientFactory) {
+        val statefulDecoder = StatefulDecoder()
+        val chuckerInterceptor = ChuckerInterceptorDelegate(
+            cacheDirectoryProvider = { tempDir },
+            decoders = listOf(LiteralBodyDecoder(), statefulDecoder),
+        )
+        val client = factory.create(chuckerInterceptor)
+        val request = Request.Builder().url(serverUrl)
+            .post("Hello".toRequestBody())
+            .build()
+        server.enqueue(MockResponse().setBody("Goodbye"))
+
+        client.newCall(request).execute().readByteStringBody()
+
+        assertThat(statefulDecoder.didDecodeRequest).isFalse()
+        assertThat(statefulDecoder.didDecodeResponse).isFalse()
+    }
+
+    private class LiteralBodyDecoder : BodyDecoder {
+        override fun decodeRequest(request: Request, body: ByteString) = "Request"
+        override fun decodeResponse(response: Response, body: ByteString) = "Response"
+    }
+
+    private class ReversingDecoder : BodyDecoder {
+        override fun decodeRequest(request: Request, body: ByteString) = body.utf8().reversed()
+        override fun decodeResponse(response: Response, body: ByteString) = body.utf8().reversed()
+    }
+
+    private class NoOpDecoder : BodyDecoder {
+        override fun decodeRequest(request: Request, body: ByteString): String? = null
+        override fun decodeResponse(response: Response, body: ByteString): String? = null
+    }
+
+    private class IoThrowingDecoder : BodyDecoder {
+        override fun decodeRequest(request: Request, body: ByteString) = throw IOException("Request")
+        override fun decodeResponse(response: Response, body: ByteString) = throw IOException("Response")
+    }
+
+    private class StatefulDecoder : BodyDecoder {
+        var didDecodeRequest = false
+
+        override fun decodeRequest(request: Request, body: ByteString): String {
+            didDecodeRequest = true
+            return ""
+        }
+
+        var didDecodeResponse = false
+
+        override fun decodeResponse(response: Response, body: ByteString): String {
+            didDecodeResponse = true
+            return ""
+        }
+    }
+}

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/DepletingSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/DepletingSourceTest.kt
@@ -1,6 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
-import com.chuckerteam.chucker.NoLoggerRule
+import com.chuckerteam.chucker.util.NoLoggerRule
 import com.google.common.truth.Truth.assertThat
 import okio.Buffer
 import okio.BufferedSource

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/LimitingSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/LimitingSourceTest.kt
@@ -1,6 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
-import com.chuckerteam.chucker.SEGMENT_SIZE
+import com.chuckerteam.chucker.util.SEGMENT_SIZE
 import com.google.common.truth.Truth.assertThat
 import okio.Buffer
 import okio.buffer

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataCombineLatestTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataCombineLatestTest.kt
@@ -2,7 +2,7 @@ package com.chuckerteam.chucker.internal.support
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
-import com.chuckerteam.chucker.test
+import com.chuckerteam.chucker.util.test
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/LiveDataDistinctUntilChangedTest.kt
@@ -3,7 +3,7 @@ package com.chuckerteam.chucker.internal.support
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.distinctUntilChanged
-import com.chuckerteam.chucker.test
+import com.chuckerteam.chucker.util.test
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
 import org.junit.Test

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/ReportingSinkTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/ReportingSinkTest.kt
@@ -1,6 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
-import com.chuckerteam.chucker.SEGMENT_SIZE
+import com.chuckerteam.chucker.util.SEGMENT_SIZE
 import com.google.common.truth.Truth.assertThat
 import okio.Buffer
 import okio.ByteString
@@ -82,7 +82,7 @@ internal class ReportingSinkTest {
 
     private class TestReportingCallback : ReportingSink.Callback {
         private var file: File? = null
-        val fileContent get() = file?.let { it.source().buffer().readByteString() }
+        val fileContent get() = file?.source()?.buffer()?.readByteString()
         var exception: IOException? = null
         var isSuccess = false
             private set

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
@@ -1,6 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
-import com.chuckerteam.chucker.SEGMENT_SIZE
+import com.chuckerteam.chucker.util.SEGMENT_SIZE
 import com.google.common.truth.Truth.assertThat
 import okio.Buffer
 import okio.BufferedSource

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharableTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharableTest.kt
@@ -2,8 +2,8 @@ package com.chuckerteam.chucker.internal.support
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import com.chuckerteam.chucker.TestTransactionFactory
 import com.chuckerteam.chucker.internal.data.entity.HttpHeader
+import com.chuckerteam.chucker.util.TestTransactionFactory
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionDetailsSharableTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionDetailsSharableTest.kt
@@ -2,7 +2,7 @@ package com.chuckerteam.chucker.internal.support
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import com.chuckerteam.chucker.TestTransactionFactory
+import com.chuckerteam.chucker.util.TestTransactionFactory
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionListDetailsSharableTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TransactionListDetailsSharableTest.kt
@@ -2,7 +2,7 @@ package com.chuckerteam.chucker.internal.support
 
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
-import com.chuckerteam.chucker.TestTransactionFactory
+import com.chuckerteam.chucker.util.TestTransactionFactory
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/library/src/test/java/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
@@ -1,6 +1,7 @@
-package com.chuckerteam.chucker
+package com.chuckerteam.chucker.util
 
 import android.content.Context
+import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.api.BodyDecoder
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor

--- a/library/src/test/java/com/chuckerteam/chucker/util/ClientFactory.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/util/ClientFactory.kt
@@ -1,0 +1,23 @@
+package com.chuckerteam.chucker.util
+
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+
+internal enum class ClientFactory {
+    APPLICATION {
+        override fun create(interceptor: Interceptor): OkHttpClient {
+            return OkHttpClient.Builder()
+                .addInterceptor(interceptor)
+                .build()
+        }
+    },
+    NETWORK {
+        override fun create(interceptor: Interceptor): OkHttpClient {
+            return OkHttpClient.Builder()
+                .addNetworkInterceptor(interceptor)
+                .build()
+        }
+    };
+
+    abstract fun create(interceptor: Interceptor): OkHttpClient
+}

--- a/library/src/test/java/com/chuckerteam/chucker/util/NoLoggerRule.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/util/NoLoggerRule.kt
@@ -1,4 +1,4 @@
-package com.chuckerteam.chucker
+package com.chuckerteam.chucker.util
 
 import com.chuckerteam.chucker.api.Chucker
 import com.chuckerteam.chucker.internal.support.Logger

--- a/library/src/test/java/com/chuckerteam/chucker/util/TestTransactionFactory.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/util/TestTransactionFactory.kt
@@ -1,4 +1,4 @@
-package com.chuckerteam.chucker
+package com.chuckerteam.chucker.util
 
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import java.util.Date

--- a/library/src/test/java/com/chuckerteam/chucker/util/TestUtils.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/util/TestUtils.kt
@@ -1,8 +1,11 @@
-package com.chuckerteam.chucker
+package com.chuckerteam.chucker.util
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import com.chuckerteam.chucker.internal.support.hasBody
+import okhttp3.HttpUrl
+import okhttp3.Request
+import okhttp3.RequestBody
 import okhttp3.Response
 import okio.Buffer
 import okio.ByteString
@@ -31,6 +34,8 @@ internal fun Response.readByteStringBody(length: Long? = null): ByteString? {
         null
     }
 }
+
+internal fun RequestBody.toServerRequest(serverUrl: HttpUrl) = Request.Builder().url(serverUrl).post(this).build()
 
 internal fun <T> LiveData<T>.test(test: LiveDataRecord<T>.() -> Unit) {
     val observer = RecordingObserver<T>()

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,7 +1,16 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.squareup.wire'
+
+wire {
+    kotlin {}
+}
 
 android {
+    sourceSets {
+        getByName("main").java.srcDirs += "$buildDir/generated/source/wire/"
+    }
+
     compileSdkVersion rootProject.compileSdkVersion
 
     defaultConfig {

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/HttpBinClient.kt
@@ -1,7 +1,6 @@
 package com.chuckerteam.chucker.sample
 
 import android.content.Context
-import com.chuckerteam.chucker.api.BodyDecoder
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.chuckerteam.chucker.api.RetentionManager
@@ -14,7 +13,6 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.logging.HttpLoggingInterceptor
 import okio.Buffer
 import okio.BufferedSink
-import okio.ByteString
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -166,15 +164,5 @@ class HttpBinClient(
                 }
             }
         )
-    }
-
-    private class PokemonProtoBodyDecoder : BodyDecoder {
-        override fun decodeRequest(request: Request, body: ByteString): String? {
-            return if (request.url.host.contains("postman", ignoreCase = true)) {
-                Pokemon.ADAPTER.decode(body).toString()
-            } else null
-        }
-
-        override fun decodeResponse(response: okhttp3.Response, body: ByteString): String? = null
     }
 }

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/PokemonProtoBodyDecoder.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/PokemonProtoBodyDecoder.kt
@@ -1,0 +1,15 @@
+package com.chuckerteam.chucker.sample
+
+import com.chuckerteam.chucker.api.BodyDecoder
+import okhttp3.Request
+import okio.ByteString
+
+internal class PokemonProtoBodyDecoder : BodyDecoder {
+    override fun decodeRequest(request: Request, body: ByteString): String? {
+        return if (request.url.host.contains("postman", ignoreCase = true)) {
+            Pokemon.ADAPTER.decode(body).toString()
+        } else null
+    }
+
+    override fun decodeResponse(response: okhttp3.Response, body: ByteString): String? = null
+}

--- a/sample/src/main/proto/com/chuckerteam/chucker/sample/pokemon.proto
+++ b/sample/src/main/proto/com/chuckerteam/chucker/sample/pokemon.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package com.chuckerteam.chucker.sample;
+
+option java_package = "com.chuckerteam.chucker.sample";
+
+message Pokemon {
+  string name = 1;
+  int32 level = 2;
+}


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

Protobuf encoded request available in preview:

![Screenshot_20210210_201958](https://user-images.githubusercontent.com/30936061/107561041-594c0c80-6bde-11eb-9e3a-94d839c8822d.png)

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an issue – #523.

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

I added `BodyEncoder` interface which instances can be installed in `ChukcerInterceptor`. They are then applied when bodies are being processed. First result that is non–null `String` is used as a body in transaction.

Exporting functionality was modified to accommodate for changes and export custom payloads as well.

I also edited sample to contain some custom processing. Unfortunately I did only for requests because I cannot find any public service that will echo proto data.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Run the sample, check postman echo request, check exporting.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

`ChuckerInterceptorTest` needs some splitting into smaller units and/or moving test to respective processors. Also, `HttpBinClient` needs some clean-up because as mentioned some time ago it is now doing more than communicating with httpbin.
Closes #523. 