### PR TITLE
Allow to choose interception type in the sample

### DIFF
--- a/sample/src/main/java/com/chuckerteam/chucker/sample/InterceptorType.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/InterceptorType.kt
@@ -1,0 +1,24 @@
+package com.chuckerteam.chucker.sample
+
+import okhttp3.Interceptor
+
+enum class InterceptorType {
+    APPLICATION,
+    NETWORK,
+    ;
+
+    interface Provider {
+        val value: InterceptorType
+    }
+}
+
+fun Interceptor.activeForType(
+    activeType: InterceptorType,
+    typeProvider: InterceptorType.Provider,
+) = Interceptor { chain ->
+    if (activeType == typeProvider.value) {
+        intercept(chain)
+    } else {
+        chain.proceed(chain.request())
+    }
+}

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/InterceptorTypeSelector.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/InterceptorTypeSelector.kt
@@ -1,0 +1,5 @@
+package com.chuckerteam.chucker.sample
+
+class InterceptorTypeSelector : InterceptorType.Provider {
+    override var value = InterceptorType.APPLICATION
+}

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -2,17 +2,20 @@ package com.chuckerteam.chucker.sample
 
 import android.os.Bundle
 import android.os.StrictMode
+import android.text.method.LinkMovementMethod
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.chuckerteam.chucker.api.Chucker
 import com.chuckerteam.chucker.sample.databinding.ActivityMainSampleBinding
