### PR TITLE
Disable lint check for dependency versions

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -31,6 +31,8 @@ android {
         abortOnError true
         // We don't want to impose RTL on consuming applications.
         disable 'RtlEnabled'
+        // Don't fail build if some dependencies outdated
+        disable 'GradleDependency'
     }
 
     testOptions {


### PR DESCRIPTION
## :page_facing_up: Context
Lint started to fail builds because some dependencies have newer versions. It is quite annoying to see.
Check #555, #556, for example.
I decided to disable such rule, because it shouldn't be a blocker

## :pencil: Changes
- Disabled lint rule for checking dependencies version.

## :no_entry_sign: Breaking
Nothing expected 

## :hammer_and_wrench: How to test
Lint check shouldn't fail on CI for this PR

## :stopwatch: Next steps
Update other branches suffering from this lint check.
