### PR TITLE
Feature/clickable url

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -42,4 +42,6 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
     }
 
     override suspend fun getAllTransactions(): List<HttpTransaction> = transactionDao.getAll()
+
+    override suspend fun getByUrl(url: String): HttpTransaction? = transactionDao.getByUrl(url)
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
@@ -26,4 +26,6 @@ internal interface HttpTransactionRepository {
     fun getTransaction(transactionId: Long): LiveData<HttpTransaction?>
 
     suspend fun getAllTransactions(): List<HttpTransaction>
+
+    suspend fun getByUrl(url: String): HttpTransaction?
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -44,4 +44,7 @@ internal interface HttpTransactionDao {
 
     @Query("SELECT * FROM transactions")
     suspend fun getAll(): List<HttpTransaction>
+
+    @Query("SELECT * FROM transactions WHERE url = :url LIMIT 1")
+    suspend fun getByUrl(url: String): HttpTransaction?
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/BodyLineItemCreator.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/BodyLineItemCreator.kt
@@ -1,0 +1,43 @@
+package com.chuckerteam.chucker.internal.ui.transaction
+
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.ClickableSpan
+import android.view.View
+import com.chuckerteam.chucker.internal.support.Logger
+
+internal class BodyLineItemCreator(private val bodyLine: String, private val onUrlClicked: (String) -> Unit) {
+
+    fun create(): SpannableStringBuilder =
+        SpannableStringBuilder().apply {
+            append(bodyLine)
+            checkUrl { url, range ->
+                val clickableSpan = object : ClickableSpan() {
+                    override fun onClick(widget: View) {
+                        onUrlClicked(url)
+                    }
+                }
+
+                setSpan(clickableSpan, range.first, range.last + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+        }
+
+    private fun checkUrl(link: (String, IntRange) -> Unit) {
+        val matchGroup = getValue() ?: return
+        try {
+            if (URL_MATCHER.toRegex().matches(matchGroup.value)) {
+                link.invoke(matchGroup.value, matchGroup.range)
+            }
+        } catch (ignored: IllegalStateException) {
+            Logger.info("regex not matched for bodyLine $bodyLine")
+        }
+    }
+
+    private fun getValue(): MatchGroup? = KEY_VALUE_SEPARATOR.toRegex().matchEntire(bodyLine)?.groups?.get(2)
+
+    companion object {
+
+        private const val KEY_VALUE_SEPARATOR = "(.*)?\".*\":\\s\"(.*)\"(.*)?"
+        private const val URL_MATCHER = "^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]"
+    }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/BodyLineItemCreator.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/BodyLineItemCreator.kt
@@ -40,7 +40,7 @@ internal class BodyLineItemCreator(private val bodyLine: String, private val onU
 
     companion object {
 
-        private const val KEY_VALUE_SEPARATOR = "\\s*\".*\":\\s\"(.*)\"|<.*>(.*)</.*?"
+        private const val KEY_VALUE_SEPARATOR = "\\s*\".*\":\\s\"(.*)\",?|<.*>(.*)</.*?"
         private const val URL_MATCHER = "^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]"
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/BodyLineItemCreator.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/BodyLineItemCreator.kt
@@ -33,11 +33,14 @@ internal class BodyLineItemCreator(private val bodyLine: String, private val onU
         }
     }
 
-    private fun getValue(): MatchGroup? = KEY_VALUE_SEPARATOR.toRegex().matchEntire(bodyLine)?.groups?.get(2)
+    private fun getValue(): MatchGroup? {
+        val groups = KEY_VALUE_SEPARATOR.toRegex().matchEntire(bodyLine)?.groups.orEmpty().toList()
+        return groups.getOrNull(2) ?: groups.getOrNull(1)
+    }
 
     companion object {
 
-        private const val KEY_VALUE_SEPARATOR = "(.*)?\".*\":\\s\"(.*)\"(.*)?"
+        private const val KEY_VALUE_SEPARATOR = "\\s*\".*\":\\s\"(.*)\"|<.*>(.*)</.*?"
         private const val URL_MATCHER = "^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]"
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.text.SpannableStringBuilder
 import android.text.Spanned
+import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -117,6 +118,10 @@ internal sealed class TransactionPayloadViewHolder(view: View) : RecyclerView.Vi
     internal class BodyLineViewHolder(
         private val bodyBinding: ChuckerTransactionItemBodyLineBinding
     ) : TransactionPayloadViewHolder(bodyBinding.root) {
+        init {
+            bodyBinding.bodyLine.movementMethod = LinkMovementMethod.getInstance()
+        }
+
         override fun bind(item: TransactionPayloadItem) {
             if (item is TransactionPayloadItem.BodyLineItem) {
                 bodyBinding.bodyLine.text = item.line

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -2,6 +2,7 @@ package com.chuckerteam.chucker.internal.ui.transaction
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.Intent
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
@@ -26,11 +27,11 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.support.Logger
 import com.chuckerteam.chucker.internal.support.calculateLuminance
 import com.chuckerteam.chucker.internal.support.combineLatest
+import java.io.FileOutputStream
+import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.FileOutputStream
-import java.io.IOException
 
 internal class TransactionPayloadFragment :
     Fragment(), SearchView.OnQueryTextListener {
@@ -264,7 +265,14 @@ internal class TransactionPayloadFragment :
                     result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(text)))
                 }
                 else -> bodyString.lines().forEach {
-                    result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(it)))
+                    val bodyLineItemCreator = BodyLineItemCreator(it) { url ->
+                        viewModel.onBodyLineItemClicked(
+                            url,
+                            { transactionId -> TransactionActivity.start(requireContext(), transactionId) },
+                            { startActivity(Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(url) }) }
+                        )
+                    }
+                    result.add(TransactionPayloadItem.BodyLineItem(bodyLineItemCreator.create()))
                 }
             }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -265,13 +265,7 @@ internal class TransactionPayloadFragment :
                     result.add(TransactionPayloadItem.BodyLineItem(SpannableStringBuilder.valueOf(text)))
                 }
                 else -> bodyString.lines().forEach {
-                    val bodyLineItemCreator = BodyLineItemCreator(it) { url ->
-                        viewModel.onBodyLineItemClicked(
-                            url,
-                            { transactionId -> TransactionActivity.start(requireContext(), transactionId) },
-                            { startActivity(Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(url) }) }
-                        )
-                    }
+                    val bodyLineItemCreator = BodyLineItemCreator(it, ::onBodyLineItemClicked)
                     result.add(TransactionPayloadItem.BodyLineItem(bodyLineItemCreator.create()))
                 }
             }
@@ -302,6 +296,13 @@ internal class TransactionPayloadFragment :
                 return@withContext false
             }
             return@withContext true
