### PR TITLE
Add missing comment closing to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,7 +6,7 @@
 
 ## :pencil: Changes
 <!-- Which code did you change? How? -->
-<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file.
+<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->
 
 ## :paperclip: Related PR
 <!-- PR that blocks this one, or the ones blocked by this PR -->


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

PR template has an unclosed comment in the changes section.