+
+private val interceptorTypeSelector = InterceptorTypeSelector()
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var mainBinding: ActivityMainSampleBinding
 
     private val client: HttpBinClient by lazy {
-        HttpBinClient(applicationContext)
+        HttpBinClient(applicationContext, interceptorTypeSelector)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,6 +29,18 @@ class MainActivity : AppCompatActivity() {
 
             launchChuckerDirectly.visibility = if (Chucker.isOp) View.VISIBLE else View.GONE
             launchChuckerDirectly.setOnClickListener { launchChuckerDirectly() }
+
+            interceptorTypeLabel.movementMethod = LinkMovementMethod.getInstance()
+            useApplicationInterceptor.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    interceptorTypeSelector.value = InterceptorType.APPLICATION
+                }
+            }
+            useNetworkInterceptor.setOnCheckedChangeListener { _, isChecked ->
+                if (isChecked) {
+                    interceptorTypeSelector.value = InterceptorType.NETWORK
+                }
+            }
         }
 
         StrictMode.setVmPolicy(

--- a/sample/src/main/res/layout-land/activity_main_sample.xml
+++ b/sample/src/main/res/layout-land/activity_main_sample.xml
@@ -4,21 +4,22 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/doub_grid_size"
     tools:context="com.chuckerteam.chucker.sample.MainActivity">
 
     <TextView
         android:id="@+id/title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/doub_grid_size"
         android:layout_marginBottom="@dimen/doub_grid_size"
         android:gravity="center"
         android:text="@string/intro_title"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
         app:layout_constraintBottom_toTopOf="@+id/description"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guideline"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/interceptor_type_label"
+        app:layout_constraintVertical_bias="0.0"
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
@@ -26,11 +27,12 @@
         android:id="@+id/description"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/doub_grid_size"
         android:gravity="center"
         android:text="@string/intro_body"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-        app:layout_constraintBottom_toTopOf="@+id/guideline"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/guideline"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/title"
         app:layout_constraintWidth_max="@dimen/max_width" />
@@ -39,12 +41,13 @@
         android:id="@+id/interceptor_type_label"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/doub_grid_size"
         android:text="@string/interceptor_type"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
         app:layout_constraintBottom_toTopOf="@+id/interceptor_type_group"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/guideline"
+        app:layout_constraintStart_toStartOf="@+id/guideline"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
@@ -52,12 +55,13 @@
         android:id="@+id/interceptor_type_group"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/doub_grid_size"
         android:layout_marginVertical="@dimen/norm_grid_size"
         android:checkedButton="@+id/use_application_interceptor"
         android:orientation="horizontal"
         app:layout_constraintBottom_toTopOf="@+id/do_http"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guideline"
         app:layout_constraintTop_toBottomOf="@+id/interceptor_type_label"
         app:layout_constraintWidth_max="@dimen/max_width">
 
@@ -81,11 +85,12 @@
         android:id="@+id/do_http"
         android:layout_width="0dp"
         android:layout_height="?attr/actionBarSize"
+        android:layout_marginHorizontal="@dimen/doub_grid_size"
         android:layout_marginBottom="@dimen/doub_grid_size"
         android:text="@string/do_http_activity"
         app:layout_constraintBottom_toTopOf="@+id/launch_chucker_directly"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guideline"
         app:layout_constraintTop_toBottomOf="@+id/interceptor_type_group"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
@@ -93,10 +98,11 @@
         android:id="@+id/launch_chucker_directly"
         android:layout_width="0dp"
         android:layout_height="?attr/actionBarSize"
+        android:layout_marginHorizontal="@dimen/doub_grid_size"
         android:text="@string/launch_chucker_directly"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guideline"
         app:layout_constraintTop_toBottomOf="@+id/do_http"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
@@ -104,7 +110,7 @@
         android:id="@+id/guideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.4" />
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/layout/activity_main_sample.xml
+++ b/sample/src/main/res/layout/activity_main_sample.xml
@@ -37,15 +37,17 @@
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/interceptor_type_label"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/interceptor_type"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
         app:layout_constraintBottom_toTopOf="@+id/interceptor_type_group"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/guideline"
         app:layout_constraintVertical_bias="0.0"
-        app:layout_constraintVertical_chainStyle="packed" />
+        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintWidth_max="@dimen/max_width" />
 
     <RadioGroup
         android:id="@+id/interceptor_type_group"

--- a/sample/src/main/res/layout/activity_main_sample.xml
+++ b/sample/src/main/res/layout/activity_main_sample.xml
@@ -35,6 +35,46 @@
         app:layout_constraintTop_toBottomOf="@+id/title"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/interceptor_type_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/interceptor_type"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+        app:layout_constraintBottom_toTopOf="@+id/interceptor_type_group"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/guideline"
+        app:layout_constraintVertical_bias="0.0"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <RadioGroup
+        android:id="@+id/interceptor_type_group"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:checkedButton="@+id/use_application_interceptor"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toTopOf="@+id/do_http"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/interceptor_type_label"
+        app:layout_constraintWidth_max="@dimen/max_width">
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/use_application_interceptor"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/application_type" />
+
+        <com.google.android.material.radiobutton.MaterialRadioButton
+            android:id="@+id/use_network_interceptor"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/network_type" />
+
+    </RadioGroup>
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/do_http"
         android:layout_width="0dp"
@@ -44,9 +84,7 @@
         app:layout_constraintBottom_toTopOf="@+id/launch_chucker_directly"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/guideline"
-        app:layout_constraintVertical_bias="0.25"
-        app:layout_constraintVertical_chainStyle="packed"
+        app:layout_constraintTop_toBottomOf="@+id/interceptor_type_group"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
     <com.google.android.material.button.MaterialButton
@@ -59,6 +97,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/do_http"
         app:layout_constraintWidth_max="@dimen/max_width" />
+
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/guideline"

--- a/sample/src/main/res/layout/activity_main_sample.xml
+++ b/sample/src/main/res/layout/activity_main_sample.xml
@@ -53,6 +53,7 @@
         android:id="@+id/interceptor_type_group"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/norm_grid_size"
         android:checkedButton="@+id/use_application_interceptor"
         android:orientation="horizontal"
         app:layout_constraintBottom_toTopOf="@+id/do_http"

--- a/sample/src/main/res/layout/activity_main_sample.xml
+++ b/sample/src/main/res/layout/activity_main_sample.xml
@@ -45,7 +45,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/guideline"
-        app:layout_constraintVertical_bias="0.0"
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
@@ -107,6 +106,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.5" />
+        app:layout_constraintGuide_percent="0.4" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,5 +1,8 @@
 <resources>
     <string name="app_name">Chucker Sample</string>
+    <string name="interceptor_type"><a href="https://square.github.io/okhttp/interceptors/">Interceptor type</a>:</string>
+    <string name="application_type">Application</string>
+    <string name="network_type">Network</string>
     <string name="do_http_activity">Do HTTP activity</string>
     <string name="launch_chucker_directly">Launch Chucker directly</string>
 


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

![Screenshot_20210215_185231](https://user-images.githubusercontent.com/30936061/107979934-ac97d380-6fbf-11eb-8680-b708a3fb7839.png)
![Screenshot_20210215_185620](https://user-images.githubusercontent.com/30936061/107979938-adc90080-6fbf-11eb-8a7b-a02ab60e7ce0.png)

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an open issue – #389.

I wanted to split `HttpBinClient` into smaller pieces but first I wanted to add the ability to test `ChuckerInterceptor` both as an application type and as a network type interceptor without changing it in the code.

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

I added a radio group to the sample UI that allows to choose how `ChuckerInterceptor` will be applied. Based on a selected radio button the interceptor is active in one or the other pipeline.

Behaviour is slightly different than the one described in #389. Interceptor type can be changed on the fly while requests are being performed. Making it toggleable only during idle periods would be too complex as it would require either two HTTP clients or some syncing and queueing mechanisma.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Play with the sample and toggle radio buttons.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Closes #389.