### PR TITLE
Correctly set `FLAG_IMMUTABLE` for error screen `PendingIntent`

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -57,7 +57,7 @@ internal class NotificationHelper(val context: Context) {
             context,
             ERROR_NOTIFICATION_ID,
             Chucker.getLaunchIntent(context, Chucker.SCREEN_ERROR),
-            PendingIntent.FLAG_UPDATE_CURRENT
+            PendingIntent.FLAG_UPDATE_CURRENT or immutableFlag()
         )
     }
 


### PR DESCRIPTION
## :page_facing_up: Context
Originally reported here https://github.com/ChuckerTeam/chucker/issues/634#issuecomment-880196269
When we backported this PR #593, the `PendingIntent` for the error screen slipped through. Therefore users

## :pencil: Changes
Just adding the `FLAG_IMMUTABLE` to the only `PendingIntent` that was missing it.

## :paperclip: Related PR
#593 and #637

## :hammer_and_wrench: How to test
I haven't tested this, it's a best guess fix.

## :stopwatch: Next steps
We should potentially release `3.5.1` with this fix included. Wdyt @vbuberen @MiSikora 