### PR TITLE
Fix UI for emtpy body in request/response

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -247,17 +247,24 @@ internal class TransactionPayloadFragment :
 
             // The body could either be an image, plain text, decoded binary or not decoded binary.
             val responseBitmap = transaction.responseImageBitmap
-            when {
-                type == PayloadType.RESPONSE && responseBitmap != null -> {
-                    val bitmapLuminance = responseBitmap.calculateLuminance()
-                    result.add(TransactionPayloadItem.ImageItem(responseBitmap, bitmapLuminance))
-                }
-                bodyString.isNotBlank() -> bodyString.lines().forEach {
-                    result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
-                }
-                !isBodyPlainText -> {
+
+            if (type == PayloadType.RESPONSE && responseBitmap != null) {
+                val bitmapLuminance = responseBitmap.calculateLuminance()
+                result.add(TransactionPayloadItem.ImageItem(responseBitmap, bitmapLuminance))
+                return@withContext result
+            }
+
+            if (bodyString.isBlank()) {
+                val text = requireContext().getString(R.string.chucker_body_empty)
+                result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(text)))
+            } else {
+                if (!isBodyPlainText) {
                     val text = requireContext().getString(R.string.chucker_body_omitted)
                     result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(text)))
+                } else {
+                    bodyString.lines().forEach {
+                        result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
+                    }
                 }
             }
 


### PR DESCRIPTION
## :camera: Screenshots
Before:
<img width="359" alt="Screenshot 2021-02-14 at 18 31 00" src="https://user-images.githubusercontent.com/13467769/107884089-7b55cf80-6efb-11eb-841a-03f17a1f98e9.png">
After: 
<img width="361" alt="Screenshot 2021-02-14 at 19 27 36" src="https://user-images.githubusercontent.com/13467769/107884095-83157400-6efb-11eb-91d0-d64fd1e6118f.png">

## :page_facing_up: Context
Looks like #555 introduced a bug with payload UI. All empty bodies started to show `encoded or binary body omitted` string while they should be empty. Except fixing this I added a string resources to show in empty bodies transactions, like we do when trying to share transactions.

## :pencil: Changes
- Changed conditions in payload processing in `TransactionPayloadFragment`.
- Added string resource to clear indicate that body is empty.

## :no_entry_sign: Breaking
Nothing

## :hammer_and_wrench: How to test
Run sample app and check some transactions with emtpy requests/responses 

## :stopwatch: Next steps
I thing I found one more bug introduced by #555, but want to check how Chucker behaved in `3.4.0` to understand if it is really something new.
