### PR TITLE
Replace IntentService with JobIntentService

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
         </intent>
     </queries>
 
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+
     <application>
         <activity
             android:name="com.chuckerteam.chucker.internal.ui.MainActivity"
@@ -17,14 +19,20 @@
             android:taskAffinity="com.chuckerteam.chucker.task"
             android:theme="@style/Chucker.Theme" />
 
-        <activity android:name="com.chuckerteam.chucker.internal.ui.transaction.TransactionActivity"
-            android:theme="@style/Chucker.Theme"
-            android:parentActivityName="com.chuckerteam.chucker.internal.ui.MainActivity"/>
+        <activity
+            android:name="com.chuckerteam.chucker.internal.ui.transaction.TransactionActivity"
+            android:parentActivityName="com.chuckerteam.chucker.internal.ui.MainActivity"
+            android:theme="@style/Chucker.Theme" />
 
         <service
             android:name="com.chuckerteam.chucker.internal.support.ClearDatabaseService"
+            android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+
+        <receiver
+            android:name="com.chuckerteam.chucker.internal.support.ClearDatabaseJobIntentServiceReceiver"
             android:exported="false" />
-    
+
         <provider
             android:name="com.chuckerteam.chucker.internal.support.ChuckerFileProvider"
             android:authorities="${applicationId}.com.chuckerteam.chucker.provider"

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
         </intent>
     </queries>
 
-    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+    <uses-permission
+        android:name="android.permission.WAKE_LOCK"
+        android:maxSdkVersion="25" />
 
     <application>
         <activity

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseJobIntentServiceReceiver.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseJobIntentServiceReceiver.kt
@@ -1,0 +1,12 @@
+package com.chuckerteam.chucker.internal.support
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+internal class ClearDatabaseJobIntentServiceReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        ClearDatabaseService().enqueueWork(context, intent)
+    }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseJobIntentServiceReceiver.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseJobIntentServiceReceiver.kt
@@ -7,6 +7,6 @@ import android.content.Intent
 internal class ClearDatabaseJobIntentServiceReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
-        ClearDatabaseService().enqueueWork(context, intent)
+        ClearDatabaseService.enqueueWork(context, intent)
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
@@ -1,15 +1,20 @@
 package com.chuckerteam.chucker.internal.support
 
-import android.app.IntentService
+import android.content.Context
 import android.content.Intent
+import androidx.core.app.JobIntentService
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 
-internal class ClearDatabaseService : IntentService(CLEAN_DATABASE_SERVICE_NAME) {
+internal class ClearDatabaseService : JobIntentService() {
     private val scope = MainScope()
 
-    override fun onHandleIntent(intent: Intent?) {
+    fun enqueueWork(context: Context, work: Intent) {
+        enqueueWork(context, ClearDatabaseService::class.java, CLEAN_DATABASE_JOB_ID, work)
+    }
+
+    override fun onHandleWork(intent: Intent) {
         RepositoryProvider.initialize(applicationContext)
         scope.launch {
             RepositoryProvider.transaction().deleteAllTransactions()
@@ -19,6 +24,6 @@ internal class ClearDatabaseService : IntentService(CLEAN_DATABASE_SERVICE_NAME)
     }
 
     companion object {
-        const val CLEAN_DATABASE_SERVICE_NAME = "Chucker-ClearDatabaseService"
+        const val CLEAN_DATABASE_JOB_ID = 123321
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/ClearDatabaseService.kt
@@ -10,10 +10,6 @@ import kotlinx.coroutines.launch
 internal class ClearDatabaseService : JobIntentService() {
     private val scope = MainScope()
 
-    fun enqueueWork(context: Context, work: Intent) {
-        enqueueWork(context, ClearDatabaseService::class.java, CLEAN_DATABASE_JOB_ID, work)
-    }
-
     override fun onHandleWork(intent: Intent) {
         RepositoryProvider.initialize(applicationContext)
         scope.launch {
@@ -24,6 +20,10 @@ internal class ClearDatabaseService : JobIntentService() {
     }
 
     companion object {
-        const val CLEAN_DATABASE_JOB_ID = 123321
+        private const val CLEAN_DATABASE_JOB_ID = 123321
+
+        fun enqueueWork(context: Context, work: Intent) {
+            enqueueWork(context, ClearDatabaseService::class.java, CLEAN_DATABASE_JOB_ID, work)
+        }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -113,14 +113,19 @@ internal class NotificationHelper(val context: Context) {
     private fun createClearAction():
         NotificationCompat.Action {
             val clearTitle = context.getString(R.string.chucker_clear)
-            val deleteIntent = Intent(context, ClearDatabaseService::class.java)
-            val intent = PendingIntent.getService(
+            val clearTransactionsBroadcastIntent =
+                Intent(context, ClearDatabaseJobIntentServiceReceiver::class.java)
+            val pendingBroadcastIntent = PendingIntent.getBroadcast(
                 context,
                 INTENT_REQUEST_CODE,
-                deleteIntent,
+                clearTransactionsBroadcastIntent,
                 PendingIntent.FLAG_ONE_SHOT or immutableFlag()
             )
-            return NotificationCompat.Action(R.drawable.chucker_ic_delete_white, clearTitle, intent)
+            return NotificationCompat.Action(
+                R.drawable.chucker_ic_delete_white,
+                clearTitle,
+                pendingBroadcastIntent
+            )
         }
 
     fun dismissNotifications() {


### PR DESCRIPTION
## :page_facing_up: Context
Chucker used `IntentService` for notification action to clear transactions database, which is currently deprecated.
To address this deprecation this PR replaces `IntentService` with `JobIntentService`. 

Since `JobIntentService` requires call to `enqueueWork()` function I had to use `Broadcast` and declare `BroadcastReceiver` which would call `enqueueWork()` when required.
Additionally, I had to add `WAKE_LOCK` permission for pre-Oreo devices or Chucker would crash on devices with API < 26.

## :pencil: Changes
- Switched from `IntentService` to `JobIntentService`
- Declared a `BroadcastReceiver` to receive `Clear` action events.
- Added `WAKE_LOCK` permission for pre-Oreo devices.

## :no_entry_sign: Breaking
Nothing breaking expected

## :hammer_and_wrench: How to test
No special requirements. Just try `Clear` action from some Chucker notification and everything should work.