### PR TITLE
Switch to Activity Result API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,12 @@ buildscript {
         coroutineVersion = '1.4.2'
 
         // Google libraries
+        activityVersion = '1.2.0-alpha07'
         appCompatVersion = '1.2.0'
         constraintLayoutVersion = '2.0.4'
         materialComponentsVersion = '1.3.0'
         roomVersion = '2.2.6'
-        fragmentVersion = '1.2.5'
+        fragmentVersion = '1.3.0-alpha07'
         lifecycleVersion = '2.2.0'
         androidXCoreVersion = '2.1.0'
         paletteKtxVersion = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,12 @@ buildscript {
         coroutineVersion = '1.4.2'
 
         // Google libraries
-        activityVersion = '1.2.0-alpha07'
+        activityVersion = '1.2.0'
         appCompatVersion = '1.2.0'
         constraintLayoutVersion = '2.0.4'
         materialComponentsVersion = '1.3.0'
         roomVersion = '2.2.6'
-        fragmentVersion = '1.3.0-alpha07'
+        fragmentVersion = '1.3.0'
         lifecycleVersion = '2.2.0'
         androidXCoreVersion = '2.1.0'
         paletteKtxVersion = '1.0.0'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "androidx.palette:palette-ktx:$paletteKtxVersion"
 
-    implementation "androidx.activity:activity:$activityVersion"
     implementation "androidx.activity:activity-ktx:$activityVersion"
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -52,6 +52,8 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "androidx.palette:palette-ktx:$paletteKtxVersion"
 
+    implementation "androidx.activity:activity:$activityVersion"
+    implementation "androidx.activity:activity-ktx:$activityVersion"
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -33,7 +33,7 @@ import java.io.FileOutputStream
 import java.io.IOException
 
 internal class TransactionPayloadFragment :
-        Fragment(), SearchView.OnQueryTextListener {
+    Fragment(), SearchView.OnQueryTextListener {
 
     private val viewModel: TransactionViewModel by activityViewModels { TransactionViewModelFactory() }
 
@@ -55,9 +55,9 @@ internal class TransactionPayloadFragment :
             }
         } else {
             Toast.makeText(
-                    requireContext(),
-                    R.string.chucker_save_failed_to_open_document,
-                    Toast.LENGTH_SHORT
+                requireContext(),
+                R.string.chucker_save_failed_to_open_document,
+                Toast.LENGTH_SHORT
             ).show()
         }
     }
@@ -74,14 +74,14 @@ internal class TransactionPayloadFragment :
     }
 
     override fun onCreateView(
-            inflater: LayoutInflater,
-            container: ViewGroup?,
-            savedInstanceState: Bundle?
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
     ): View {
         payloadBinding = ChuckerFragmentTransactionPayloadBinding.inflate(
-                inflater,
-                container,
-                false
+            inflater,
+            container,
+            false
         )
         return payloadBinding.root
     }
@@ -95,28 +95,28 @@ internal class TransactionPayloadFragment :
         }
 
         viewModel.transaction
