### PR TITLE
Update lint options

### DIFF
--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -22,6 +22,10 @@ android {
     lintOptions {
         warningsAsErrors true
         abortOnError true
+        // We don't want to impose RTL on consuming applications.
+        disable 'RtlEnabled'
+        // Don't fail build if some dependencies outdated
+        disable 'GradleDependency'
     }
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -52,6 +52,8 @@ android {
         warningsAsErrors true
         abortOnError true
         disable 'AcceptsUserCertificates'
+        // Don't fail build if some dependencies outdated
+        disable 'GradleDependency'
     }
 
     compileOptions {


### PR DESCRIPTION
## :page_facing_up: Context
In some PRs lint on CI fails due to new version of some dependency being available. It is not something that important to fail the build. Previously we added an exception for such cases, but only in `library` module. This PR adds the same exception rule to `no-op` and `sample` modules.
Additionally added and exception about RTL to `no-op` module, since it looks like it should be there as well.

## :pencil: Changes
- Updated lint rule in `no-op` and `sample` modules.