### PR TITLE
Explicitly set exported property for sample

### DIFF
--- a/sample/src/debug/AndroidManifest.xml
+++ b/sample/src/debug/AndroidManifest.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:networkSecurityConfig="@xml/network_security_config"
-        tools:targetApi="n">
-    </application>
+        tools:targetApi="n" />
 </manifest>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -8,11 +8,13 @@
     <application
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
-        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.chuckerteam.chucker.sample.MainActivity">
+        <activity
+            android:name="com.chuckerteam.chucker.sample.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## :page_facing_up: Context
Another change required before app can target Android S (12) is requirement to set `exported` for all components in app's manifest: https://developer.android.com/about/versions/12/behavior-changes-12#exported
We didn't have it, so I couldn't build sample to test with `targetSDK` changed to 31. To fix it and prepare for future `targetSDK` change I did this small update.

## :pencil: Changes
- Added `exported=true` to sample's `MainActivity`, so it could be launched on devices with Android 12 when `targetSDK` is set to 31.

## :stopwatch: Next steps
Pick it into `3.x` as well before creating a new patch release.
