### PR TITLE
Add immutable flag to pending intents

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -43,7 +43,7 @@ internal class NotificationHelper(val context: Context) {
             context,
             TRANSACTION_NOTIFICATION_ID,
             Chucker.getLaunchIntent(context),
-            PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_UPDATE_CURRENT or immutableFlag()
         )
     }
 
@@ -118,12 +118,18 @@ internal class NotificationHelper(val context: Context) {
                 context,
                 INTENT_REQUEST_CODE,
                 deleteIntent,
-                PendingIntent.FLAG_ONE_SHOT
+                PendingIntent.FLAG_ONE_SHOT or immutableFlag()
             )
             return NotificationCompat.Action(R.drawable.chucker_ic_delete_white, clearTitle, intent)
         }
 
     fun dismissNotifications() {
         notificationManager.cancel(TRANSACTION_NOTIFICATION_ID)
+    }
+
+    private fun immutableFlag() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        PendingIntent.FLAG_IMMUTABLE
+    } else {
+        0
     }
 }


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

Android 31 [requires](https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability) to specify mutability of pending intents.

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

I added mutability flag to our pending intents.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Not sure, run on Android 31?

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

Either cherry–pick it to `3.x` or plan release of `4.x` soonish.