+        }
+    }
+
+    private fun onBodyLineItemClicked(url: String) = lifecycleScope.launch {
+        when(val action = viewModel.onBodyLineItemClicked(url)) {
+            is Action.OpenTransaction -> TransactionActivity.start(requireContext(), action.transactionId)
+            is Action.OpenUrl -> startActivity(Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(url) })
         }
     }
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -27,11 +27,11 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.support.Logger
 import com.chuckerteam.chucker.internal.support.calculateLuminance
 import com.chuckerteam.chucker.internal.support.combineLatest
-import java.io.FileOutputStream
-import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.FileOutputStream
+import java.io.IOException
 
 internal class TransactionPayloadFragment :
     Fragment(), SearchView.OnQueryTextListener {
@@ -300,7 +300,7 @@ internal class TransactionPayloadFragment :
     }
 
     private fun onBodyLineItemClicked(url: String) = lifecycleScope.launch {
-        when(val action = viewModel.onBodyLineItemClicked(url)) {
+        when (val action = viewModel.onBodyLineItemClicked(url)) {
             is Action.OpenTransaction -> TransactionActivity.start(requireContext(), action.transactionId)
             is Action.OpenUrl -> startActivity(Intent(Intent.ACTION_VIEW).apply { data = Uri.parse(url) })
         }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
@@ -5,9 +5,11 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.map
+import androidx.lifecycle.viewModelScope
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
 import com.chuckerteam.chucker.internal.support.combineLatest
+import kotlinx.coroutines.launch
 
 internal class TransactionViewModel(transactionId: Long) : ViewModel() {
 
@@ -48,6 +50,16 @@ internal class TransactionViewModel(transactionId: Long) : ViewModel() {
 
     fun encodeUrl(encode: Boolean) {
         mutableEncodeUrl.value = encode
+    }
+
+    fun onBodyLineItemClicked(url: String, onRequestFound: (Long) -> Unit, onRequestNotFound: () -> Unit) {
+        viewModelScope.launch {
+            val request = RepositoryProvider.transaction()
+                .getAllTransactions()
+                .firstOrNull { it.url == url }
+
+            request?.id?.let(onRequestFound) ?: onRequestNotFound.invoke()
+        }
     }
 }
 

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -219,6 +219,28 @@ internal class HttpTransactionDaoTest {
         }
     }
 
+    @Test
+    fun `get a transaction by URL`() = runBlocking {
+        val firstTransaction = createRequest("abc")
+        insertTransaction(firstTransaction)
+        val secondTransaction = createRequest()
+        insertTransaction(secondTransaction)
+
+        val result = testObject.getByUrl(firstTransaction.url!!)
+        assertTransaction(firstTransaction.id, firstTransaction, result)
+    }
+
+    @Test
+    fun `do not get a transaction by URL`() = runBlocking {
+        val firstTransaction = createRequest("abc")
+        insertTransaction(firstTransaction)
+        val secondTransaction = createRequest()
+        insertTransaction(secondTransaction)
+
+        val result = testObject.getByUrl("abcdef")
+        assertThat(result).isNull()
+    }
+
     private suspend fun insertTransaction(transaction: HttpTransaction) {
         transaction.id = testObject.insert(transaction)!!
     }


### PR DESCRIPTION
## :camera: Screenshots
<img src="https://user-images.githubusercontent.com/11295209/114566442-f11bb480-9c7a-11eb-8b01-bc158ed10c1a.png" width="250" /><img src="https://user-images.githubusercontent.com/11295209/114566461-f678ff00-9c7a-11eb-809a-c36dae3f2f48.gif" width="250" /><img src="https://user-images.githubusercontent.com/11295209/114566472-fb3db300-9c7a-11eb-9c24-7e074818577a.gif" width="250" />

## :page_facing_up: Context
Response body sometimes can contain URL's of feature network requests, with this development user can navigate between requests. Also other URL's will be opened in browser( via Intent.VIEW action).

## :pencil: Changes
- Add new method to query previous request by url.
- Add BodyLineItemCreator to assign ClickableSpan to response body field values.

## :no_entry_sign: Breaking
- This implementation does not changes current behaviour of API.

## :hammer_and_wrench: How to test
Sample response fields are enough for testing JSON fields. To test XML fields, custom response or implementing to another library that can provide XML response is required.