### PR TITLE
Update readme and change list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Please add your entries according to this format.
 
 * Updated OkHttp to 4.9.1
 
-## Version 3.5.0 *(2021-06-27)*
+## Version 3.5.0 *(2021-06-29)*
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,11 @@ Please add your entries according to this format.
 
 ### Added
 
-* Android 12 support
+* Android 12 support.
 
 ### Fixed
 
-* Fix crash on Android 12 due to missing immutability flags [#593]
+* Fix crash on Android 12 due to missing immutability flags [#593].
 * Fix not setting request body type correctly [#538].
 
 ## Version 3.4.0 *(2020-11-05)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ Please add your entries according to this format.
 
 ### Fixed
 
-* Fixed not setting request body type correctly [#538].
-* Fixed request headers not being redacted in case of failures [#545].
+s* Fixed request headers not being redacted in case of failures [#545].
 * Fixed wrongful processing of one shot and duplex requests [#544].
 * Fixed writing to database on the main thread [#487]. 
 
@@ -24,6 +23,17 @@ Please add your entries according to this format.
 ### Changed
 
 * Updated OkHttp to 4.9.1
+
+## Version 3.5.0 *(2021-06-27)*
+
+### Added
+
+* Android 12 support
+
+### Fixed
+
+* Fix crash on Android 12 due to missing immutability flags [#593]
+* Fix not setting request body type correctly [#538].
 
 ## Version 3.4.0 *(2020-11-05)*
 
@@ -488,3 +498,8 @@ Initial release.
 [#465]: https://github.com/ChuckerTeam/chucker/issues/465
 [#472]: https://github.com/ChuckerTeam/chucker/issues/472
 [#480]: https://github.com/ChuckerTeam/chucker/issues/480
+[#487]: https://github.com/ChuckerTeam/chucker/issues/487
+[#538]: https://github.com/ChuckerTeam/chucker/issues/538
+[#544]: https://github.com/ChuckerTeam/chucker/issues/544
+[#545]: https://github.com/ChuckerTeam/chucker/issues/545
+[#593]: https://github.com/ChuckerTeam/chucker/issues/593

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Please add your entries according to this format.
 
 ### Fixed
 
-s* Fixed request headers not being redacted in case of failures [#545].
+* Fixed request headers not being redacted in case of failures [#545].
 * Fixed wrongful processing of one shot and duplex requests [#544].
 * Fixed writing to database on the main thread [#487]. 
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Please note that you should add both the `library` and the the `library-no-op` v
 
 ```groovy
 dependencies {
-  debugImplementation "com.github.chuckerteam.chucker:library:3.4.0"
-  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.4.0"
+  debugImplementation "com.github.chuckerteam.chucker:library:3.5.0"
+  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.5.0"
 }
 ```
 
@@ -117,7 +117,7 @@ val chuckerInterceptor = ChuckerInterceptor.Builder(context)
         // Use decoder when processing request and response bodies. When multiple decoders are installed they
         // are applied in an order they were added.
         .addBodyDecoder(decoder)
-        // Controls Android shortcut creation.
+        // Controls Android shortcut creation. Available in SNAPSHOTS versions only at the moment
         .createShortcut(true)
         .build()
 
@@ -141,6 +141,8 @@ interceptor.redactHeader("Auth-Token", "User-Session");
 ```
 
 ### Decode-Body 📖
+
+**Warning** This feature is available in SNAPSHOT builds at the moment, not in 3.5.0
 
 Chucker by default handles only plain text bodies. If you use a binary format like, for example, Protobuf or Thrift it won't be automatically handled by Chucker. You can, however, install a custom decoder that is capable to read data from different encodings.
 
@@ -177,8 +179,8 @@ repositories {
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }
 dependencies {
-  debugImplementation "com.github.chuckerteam.chucker:library:3.4.1-SNAPSHOT"
-  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.4.1-SNAPSHOT"
+  debugImplementation "com.github.chuckerteam.chucker:library:4.0.0-SNAPSHOT"
+  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:4.0.0-SNAPSHOT"
 }
 ```
 


### PR DESCRIPTION
## :page_facing_up: Context
Updates to CHANGELOG and README files for next `3.5.0` release

## :paperclip: Related PR
This PR should be merged after #637 is merged and released to not misinform users

## :stopwatch: Next steps
Not sure if we need this PR in `3.x` branch as well, since `develop` is a source of truth for users.