### PR TITLE
Add reviewers for Github Actions updates PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       directory: "/"
       schedule:
         interval: "weekly"
+      reviewers:
+      - "cortinico"
+      - "vbuberen"
+      - "MiSikora"
 # Updates for Gradle dependencies used in the app      
     - package-ecosystem: gradle
       directory: "/"


### PR DESCRIPTION
## :page_facing_up: Context
Dependabot lacked info on who should be in reviewers for Github Actions updates PRs.
So in #565 there were no reviewers assigned.

## :pencil: Changes
- Added the same reviewers to config for Github Actions PRs

## :no_entry_sign: Breaking
Nothing

## :hammer_and_wrench: How to test
Wait for another Dependabot PR for Github Actions
