### PR TITLE
Make transaction updates suspending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please add your entries according to this format.
 * Fixed not setting request body type correctly [#538].
 * Fixed request headers not being redacted in case of failures [#545].
 * Fixed wrongful processing of one shot and duplex requests [#544].
+* Fixed writing to database on the main thread [#487]. 
 
 ### Removed
 

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -4,11 +4,8 @@ import android.content.Context
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.support.NotificationHelper
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 
 /**
  * The collector responsible of collecting data from a [ChuckerInterceptor] and
@@ -28,7 +25,7 @@ public class ChuckerCollector @JvmOverloads constructor(
 ) {
     private val retentionManager: RetentionManager = RetentionManager(context, retentionPeriod)
     private val notificationHelper: NotificationHelper = NotificationHelper(context)
-    private val scope = CoroutineScope(Dispatchers.Main) + SupervisorJob()
+    private val scope = MainScope()
 
     init {
         RepositoryProvider.initialize(context)

--- a/library/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/RetentionManager.kt
@@ -2,11 +2,12 @@ package com.chuckerteam.chucker.api
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.chuckerteam.chucker.api.RetentionManager.Period
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.support.Logger
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.TimeUnit
 
 /**
@@ -27,6 +28,7 @@ public class RetentionManager @JvmOverloads constructor(
     // How often the cleanup should happen
     private val cleanupFrequency: Long
     private val prefs: SharedPreferences = context.getSharedPreferences(PREFS_NAME, 0)
+    private val maintenanceMutex = Mutex()
 
     init {
         cleanupFrequency = if (retentionPeriod == Period.ONE_HOUR) {
@@ -40,8 +42,7 @@ public class RetentionManager @JvmOverloads constructor(
      * Call this function to check and eventually trigger a cleanup.
      * Please note that this method is not forcing a cleanup.
      */
-    @Synchronized
-    internal fun doMaintenance() {
+    internal suspend fun doMaintenance() = maintenanceMutex.withLock {
         if (period > 0) {
             val now = System.currentTimeMillis()
             if (isCleanupDue(now)) {
@@ -61,13 +62,11 @@ public class RetentionManager @JvmOverloads constructor(
 
     private fun updateLastCleanup(time: Long) {
         lastCleanup = time
-        prefs.edit().putLong(KEY_LAST_CLEANUP, time).apply()
+        prefs.edit { putLong(KEY_LAST_CLEANUP, time) }
     }
 
-    private fun deleteSince(threshold: Long) {
-        CoroutineScope(Dispatchers.IO).launch {
-            RepositoryProvider.transaction().deleteOldTransactions(threshold)
-        }
+    private suspend fun deleteSince(threshold: Long) {
+        RepositoryProvider.transaction().deleteOldTransactions(threshold)
     }
 
     private fun isCleanupDue(now: Long) = now - getLastCleanup(now) > cleanupFrequency

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -33,7 +33,7 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
         transaction.id = id ?: 0
     }
 
-    override fun updateTransaction(transaction: HttpTransaction): Int {
+    override suspend fun updateTransaction(transaction: HttpTransaction): Int {
         return transactionDao.update(transaction)
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
@@ -13,7 +13,7 @@ internal interface HttpTransactionRepository {
 
     suspend fun insertTransaction(transaction: HttpTransaction)
 
-    fun updateTransaction(transaction: HttpTransaction): Int
+    suspend fun updateTransaction(transaction: HttpTransaction): Int
 
     suspend fun deleteOldTransactions(threshold: Long)
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -31,7 +31,7 @@ internal interface HttpTransactionDao {
     suspend fun insert(transaction: HttpTransaction): Long?
 
     @Update(onConflict = OnConflictStrategy.REPLACE)
-    fun update(transaction: HttpTransaction): Int
+    suspend fun update(transaction: HttpTransaction): Int
 
     @Query("DELETE FROM transactions")
     suspend fun deleteAll()

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
@@ -5,17 +5,20 @@ import android.content.Intent
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 
 internal class ClearDatabaseService : IntentService(CLEAN_DATABASE_SERVICE_NAME) {
+    private val scope = CoroutineScope(Dispatchers.Main) + SupervisorJob()
 
     override fun onHandleIntent(intent: Intent?) {
         RepositoryProvider.initialize(applicationContext)
-        CoroutineScope(Dispatchers.IO).launch {
+        scope.launch {
             RepositoryProvider.transaction().deleteAllTransactions()
+            NotificationHelper.clearBuffer()
+            NotificationHelper(applicationContext).dismissNotifications()
         }
-        NotificationHelper.clearBuffer()
-        NotificationHelper(this).dismissNotifications()
     }
 
     companion object {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
@@ -3,14 +3,11 @@ package com.chuckerteam.chucker.internal.support
 import android.app.IntentService
 import android.content.Intent
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.plus
 
 internal class ClearDatabaseService : IntentService(CLEAN_DATABASE_SERVICE_NAME) {
-    private val scope = CoroutineScope(Dispatchers.Main) + SupervisorJob()
+    private val scope = MainScope()
 
     override fun onHandleIntent(intent: Intent?) {
         RepositoryProvider.initialize(applicationContext)


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

There is an issue – #487. While at first I was reluctant to fix it, because I didn't want to do some strange executor delegation inside closing to avoid talking to the database on the main thread, I actually checked the code today and all of the work can be delegated to Room.

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

I made `transactionUpdate()` function suspending. This delegates internally in Room to Architecture Components executor. Additionally I fixed coroutine scopes. Previously we created a scope per request in collector or retention manager. Now they have their own scopes.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Change `ReadBytesCallback` in the sample to something like this.

```kotlin
class ReadBytesCallback(
    private val byteCount: Long? = null,
) : Callback {
    override fun onFailure(call: Call, e: IOException) {
        e.printStackTrace()
    }

    override fun onResponse(call: Call, response: Response) {
        Handler(Looper.getMainLooper()).post {
            response.body?.source()?.use {
                try {
                    if (byteCount == null) {
                        it.readByteString()
                    } else {
                        it.readByteString(byteCount)
                    }
                } catch (e: IOException) {
                    e.printStackTrace()
                }
            }
        }
    }
}
```

It will crash with the original code. Now it behaves correctly.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Closes #487.