### PR TITLE
Limit Jcenter usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,6 @@ buildscript {
     }
 
     repositories {
-        jcenter()
         google()
         gradlePluginPortal()
     }
@@ -71,8 +70,9 @@ allprojects {
     group = GROUP
 
     repositories {
-        jcenter()
         google()
+        mavenCentral()
+        gradlePluginPortal()
     }
 
     tasks.withType(Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,12 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        gradlePluginPortal()
+        jcenter {
+            content {
+                includeModule("org.jetbrains.trove4j", "trove4j")
+                includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
+            }
+        }
     }
 
     tasks.withType(Test) {


### PR DESCRIPTION
## :page_facing_up: Context
Future-proofing Chucker by limiting usage of Jcenter. Most dependencies now resolved through `mavenCentral` instead. 

~~However, there was one issue with `org.jetbrains.trove4j:trove4j`, which is used by `android-lint`, so I had to add `gradlePluginPortal()` to `allprojects` section or the build process would fail for me. Not sure how it helps, considering that I couldn't find `trove4j` on Gradle portal.~~

Jcenter left only for dependencies, which can't be resolved via `mavenCentral`.

## :pencil: Changes
- Removed `jcenter` from repositories in `buildscript`.
- Added `mavenCentral` to `allprojects` section.
- (UPD: 08.04.2021) Limited usage of Jcenter only to required dependencies in `allprojects` section: `trove4j` and `kotlinx-html-jvm`