### PR TITLE
Setup automatic repo closure

### DIFF
--- a/.github/workflows/close-and-release-repository.yaml
+++ b/.github/workflows/close-and-release-repository.yaml
@@ -1,0 +1,16 @@
+name: Close and Release Repository
+on: workflow_dispatch
+
+jobs:
+  publish:
+    runs-on: [ubuntu-latest]
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+
+    - name: Close and Release Staging Repository
+      run: ./gradlew closeAndReleaseStagingRepository
+      env:
+        ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_USERNAME }}
+        ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_PASSWORD }}

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -26,7 +26,7 @@ jobs:
         path: '~/.m2/repository/'
 
     - name: Publish to the Staging Repository
-      run: ./gradlew publishReleasePublicationToStagingRepository
+      run: ./gradlew publishReleasePublicationToStagingRepository --no-parallel
       env:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -31,7 +31,7 @@ jobs:
         path: '~/.m2/repository/'
 
     - name: Publish to the Snapshot Repository
-      run: ./gradlew publishReleasePublicationToSnapshotRepository
+      run: ./gradlew publishReleasePublicationToSnapshotRepository --no-parallel
       env:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ buildscript {
         robolectricVersion = '4.5.1'
         truthVersion = '1.1.3'
         vintageJunitVersion = '4.13'
+
+        // Publishing
+        nexusStagingPlugin = '0.30.0'
     }
 
     repositories {
@@ -52,9 +55,11 @@ buildscript {
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktLintGradleVersion"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binaryCompatibilityValidator"
         classpath "com.squareup.wire:wire-gradle-plugin:$wireVersion"
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:$nexusStagingPlugin"
     }
 }
 apply plugin: 'binary-compatibility-validator'
+apply plugin: 'io.codearte.nexus-staging'
 
 apiValidation {
     ignoredProjects += ["sample"]
@@ -101,4 +106,10 @@ ext {
     minSdkVersion = 21
     targetSdkVersion = 30
     compileSdkVersion = 30
+}
+
+nexusStaging {
+    username = findProperty("NEXUS_USERNAME")
+    password = findProperty("NEXUS_PASSWORD")
+    stagingProfileId = "ea09119de9f4"
 }


### PR DESCRIPTION
## :page_facing_up: Context
I've setup a manual GH Actions workflow to trigger the closing/publishing of the sonatype plugin.

## :pencil: Changes
I've used the `io.codearte.nexus-staging` to achieve this. I wanted to use https://github.com/gradle-nexus/publish-plugin/ but just closing the repo was not supported due to https://github.com/gradle-nexus/publish-plugin/issues/19

I've also added the `--no-parallel` flag on the publishing tasks as I noticed that two Staging Repositories gets created whenver a new tag is published. This should mitigate the issue.

## :hammer_and_wrench: How to test
I've tested the plugin locally when releasing `3.5.0`. We can try the GH workflow end to end on the next release.