### PR TITLE
Release 3.5.1 changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Please add your entries according to this format.
 ## Version 3.5.1 *(2021-07-19)*
 
 ### Fixed
+
 * Fix crash on Android 12 due to missing immutability flags in deprecated error reporting feature [#653].
 
 ## Version 3.5.0 *(2021-06-29)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,14 @@ Please add your entries according to this format.
 
 * Updated OkHttp to 4.9.1
 
+## Version 3.5.1 *(2021-07-19)*
+
+### Fixed
+* Fix crash on Android 12 due to missing immutability flags in deprecated error reporting feature [#653].
+
 ## Version 3.5.0 *(2021-06-29)*
+
+Note: this release has issue with Android 12 support, so update to 3.5.1 is highly recommended.
 
 ### Added
 
@@ -503,3 +510,4 @@ Initial release.
 [#544]: https://github.com/ChuckerTeam/chucker/issues/544
 [#545]: https://github.com/ChuckerTeam/chucker/issues/545
 [#593]: https://github.com/ChuckerTeam/chucker/issues/593
+[#653]: https://github.com/ChuckerTeam/chucker/pull/653

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Please note that you should add both the `library` and the the `library-no-op` v
 
 ```groovy
 dependencies {
-  debugImplementation "com.github.chuckerteam.chucker:library:3.5.0"
-  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.5.0"
+  debugImplementation "com.github.chuckerteam.chucker:library:3.5.1"
+  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.5.1"
 }
 ```
 
@@ -142,7 +142,7 @@ interceptor.redactHeader("Auth-Token", "User-Session");
 
 ### Decode-Body 📖
 
-**Warning** This feature is available in SNAPSHOT builds at the moment, not in 3.5.0
+**Warning** This feature is available in SNAPSHOT builds at the moment, not in 3.5.1
 
 Chucker by default handles only plain text bodies. If you use a binary format like, for example, Protobuf or Thrift it won't be automatically handled by Chucker. You can, however, install a custom decoder that is capable to read data from different encodings.
 


### PR DESCRIPTION
## :page_facing_up: Context
Preparations for patch 3.5.1 release

## :pencil: Changes
- Updated release notes and readme

## :paperclip: Related PR
Blocked by #655 as we need to release 3.5.1 first