-                .combineLatest(viewModel.formatRequestBody)
-                .observe(
-                        viewLifecycleOwner,
-                        Observer { (transaction, formatRequestBody) ->
-                            if (transaction == null) return@Observer
-                            lifecycleScope.launch {
-                                payloadBinding.loadingProgress.visibility = View.VISIBLE
+            .combineLatest(viewModel.formatRequestBody)
+            .observe(
+                viewLifecycleOwner,
+                Observer { (transaction, formatRequestBody) ->
+                    if (transaction == null) return@Observer
+                    lifecycleScope.launch {
+                        payloadBinding.loadingProgress.visibility = View.VISIBLE
 
-                                val result = processPayload(payloadType, transaction, formatRequestBody)
-                                if (result.isEmpty()) {
-                                    showEmptyState()
-                                } else {
-                                    payloadAdapter.setItems(result)
-                                    showPayloadState()
-                                }
-                                // Invalidating menu, because we need to hide menu items for empty payloads
-                                requireActivity().invalidateOptionsMenu()
-
-                                payloadBinding.loadingProgress.visibility = View.GONE
-                            }
+                        val result = processPayload(payloadType, transaction, formatRequestBody)
+                        if (result.isEmpty()) {
+                            showEmptyState()
+                        } else {
+                            payloadAdapter.setItems(result)
+                            showPayloadState()
                         }
-                )
+                        // Invalidating menu, because we need to hide menu items for empty payloads
+                        requireActivity().invalidateOptionsMenu()
+
+                        payloadBinding.loadingProgress.visibility = View.GONE
+                    }
+                }
+            )
     }
 
     private fun showEmptyState() {
@@ -162,8 +162,8 @@ internal class TransactionPayloadFragment :
 
         if (payloadType == PayloadType.REQUEST) {
             viewModel.doesRequestBodyRequireEncoding.observe(
-                    viewLifecycleOwner,
-                    { menu.findItem(R.id.encode_url).isVisible = it }
+                viewLifecycleOwner,
+                { menu.findItem(R.id.encode_url).isVisible = it }
             )
         } else {
             menu.findItem(R.id.encode_url).isVisible = false
@@ -209,9 +209,9 @@ internal class TransactionPayloadFragment :
     }
 
     private suspend fun processPayload(
-            type: PayloadType,
-            transaction: HttpTransaction,
-            formatRequestBody: Boolean
+        type: PayloadType,
+        transaction: HttpTransaction,
+        formatRequestBody: Boolean
     ): MutableList<TransactionPayloadItem> {
         return withContext(Dispatchers.Default) {
             val result = mutableListOf<TransactionPayloadItem>()
@@ -236,12 +236,12 @@ internal class TransactionPayloadFragment :
 
             if (headersString.isNotBlank()) {
                 result.add(
-                        TransactionPayloadItem.HeaderItem(
-                                HtmlCompat.fromHtml(
-                                        headersString,
-                                        HtmlCompat.FROM_HTML_MODE_LEGACY
-                                )
+                    TransactionPayloadItem.HeaderItem(
+                        HtmlCompat.fromHtml(
+                            headersString,
+                            HtmlCompat.FROM_HTML_MODE_LEGACY
                         )
+                    )
                 )
             }
 
@@ -273,11 +273,11 @@ internal class TransactionPayloadFragment :
                         when (type) {
                             PayloadType.REQUEST -> {
                                 transaction.requestBody?.byteInputStream()?.copyTo(fos)
-                                        ?: throw IOException(TRANSACTION_EXCEPTION)
+                                    ?: throw IOException(TRANSACTION_EXCEPTION)
                             }
                             PayloadType.RESPONSE -> {
                                 transaction.responseBody?.byteInputStream()?.copyTo(fos)
-                                        ?: throw IOException(TRANSACTION_EXCEPTION)
+                                    ?: throw IOException(TRANSACTION_EXCEPTION)
                             }
                         }
                     }
@@ -299,10 +299,10 @@ internal class TransactionPayloadFragment :
         const val DEFAULT_FILE_PREFIX = "chucker-export-"
 
         fun newInstance(type: PayloadType): TransactionPayloadFragment =
-                TransactionPayloadFragment().apply {
-                    arguments = Bundle().apply {
-                        putSerializable(ARG_TYPE, type)
-                    }
+            TransactionPayloadFragment().apply {
+                arguments = Bundle().apply {
+                    putSerializable(ARG_TYPE, type)
                 }
+            }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -1,12 +1,9 @@
 package com.chuckerteam.chucker.internal.ui.transaction
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import android.graphics.Color
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.text.SpannableStringBuilder
 import android.view.LayoutInflater
@@ -15,7 +12,7 @@ import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import androidx.annotation.RequiresApi
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
@@ -35,15 +32,34 @@ import kotlinx.coroutines.withContext
 import java.io.FileOutputStream
 import java.io.IOException
 
-private const val GET_FILE_FOR_SAVING_REQUEST_CODE: Int = 43
-
 internal class TransactionPayloadFragment :
-    Fragment(), SearchView.OnQueryTextListener {
+        Fragment(), SearchView.OnQueryTextListener {
 
     private val viewModel: TransactionViewModel by activityViewModels { TransactionViewModelFactory() }
 
     private val payloadType: PayloadType by lazy(LazyThreadSafetyMode.NONE) {
         arguments?.getSerializable(ARG_TYPE) as PayloadType
+    }
+
+    private val saveToFile = registerForActivityResult(ActivityResultContracts.CreateDocument()) { uri ->
+        val transaction = viewModel.transaction.value
+        if (uri != null && transaction != null) {
+            lifecycleScope.launch {
+                val result = saveToFile(payloadType, uri, transaction)
+                val toastMessageId = if (result) {
+                    R.string.chucker_file_saved
+                } else {
+                    R.string.chucker_file_not_saved
+                }
+                Toast.makeText(context, toastMessageId, Toast.LENGTH_SHORT).show()
+            }
+        } else {
+            Toast.makeText(
+                    requireContext(),
+                    R.string.chucker_save_failed_to_open_document,
+                    Toast.LENGTH_SHORT
+            ).show()
+        }
     }
 
     private lateinit var payloadBinding: ChuckerFragmentTransactionPayloadBinding
@@ -58,14 +74,14 @@ internal class TransactionPayloadFragment :
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
     ): View {
         payloadBinding = ChuckerFragmentTransactionPayloadBinding.inflate(
-            inflater,
-            container,
-            false
+                inflater,
+                container,
+                false
         )
         return payloadBinding.root
     }
@@ -79,28 +95,28 @@ internal class TransactionPayloadFragment :
         }
 
         viewModel.transaction
-            .combineLatest(viewModel.formatRequestBody)
-            .observe(
-                viewLifecycleOwner,
-                Observer { (transaction, formatRequestBody) ->
-                    if (transaction == null) return@Observer
-                    lifecycleScope.launch {
-                        payloadBinding.loadingProgress.visibility = View.VISIBLE
+                .combineLatest(viewModel.formatRequestBody)
+                .observe(
+                        viewLifecycleOwner,
+                        Observer { (transaction, formatRequestBody) ->
+                            if (transaction == null) return@Observer
+                            lifecycleScope.launch {
+                                payloadBinding.loadingProgress.visibility = View.VISIBLE
 
-                        val result = processPayload(payloadType, transaction, formatRequestBody)
-                        if (result.isEmpty()) {
-                            showEmptyState()
-                        } else {
-                            payloadAdapter.setItems(result)
-                            showPayloadState()
+                                val result = processPayload(payloadType, transaction, formatRequestBody)
+                                if (result.isEmpty()) {
+                                    showEmptyState()
+                                } else {
+                                    payloadAdapter.setItems(result)
+                                    showPayloadState()
+                                }
+                                // Invalidating menu, because we need to hide menu items for empty payloads
+                                requireActivity().invalidateOptionsMenu()
+
+                                payloadBinding.loadingProgress.visibility = View.GONE
+                            }
                         }
-                        // Invalidating menu, because we need to hide menu items for empty payloads
-                        requireActivity().invalidateOptionsMenu()
-
-                        payloadBinding.loadingProgress.visibility = View.GONE
-                    }
-                }
-            )
+                )
     }
 
     private fun showEmptyState() {
@@ -146,8 +162,8 @@ internal class TransactionPayloadFragment :
 
         if (payloadType == PayloadType.REQUEST) {
             viewModel.doesRequestBodyRequireEncoding.observe(
-                viewLifecycleOwner,
-                { menu.findItem(R.id.encode_url).isVisible = it }
+                    viewLifecycleOwner,
+                    { menu.findItem(R.id.encode_url).isVisible = it }
             )
         } else {
             menu.findItem(R.id.encode_url).isVisible = false
@@ -177,42 +193,8 @@ internal class TransactionPayloadFragment :
         foregroundSpanColor = ContextCompat.getColor(context, R.color.chucker_foreground_span_color)
     }
 
-    @RequiresApi(Build.VERSION_CODES.KITKAT)
     private fun createFileToSaveBody() {
-        val intent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
-            addCategory(Intent.CATEGORY_OPENABLE)
-            putExtra(Intent.EXTRA_TITLE, "$DEFAULT_FILE_PREFIX${System.currentTimeMillis()}")
-            type = "*/*"
-        }
-        if (intent.resolveActivity(requireActivity().packageManager) != null) {
-            startActivityForResult(intent, GET_FILE_FOR_SAVING_REQUEST_CODE)
-        } else {
-            Toast.makeText(
-                requireContext(),
-                R.string.chucker_save_failed_to_open_document,
-                Toast.LENGTH_SHORT
-            ).show()
-        }
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, resultData: Intent?) {
-        if (requestCode == GET_FILE_FOR_SAVING_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-            val uri = resultData?.data
-            val transaction = viewModel.transaction.value
-            if (uri != null && transaction != null) {
-                lifecycleScope.launch {
-                    val result = saveToFile(payloadType, uri, transaction)
-                    val toastMessageId = if (result) {
-                        R.string.chucker_file_saved
-                    } else {
-                        R.string.chucker_file_not_saved
-                    }
-                    Toast.makeText(context, toastMessageId, Toast.LENGTH_SHORT).show()
-                }
-            } else {
-                Toast.makeText(context, R.string.chucker_file_not_saved, Toast.LENGTH_SHORT).show()
-            }
-        }
+        saveToFile.launch("$DEFAULT_FILE_PREFIX${System.currentTimeMillis()}")
     }
 
     override fun onQueryTextSubmit(query: String): Boolean = false
@@ -227,9 +209,9 @@ internal class TransactionPayloadFragment :
     }
 
     private suspend fun processPayload(
-        type: PayloadType,
-        transaction: HttpTransaction,
-        formatRequestBody: Boolean
+            type: PayloadType,
+            transaction: HttpTransaction,
+            formatRequestBody: Boolean
     ): MutableList<TransactionPayloadItem> {
         return withContext(Dispatchers.Default) {
             val result = mutableListOf<TransactionPayloadItem>()
@@ -254,12 +236,12 @@ internal class TransactionPayloadFragment :
 
             if (headersString.isNotBlank()) {
                 result.add(
-                    TransactionPayloadItem.HeaderItem(
-                        HtmlCompat.fromHtml(
-                            headersString,
-                            HtmlCompat.FROM_HTML_MODE_LEGACY
+                        TransactionPayloadItem.HeaderItem(
+                                HtmlCompat.fromHtml(
+                                        headersString,
+                                        HtmlCompat.FROM_HTML_MODE_LEGACY
+                                )
                         )
-                    )
                 )
             }
 
@@ -291,11 +273,11 @@ internal class TransactionPayloadFragment :
                         when (type) {
                             PayloadType.REQUEST -> {
                                 transaction.requestBody?.byteInputStream()?.copyTo(fos)
-                                    ?: throw IOException(TRANSACTION_EXCEPTION)
+                                        ?: throw IOException(TRANSACTION_EXCEPTION)
                             }
                             PayloadType.RESPONSE -> {
                                 transaction.responseBody?.byteInputStream()?.copyTo(fos)
-                                    ?: throw IOException(TRANSACTION_EXCEPTION)
+                                        ?: throw IOException(TRANSACTION_EXCEPTION)
                             }
                         }
                     }
@@ -317,10 +299,10 @@ internal class TransactionPayloadFragment :
         const val DEFAULT_FILE_PREFIX = "chucker-export-"
 
         fun newInstance(type: PayloadType): TransactionPayloadFragment =
-            TransactionPayloadFragment().apply {
-                arguments = Bundle().apply {
-                    putSerializable(ARG_TYPE, type)
+                TransactionPayloadFragment().apply {
+                    arguments = Bundle().apply {
+                        putSerializable(ARG_TYPE, type)
+                    }
                 }
-            }
     }
 }


### PR DESCRIPTION
## :page_facing_up: Context
Since Activity and Fragment with the new Activity Result API to replace things like `startActivityForResult()` are stable I have blown off dust from my branch where I tried to apply this new API in Chucker and updated dependencies to use stable library versions.

## :pencil: Changes
- Updated Activity to 1.2.0
- Updated Fragment to 1.3.0
- Replaced `startActivityForResult()` used to save file with payload with new Activity Result API

## :no_entry_sign: Breaking
Nothing breaking expected and I wasn't able to find any broken things while testing, but [Fragment 1.3.0](https://developer.android.com/jetpack/androidx/releases/fragment#1.3.0) has quite a lot of changes, like new state manager.

## :hammer_and_wrench: How to test
Nothing changed from UX point of view, so the save operation works as before.

## :stopwatch: Next steps
Deal with more deprecations in Chucker codebase.
