### PR TITLE
Add groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please add your entries according to this format.
 ### Added
 * Decoding of request and response bodies can now be customized. In order to do this a `BodyDecoder` interface needs to be implemented and installed in the `ChuckerInterceptor` via `ChuckerInterceptor.addBinaryDecoder(decoder)` method. Decoded bodies are then displayed in the Chucker UI.
 * Create dynamic shortcut when `ChuckerInterceptor` added. Users can opt out of this feature using `createShortcut(false)` in `ChuckerInterceptor.Builder`
+* Add possibility to group requests by something meaningful for the app use case
 
 ### Fixed
 

--- a/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -3,6 +3,7 @@ package com.chuckerteam.chucker.api
 import android.content.Context
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
+import com.chuckerteam.chucker.internal.support.GroupSingleton
 import com.chuckerteam.chucker.internal.support.NotificationHelper
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -21,7 +22,8 @@ import kotlinx.coroutines.launch
 public class ChuckerCollector @JvmOverloads constructor(
     context: Context,
     public var showNotification: Boolean = true,
-    retentionPeriod: RetentionManager.Period = RetentionManager.Period.ONE_WEEK
+    retentionPeriod: RetentionManager.Period = RetentionManager.Period.ONE_WEEK,
+    groups: List<Group> = listOf()
 ) {
     private val retentionManager: RetentionManager = RetentionManager(context, retentionPeriod)
     private val notificationHelper: NotificationHelper = NotificationHelper(context)
@@ -29,6 +31,7 @@ public class ChuckerCollector @JvmOverloads constructor(
 
     init {
         RepositoryProvider.initialize(context)
+        GroupSingleton.groups = groups.toMutableList()
     }
 
     /**

--- a/library/src/main/java/com/chuckerteam/chucker/api/Group.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Group.kt
@@ -6,4 +6,8 @@ import java.util.UUID
 public data class Group(val name: String, val urls: List<String>) : Serializable {
     internal val id = UUID.randomUUID().toString()
     internal var isChecked: Boolean = false
+
+    public companion object {
+        public const val serialVersionUID: Long = 1
+    }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/api/Group.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Group.kt
@@ -1,3 +1,9 @@
 package com.chuckerteam.chucker.api
 
-public data class Group(val name: String, val urls: List<String>)
+import java.io.Serializable
+import java.util.UUID
+
+public data class Group(val name: String, val urls: List<String>) : Serializable {
+    internal val id = UUID.randomUUID().toString()
+    internal var isChecked: Boolean = false
+}

--- a/library/src/main/java/com/chuckerteam/chucker/api/Group.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/api/Group.kt
@@ -1,0 +1,3 @@
+package com.chuckerteam.chucker.api
+
+public data class Group(val name: String, val urls: List<String>)

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -22,7 +22,8 @@ internal data class HttpTransactionTuple(
     @ColumnInfo(name = "responseCode") var responseCode: Int?,
     @ColumnInfo(name = "requestPayloadSize") var requestPayloadSize: Long?,
     @ColumnInfo(name = "responsePayloadSize") var responsePayloadSize: Long?,
-    @ColumnInfo(name = "error") var error: String?
+    @ColumnInfo(name = "error") var error: String?,
+    @ColumnInfo(name = "url") var url: String?
 ) {
     val isSsl: Boolean get() = scheme.equals("https", ignoreCase = true)
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -10,9 +10,14 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
 
     private val transactionDao get() = database.transactionDao()
 
-    override fun getFilteredTransactionTuples(path: String, code: String, urls: List<String>): LiveData<List<HttpTransactionTuple>> {
+    override fun getFilteredTransactionTuples(
+        path: String,
+        code: String,
+        urls: List<String>
+    ): LiveData<List<HttpTransactionTuple>> {
         val pathQuery = if (path.isNotEmpty()) "%$path%" else "%"
-        return transactionDao.getFilteredTuples("$code%", pathQuery, urls = urls)
+        val urlsQuery = if (urls.isEmpty()) listOf("%") else urls
+        return transactionDao.getFilteredTuples("$code%", pathQuery, urls = urlsQuery)
     }
 
     override fun getTransaction(transactionId: Long): LiveData<HttpTransaction?> {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -20,6 +20,7 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
         return transactionDao.getFilteredTuples(query)
     }
 
+    @Suppress("SpreadOperator")
     private fun getFilteredTransactionQuery(
         path: String,
         code: String,

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -10,13 +10,9 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
 
     private val transactionDao get() = database.transactionDao()
 
-    override fun getFilteredTransactionTuples(code: String, path: String): LiveData<List<HttpTransactionTuple>> {
+    override fun getFilteredTransactionTuples(path: String, code: String, urls: List<String>): LiveData<List<HttpTransactionTuple>> {
         val pathQuery = if (path.isNotEmpty()) "%$path%" else "%"
-        return transactionDao.getFilteredTuples("$code%", pathQuery)
-    }
-
-    override fun getFilteredTransactionTuples(url: List<String>): LiveData<List<HttpTransactionTuple>> {
-        return transactionDao.getFilteredTuples(url)
+        return transactionDao.getFilteredTuples("$code%", pathQuery, urls = urls)
     }
 
     override fun getTransaction(transactionId: Long): LiveData<HttpTransaction?> {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -15,6 +15,10 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
         return transactionDao.getFilteredTuples("$code%", pathQuery)
     }
 
+    override fun getFilteredTransactionTuples(url: List<String>): LiveData<List<HttpTransactionTuple>> {
+        return transactionDao.getFilteredTuples(url)
+    }
+
     override fun getTransaction(transactionId: Long): LiveData<HttpTransaction?> {
         return transactionDao.getById(transactionId)
             .distinctUntilChanged { old, new -> old?.hasTheSameContent(new) != false }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
@@ -21,7 +21,11 @@ internal interface HttpTransactionRepository {
 
     fun getSortedTransactionTuples(): LiveData<List<HttpTransactionTuple>>
 
-    fun getFilteredTransactionTuples(path: String, code: String, urls: List<String>): LiveData<List<HttpTransactionTuple>>
+    fun getFilteredTransactionTuples(
+        path: String,
+        code: String,
+        urls: List<String>
+    ): LiveData<List<HttpTransactionTuple>>
 
     fun getTransaction(transactionId: Long): LiveData<HttpTransaction?>
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
@@ -21,6 +21,8 @@ internal interface HttpTransactionRepository {
 
     fun getSortedTransactionTuples(): LiveData<List<HttpTransactionTuple>>
 
+    fun getFilteredTransactionTuples(url: List<String>): LiveData<List<HttpTransactionTuple>>
+
     fun getFilteredTransactionTuples(code: String, path: String): LiveData<List<HttpTransactionTuple>>
 
     fun getTransaction(transactionId: Long): LiveData<HttpTransaction?>

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
@@ -21,9 +21,7 @@ internal interface HttpTransactionRepository {
 
     fun getSortedTransactionTuples(): LiveData<List<HttpTransactionTuple>>
 
-    fun getFilteredTransactionTuples(url: List<String>): LiveData<List<HttpTransactionTuple>>
-
-    fun getFilteredTransactionTuples(code: String, path: String): LiveData<List<HttpTransactionTuple>>
+    fun getFilteredTransactionTuples(path: String, code: String, urls: List<String>): LiveData<List<HttpTransactionTuple>>
 
     fun getTransaction(transactionId: Long): LiveData<HttpTransaction?>
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -25,7 +25,11 @@ internal interface HttpTransactionDao {
             "transactions WHERE responseCode LIKE (:codeQuery) AND path LIKE (:pathQuery) AND url LIKE (:urls)" +
             "ORDER BY requestDate DESC"
     )
-    fun getFilteredTuples(codeQuery: String, pathQuery: String, urls: List<String>): LiveData<List<HttpTransactionTuple>>
+    fun getFilteredTuples(
+        codeQuery: String,
+        pathQuery: String,
+        urls: List<String>
+    ): LiveData<List<HttpTransactionTuple>>
 
     @Insert
     suspend fun insert(transaction: HttpTransaction): Long?

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -27,6 +27,14 @@ internal interface HttpTransactionDao {
     )
     fun getFilteredTuples(codeQuery: String, pathQuery: String): LiveData<List<HttpTransactionTuple>>
 
+    @Query(
+        "SELECT id, requestDate, tookMs, protocol, method, host, " +
+            "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error FROM " +
+            "transactions WHERE url LIKE (:url)" +
+            "ORDER BY requestDate DESC"
+    )
+    fun getFilteredTuples(url: List<String>): LiveData<List<HttpTransactionTuple>>
+
     @Insert
     suspend fun insert(transaction: HttpTransaction): Long?
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -22,18 +22,10 @@ internal interface HttpTransactionDao {
     @Query(
         "SELECT id, requestDate, tookMs, protocol, method, host, " +
             "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error FROM " +
-            "transactions WHERE responseCode LIKE :codeQuery AND path LIKE :pathQuery " +
+            "transactions WHERE responseCode LIKE (:codeQuery) AND path LIKE (:pathQuery) AND url LIKE (:urls)" +
             "ORDER BY requestDate DESC"
     )
-    fun getFilteredTuples(codeQuery: String, pathQuery: String): LiveData<List<HttpTransactionTuple>>
-
-    @Query(
-        "SELECT id, requestDate, tookMs, protocol, method, host, " +
-            "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error FROM " +
-            "transactions WHERE url LIKE (:url)" +
-            "ORDER BY requestDate DESC"
-    )
-    fun getFilteredTuples(url: List<String>): LiveData<List<HttpTransactionTuple>>
+    fun getFilteredTuples(codeQuery: String, pathQuery: String, urls: List<String>): LiveData<List<HttpTransactionTuple>>
 
     @Insert
     suspend fun insert(transaction: HttpTransaction): Long?

--- a/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -5,7 +5,9 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.RawQuery
 import androidx.room.Update
+import androidx.sqlite.db.SupportSQLiteQuery
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 
@@ -19,16 +21,9 @@ internal interface HttpTransactionDao {
     )
     fun getSortedTuples(): LiveData<List<HttpTransactionTuple>>
 
-    @Query(
-        "SELECT id, requestDate, tookMs, protocol, method, host, " +
-            "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error FROM " +
-            "transactions WHERE responseCode LIKE (:codeQuery) AND path LIKE (:pathQuery) AND url LIKE (:urls)" +
-            "ORDER BY requestDate DESC"
-    )
+    @RawQuery(observedEntities = [HttpTransaction::class])
     fun getFilteredTuples(
-        codeQuery: String,
-        pathQuery: String,
-        urls: List<String>
+        query: SupportSQLiteQuery
     ): LiveData<List<HttpTransactionTuple>>
 
     @Insert

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/GroupSingleton.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/GroupSingleton.kt
@@ -1,0 +1,20 @@
+package com.chuckerteam.chucker.internal.support
+
+import com.chuckerteam.chucker.api.Group
+
+internal object GroupSingleton {
+    internal lateinit var groups: MutableList<Group>
+
+    fun getMergedGroups(others: List<Group>): List<Group> {
+        others.forEach { other -> 
+            val group = groups.find { it.id == other.id }!!
+            groups.updateItem(group, other)
+        }
+        return groups
+    }
+
+    private fun <T> MutableList<T>.updateItem(item: T, newItem: T) {
+        val index = this.indexOf(item)
+        this[index] = newItem
+    }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/GroupSingleton.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/GroupSingleton.kt
@@ -3,18 +3,5 @@ package com.chuckerteam.chucker.internal.support
 import com.chuckerteam.chucker.api.Group
 
 internal object GroupSingleton {
-    internal lateinit var groups: MutableList<Group>
-
-    fun getMergedGroups(others: List<Group>): List<Group> {
-        others.forEach { other ->
-            val group = groups.find { it.id == other.id }!!
-            groups.updateItem(group, other)
-        }
-        return groups
-    }
-
-    private fun <T> MutableList<T>.updateItem(item: T, newItem: T) {
-        val index = this.indexOf(item)
-        this[index] = newItem
-    }
+    internal var groups: MutableList<Group> = mutableListOf()
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/GroupSingleton.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/GroupSingleton.kt
@@ -6,7 +6,7 @@ internal object GroupSingleton {
     internal lateinit var groups: MutableList<Group>
 
     fun getMergedGroups(others: List<Group>): List<Group> {
-        others.forEach { other -> 
+        others.forEach { other ->
             val group = groups.find { it.id == other.id }!!
             groups.updateItem(group, other)
         }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -16,6 +16,7 @@ import com.chuckerteam.chucker.internal.data.model.DialogData
 import com.chuckerteam.chucker.internal.support.TransactionListDetailsSharable
 import com.chuckerteam.chucker.internal.support.shareAsFile
 import com.chuckerteam.chucker.internal.support.showDialog
+import com.chuckerteam.chucker.internal.ui.group.FilterByGroupDialog
 import com.chuckerteam.chucker.internal.ui.transaction.TransactionActivity
 import com.chuckerteam.chucker.internal.ui.transaction.TransactionAdapter
 import kotlinx.coroutines.launch
@@ -101,10 +102,18 @@ internal class MainActivity :
                 )
                 true
             }
+            R.id.filter_by_group -> {
+                showFilterByGroupDialog()
+                true
+            }
             else -> {
                 super.onOptionsItemSelected(item)
             }
         }
+    }
+
+    private fun showFilterByGroupDialog() {
+        FilterByGroupDialog.newInstance().show(supportFragmentManager, null)
     }
 
     override fun onQueryTextSubmit(query: String): Boolean = true

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -26,7 +26,9 @@ internal class MainActivity :
     BaseChuckerActivity(),
     SearchView.OnQueryTextListener {
 
-    private val viewModel: MainViewModel by viewModels()
+    private val viewModel: MainViewModel by viewModels {
+        MainViewModelFactory()
+    }
 
     private lateinit var mainBinding: ChuckerActivityMainBinding
     private lateinit var transactionsAdapter: TransactionAdapter

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -1,38 +1,58 @@
 package com.chuckerteam.chucker.internal.ui
 
-import android.text.TextUtils
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
+import com.chuckerteam.chucker.api.Group
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
-import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
+import com.chuckerteam.chucker.internal.data.repository.HttpTransactionRepository
 import com.chuckerteam.chucker.internal.support.NotificationHelper
 import kotlinx.coroutines.launch
 
-internal class MainViewModel : ViewModel() {
+internal class MainViewModel(private val transaction: HttpTransactionRepository) : ViewModel() {
 
     private val currentFilter = MutableLiveData("")
+    private val groups = MutableLiveData<MutableList<Group>>()
 
-    val transactions: LiveData<List<HttpTransactionTuple>> = currentFilter.switchMap { searchQuery ->
-        with(RepositoryProvider.transaction()) {
+    private val liveDataMerger = MediatorLiveData<List<HttpTransactionTuple>>()
+
+    init {
+        liveDataMerger.addSource(
+            currentFilter
+        ) {
+            fetchTransactions()
+        }
+        liveDataMerger.addSource(
+            groups
+        ) {
+            fetchTransactions()
+        }
+    }
+
+    private fun fetchTransactions() {
+        val searchQuery = currentFilter.value
+        val groups = groups.value ?: listOf()
+        with(transaction) {
             when {
-                searchQuery.isNullOrBlank() -> {
+                searchQuery.isNullOrBlank() && groups.isNullOrEmpty() -> {
                     getSortedTransactionTuples()
                 }
-                TextUtils.isDigitsOnly(searchQuery) -> {
-                    getFilteredTransactionTuples("", searchQuery, listOf())
+                searchQuery!!.isDigitsOnly() -> {
+                    getFilteredTransactionTuples("", searchQuery, groups.map { it.urls }.flatten())
                 }
                 else -> {
-                    getFilteredTransactionTuples(searchQuery, "", listOf())
+                    getFilteredTransactionTuples(searchQuery, "", groups.map { it.urls }.flatten())
                 }
             }
         }
     }
 
-    suspend fun getAllTransactions(): List<HttpTransaction> = RepositoryProvider.transaction().getAllTransactions()
+    val transactions: LiveData<List<HttpTransactionTuple>> = liveDataMerger
+
+    suspend fun getAllTransactions(): List<HttpTransaction> = transaction.getAllTransactions()
 
     fun updateItemsFilter(searchQuery: String) {
         currentFilter.value = searchQuery
@@ -40,8 +60,18 @@ internal class MainViewModel : ViewModel() {
 
     fun clearTransactions() {
         viewModelScope.launch {
-            RepositoryProvider.transaction().deleteAllTransactions()
+            transaction.deleteAllTransactions()
         }
         NotificationHelper.clearBuffer()
+    }
+
+    @Suppress("SpreadOperator")
+    fun addGroup(group: Group) {
+        val groupValue = groups.value ?: mutableListOf()
+        groups.value = mutableListOf(*groupValue.toTypedArray(), group)
+    }
+
+    private fun String.isDigitsOnly(): Boolean {
+        return this.all { it in '0'..'9' }
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -18,7 +18,6 @@ internal class MainViewModel(private val transaction: HttpTransactionRepository)
 
     private val currentFilter = MutableLiveData("")
     private val _groups = MutableLiveData<List<Group>>()
-    val groups: LiveData<List<Group>> = _groups
 
     private val liveDataMerger = MediatorLiveData<String>()
 

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -17,7 +17,8 @@ import java.util.UUID
 internal class MainViewModel(private val transaction: HttpTransactionRepository) : ViewModel() {
 
     private val currentFilter = MutableLiveData("")
-    private val groups = MutableLiveData<MutableList<Group>>()
+    private val _groups = MutableLiveData<List<Group>>()
+    val groups: LiveData<List<Group>> = _groups
 
     private val liveDataMerger = MediatorLiveData<String>()
 
@@ -28,7 +29,7 @@ internal class MainViewModel(private val transaction: HttpTransactionRepository)
             fetchTransactions()
         }
         liveDataMerger.addSource(
-            groups
+            _groups
         ) {
             fetchTransactions()
         }
@@ -47,7 +48,7 @@ internal class MainViewModel(private val transaction: HttpTransactionRepository)
 
     val transactions: LiveData<List<HttpTransactionTuple>> = liveDataMerger.switchMap {
         val searchQuery = currentFilter.value
-        val groups = groups.value ?: listOf()
+        val groups = _groups.value ?: listOf()
         with(transaction) {
             when {
                 searchQuery.isNullOrBlank() && groups.isNullOrEmpty() -> {
@@ -78,16 +79,16 @@ internal class MainViewModel(private val transaction: HttpTransactionRepository)
 
     @Suppress("SpreadOperator")
     fun addGroup(group: Group) {
-        val groupValue = groups.value ?: mutableListOf()
-        groups.value = mutableListOf(*groupValue.toTypedArray(), group)
+        val groupValue = _groups.value ?: mutableListOf()
+        _groups.value = mutableListOf(*groupValue.toTypedArray(), group)
     }
 
     @Suppress("SpreadOperator")
     fun removeGroup(group: Group) {
-        val groupValue = groups.value ?: mutableListOf()
+        val groupValue = _groups.value ?: mutableListOf()
         val listOfGroups = mutableListOf(*groupValue.toTypedArray())
         listOfGroups.remove(group)
-        groups.value = listOfGroups
+        _groups.value = listOfGroups
     }
 
     private fun String.isDigitsOnly(): Boolean {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -82,6 +82,14 @@ internal class MainViewModel(private val transaction: HttpTransactionRepository)
         groups.value = mutableListOf(*groupValue.toTypedArray(), group)
     }
 
+    @Suppress("SpreadOperator")
+    fun removeGroup(group: Group) {
+        val groupValue = groups.value ?: mutableListOf()
+        val listOfGroups = mutableListOf(*groupValue.toTypedArray())
+        listOfGroups.remove(group)
+        groups.value = listOfGroups
+    }
+
     private fun String.isDigitsOnly(): Boolean {
         return this.all { it in '0'..'9' }
     }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -23,10 +23,10 @@ internal class MainViewModel : ViewModel() {
                     getSortedTransactionTuples()
                 }
                 TextUtils.isDigitsOnly(searchQuery) -> {
-                    getFilteredTransactionTuples(searchQuery, "")
+                    getFilteredTransactionTuples("", searchQuery, listOf())
                 }
                 else -> {
-                    getFilteredTransactionTuples("", searchQuery)
+                    getFilteredTransactionTuples(searchQuery, "", listOf())
                 }
             }
         }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModelFactory.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/MainViewModelFactory.kt
@@ -1,0 +1,13 @@
+package com.chuckerteam.chucker.internal.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.chuckerteam.chucker.internal.data.repository.HttpTransactionRepository
+import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
+
+internal class MainViewModelFactory : ViewModelProvider.Factory {
+    private val transaction: HttpTransactionRepository = RepositoryProvider.transaction()
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        return MainViewModel(transaction) as T
+    }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/FilterByGroupDialog.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/FilterByGroupDialog.kt
@@ -1,0 +1,71 @@
+package com.chuckerteam.chucker.internal.ui.group
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
+import androidx.recyclerview.widget.DividerItemDecoration
+import com.chuckerteam.chucker.databinding.ChuckerFilterByGroupDialogBinding
+import com.chuckerteam.chucker.internal.support.GroupSingleton
+import com.chuckerteam.chucker.internal.ui.MainViewModel
+import com.chuckerteam.chucker.internal.ui.MainViewModelFactory
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+internal class FilterByGroupDialog : BottomSheetDialogFragment() {
+
+    private lateinit var binding: ChuckerFilterByGroupDialogBinding
+    private lateinit var adapter: GroupAdapter
+
+    private val viewModel: MainViewModel by activityViewModels {
+        MainViewModelFactory()
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = ChuckerFilterByGroupDialogBinding.inflate(inflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupAdapter()
+        with(binding) {
+            groupRecyclerView.apply {
+                setHasFixedSize(true)
+                addItemDecoration(
+                    DividerItemDecoration(
+                        requireContext(),
+                        DividerItemDecoration.VERTICAL
+                    )
+                )
+                adapter = adapter
+            }
+        }
+
+        viewModel.groups.observe(
+            viewLifecycleOwner,
+            {
+                adapter.submitList(GroupSingleton.getMergedGroups(it))
+            }
+        )
+    }
+
+    private fun setupAdapter() {
+        adapter = GroupAdapter {
+            it.isChecked = !it.isChecked
+            if (it.isChecked) {
+                viewModel.addGroup(it)
+            } else {
+                viewModel.removeGroup(it)
+            }
+        }
+    }
+
+    companion object {
+        fun newInstance() = FilterByGroupDialog()
+    }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/FilterByGroupDialog.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/FilterByGroupDialog.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.chuckerteam.chucker.databinding.ChuckerFilterByGroupDialogBinding
 import com.chuckerteam.chucker.internal.support.GroupSingleton
 import com.chuckerteam.chucker.internal.ui.MainViewModel
@@ -15,7 +16,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 internal class FilterByGroupDialog : BottomSheetDialogFragment() {
 
     private lateinit var binding: ChuckerFilterByGroupDialogBinding
-    private lateinit var adapter: GroupAdapter
+    private lateinit var groupAdapter: GroupAdapter
 
     private val viewModel: MainViewModel by activityViewModels {
         MainViewModelFactory()
@@ -34,7 +35,8 @@ internal class FilterByGroupDialog : BottomSheetDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         setupAdapter()
         with(binding) {
-            groupRecyclerView.apply {
+            this.groupRecyclerView.apply {
+                layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
                 setHasFixedSize(true)
                 addItemDecoration(
                     DividerItemDecoration(
@@ -42,20 +44,13 @@ internal class FilterByGroupDialog : BottomSheetDialogFragment() {
                         DividerItemDecoration.VERTICAL
                     )
                 )
-                adapter = adapter
+                adapter = groupAdapter
             }
         }
-
-        viewModel.groups.observe(
-            viewLifecycleOwner,
-            {
-                adapter.submitList(GroupSingleton.getMergedGroups(it))
-            }
-        )
     }
 
     private fun setupAdapter() {
-        adapter = GroupAdapter {
+        groupAdapter = GroupAdapter {
             it.isChecked = !it.isChecked
             if (it.isChecked) {
                 viewModel.addGroup(it)
@@ -63,6 +58,7 @@ internal class FilterByGroupDialog : BottomSheetDialogFragment() {
                 viewModel.removeGroup(it)
             }
         }
+        groupAdapter.submitList(GroupSingleton.groups)
     }
 
     companion object {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupAdapter.kt
@@ -1,6 +1,5 @@
 package com.chuckerteam.chucker.internal.ui.group
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupAdapter.kt
@@ -25,6 +25,7 @@ internal class GroupAdapter internal constructor(
     ) : RecyclerView.ViewHolder(itemBinding.root) {
         fun bind(item: Group) {
             itemView.setOnClickListener {
+                itemBinding.checkbox.isChecked = !itemBinding.checkbox.isChecked
                 onGroupItemClick.invoke(item)
             }
             itemBinding.apply {

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupAdapter.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupAdapter.kt
@@ -1,0 +1,37 @@
+package com.chuckerteam.chucker.internal.ui.group
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.chuckerteam.chucker.api.Group
+import com.chuckerteam.chucker.databinding.ChuckerListItemGroupBinding
+
+internal class GroupAdapter internal constructor(
+    private val onGroupItemClick: (Group) -> Unit,
+) : ListAdapter<Group, GroupAdapter.ViewHolder>(GroupDiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GroupAdapter.ViewHolder {
+        val viewBinding = ChuckerListItemGroupBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(viewBinding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class ViewHolder(
+        private val itemBinding: ChuckerListItemGroupBinding
+    ) : RecyclerView.ViewHolder(itemBinding.root) {
+        fun bind(item: Group) {
+            itemView.setOnClickListener {
+                onGroupItemClick.invoke(item)
+            }
+            itemBinding.apply {
+                this.checkbox.isChecked = item.isChecked
+                this.groupName.text = item.name
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupDiffCallback.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupDiffCallback.kt
@@ -9,6 +9,6 @@ internal object GroupDiffCallback : DiffUtil.ItemCallback<Group>() {
     }
 
     override fun areContentsTheSame(oldItem: Group, newItem: Group): Boolean {
-        return oldItem == newItem
+        return oldItem.isChecked == newItem.isChecked
     }
 }

--- a/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupDiffCallback.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/ui/group/GroupDiffCallback.kt
@@ -1,0 +1,14 @@
+package com.chuckerteam.chucker.internal.ui.group
+
+import androidx.recyclerview.widget.DiffUtil
+import com.chuckerteam.chucker.api.Group
+
+internal object GroupDiffCallback : DiffUtil.ItemCallback<Group>() {
+    override fun areItemsTheSame(oldItem: Group, newItem: Group): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: Group, newItem: Group): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/library/src/main/res/drawable/chucker_ic_filter.xml
+++ b/library/src/main/res/drawable/chucker_ic_filter.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M4.25,5.61C6.27,8.2 10,13 10,13v6c0,0.55 0.45,1 1,1h2c0.55,0 1,-0.45 1,-1v-6c0,0 3.72,-4.8 5.74,-7.39C20.25,4.95 19.78,4 18.95,4H5.04C4.21,4 3.74,4.95 4.25,5.61z"/>
+</vector>

--- a/library/src/main/res/layout/chucker_filter_by_group_dialog.xml
+++ b/library/src/main/res/layout/chucker_filter_by_group_dialog.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/group_recycler_view"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:textSize="20sp"
+        android:layout_width="match_parent"
+        android:layout_height="400dp" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/layout/chucker_list_item_group.xml
+++ b/library/src/main/res/layout/chucker_list_item_group.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:focusable="true"
+    android:background="?android:attr/selectableItemBackground"
+    android:padding="@dimen/chucker_doub_grid">
+
+    <CheckBox
+        android:id="@+id/checkbox"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <TextView
+        android:id="@+id/group_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="4"
+        android:textAppearance="@style/Chucker.TextAppearance.ListItem"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="@dimen/chucker_base_grid"
+        app:layout_constraintStart_toEndOf="@id/checkbox"
+        app:layout_constraintTop_toTopOf="@id/checkbox"
+        app:layout_constraintBottom_toBottomOf="@id/checkbox"
+        android:textAlignment="center"
+        tools:text="Cart Group" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/menu/chucker_transactions_list.xml
+++ b/library/src/main/res/menu/chucker_transactions_list.xml
@@ -6,6 +6,10 @@
         android:icon="@drawable/chucker_ic_search_white"
         app:showAsAction="collapseActionView|ifRoom"
         app:actionViewClass="androidx.appcompat.widget.SearchView" />
+    <item android:title="@string/chucker_filter_by_group"
+        android:id="@+id/filter_by_group"
+        android:icon="@drawable/chucker_ic_filter"
+        app:showAsAction="ifRoom" />
     <item android:id="@+id/export"
         android:icon="@drawable/chucker_ic_share_white"
         android:title="@string/chucker_export"

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="chucker_name">Chucker</string>
     <string name="chucker_http_notification_title">Recording HTTP activity</string>
     <string name="chucker_clear">Clear</string>
+    <string name="chucker_filter_by_group">Filter by group</string>
     <string name="chucker_encode_url">Encode URL</string>
     <string name="chucker_cancel">Cancel</string>
     <string name="chucker_overview">Overview</string>

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
@@ -118,7 +118,8 @@ internal class HttpTransactionTupleTest {
         responseCode: Int? = null,
         requestPayloadSize: Long? = null,
         responsePayloadSize: Long? = null,
-        error: String? = null
+        error: String? = null,
+        url: String? = null
     ) = HttpTransactionTuple(
         id,
         requestDate,
@@ -131,6 +132,7 @@ internal class HttpTransactionTupleTest {
         responseCode,
         requestPayloadSize,
         responsePayloadSize,
-        error
+        error,
+        url
     )
 }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/TransactionTestUtils.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/entity/TransactionTestUtils.kt
@@ -17,6 +17,18 @@ internal fun createRequest(path: String = ""): HttpTransaction =
         requestBody = randomString()
     }
 
+internal fun createRequestByURL(url: String = ""): HttpTransaction =
+    HttpTransaction().apply {
+        setRequestHeaders(randomHeaders())
+        populateUrl(url.toHttpUrlOrNull()!!)
+        isResponseBodyEncoded = true
+        requestDate = 300L
+        method = "GET"
+        requestContentType = "text/plain"
+        requestPayloadSize = 0L
+        requestBody = randomString()
+    }
+
 internal fun HttpTransaction.withResponseData(): HttpTransaction = this.apply {
     setResponseHeaders(randomHeaders())
     responseCode = 418 // I'm a teapot

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
@@ -137,7 +137,7 @@ internal class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
 
-        testObject.getFilteredTransactionTuples(code = "", path = "").observeForever { result ->
+        testObject.getFilteredTransactionTuples(path = "", code = "", listOf("")).observeForever { result ->
             assertTuples(listOf(transactionThree, transactionOne, transactionTwo), result)
         }
     }
@@ -161,7 +161,7 @@ internal class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
 
-        testObject.getFilteredTransactionTuples(code = "", path = "def").observeForever { result ->
+        testObject.getFilteredTransactionTuples(path = "def", code = "", urls = listOf("%")).observeForever { result ->
             assertTuples(listOf(transactionThree, transactionTwo), result)
         }
     }
@@ -188,7 +188,7 @@ internal class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
 
-        testObject.getFilteredTransactionTuples(code = "4", path = "").observeForever { result ->
+        testObject.getFilteredTransactionTuples(path = "", code = "4", urls = listOf("%")).observeForever { result ->
             assertTuples(listOf(transactionThree, transactionOne), result)
         }
     }
@@ -215,7 +215,7 @@ internal class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
 
-        testObject.getFilteredTransactionTuples(listOf("%google%")).observeForever { result ->
+        testObject.getFilteredTransactionTuples(urls = listOf("%google%"), path = "", code = "").observeForever { result ->
             assertTuples(listOf(transactionOne, transactionTwo), result)
         }
     }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
@@ -137,9 +137,10 @@ internal class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
 
-        testObject.getFilteredTransactionTuples(path = "", code = "", listOf("")).observeForever { result ->
-            assertTuples(listOf(transactionThree, transactionOne, transactionTwo), result)
-        }
+        testObject.getFilteredTransactionTuples(path = "", code = "", listOf())
+            .observeForever { result ->
+                assertTuples(listOf(transactionThree, transactionOne, transactionTwo), result)
+            }
     }
 
     @Test
@@ -161,7 +162,7 @@ internal class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
 
-        testObject.getFilteredTransactionTuples(path = "def", code = "", urls = listOf("%")).observeForever { result ->
+        testObject.getFilteredTransactionTuples(path = "def", code = "", urls = listOf()).observeForever { result ->
             assertTuples(listOf(transactionThree, transactionTwo), result)
         }
     }
@@ -188,7 +189,7 @@ internal class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
 
-        testObject.getFilteredTransactionTuples(path = "", code = "4", urls = listOf("%")).observeForever { result ->
+        testObject.getFilteredTransactionTuples(path = "", code = "4", urls = listOf()).observeForever { result ->
             assertTuples(listOf(transactionThree, transactionOne), result)
         }
     }

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
@@ -216,9 +216,10 @@ internal class HttpTransactionDatabaseRepositoryTest {
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
 
-        testObject.getFilteredTransactionTuples(urls = listOf("%google%"), path = "", code = "").observeForever { result ->
-            assertTuples(listOf(transactionOne, transactionTwo), result)
-        }
+        testObject.getFilteredTransactionTuples(urls = listOf("%google%"), path = "", code = "")
+            .observeForever { result ->
+                assertTuples(listOf(transactionOne, transactionTwo), result)
+            }
     }
 
     @Test

--- a/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -188,9 +188,10 @@ internal class HttpTransactionDaoTest {
         insertTransaction(transactionTwo)
         insertTransaction(transactionThree)
 
-        testObject.getFilteredTuples(codeQuery = "418", pathQuery = "%abc%", urls = listOf("%")).observeForever { result ->
-            assertTuples(listOf(transactionOne, transactionTwo), result)
-        }
+        testObject.getFilteredTuples(codeQuery = "418", pathQuery = "%abc%", urls = listOf("%"))
+            .observeForever { result ->
+                assertTuples(listOf(transactionOne, transactionTwo), result)
+            }
     }
 
     @Test
@@ -248,9 +249,10 @@ internal class HttpTransactionDaoTest {
         insertTransaction(transactionThree)
         insertTransaction(transactionFour)
 
-        testObject.getFilteredTuples(urls = listOf("%test%"), codeQuery = "%", pathQuery = "%").observeForever { result ->
-            assertTuples(listOf(transactionOne, transactionThree), result)
-        }
+        testObject.getFilteredTuples(urls = listOf("%test%"), codeQuery = "%", pathQuery = "%")
+            .observeForever { result ->
+                assertTuples(listOf(transactionOne, transactionThree), result)
+            }
     }
 
     @Test
@@ -281,9 +283,10 @@ internal class HttpTransactionDaoTest {
         insertTransaction(transactionThree)
         insertTransaction(transactionFour)
 
-        testObject.getFilteredTuples(urls = listOf("%google%"), codeQuery = "%", pathQuery = "%test%").observeForever { result ->
-            assertTuples(listOf(transactionThree), result)
-        }
+        testObject.getFilteredTuples(urls = listOf("%google%"), codeQuery = "%", pathQuery = "%test%")
+            .observeForever { result ->
+                assertTuples(listOf(transactionThree), result)
+            }
     }
 
     private suspend fun insertTransaction(transaction: HttpTransaction) {

--- a/library/src/test/java/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
@@ -64,6 +64,30 @@ internal class MainViewModelTest {
         Truth.assertThat(value).hasSize(2)
     }
 
+    @Test
+    fun `WHEN remove group is called THEN Transaction getFilteredTransactionTuples is called`() {
+        val groupOne = Group(name = "Group 1", urls = listOf("url1"))
+        val groupTwo = Group(name = "Group 2", urls = listOf("url2"))
+
+        every { transaction.getFilteredTransactionTuples(any(), any(), any()) } returns MutableLiveData()
+        sut.transactions.observeForTesting {
+            sut.addGroup(groupOne)
+            sut.addGroup(groupTwo)
+            sut.removeGroup(groupTwo)
+
+            verify(exactly = 2) {
+                transaction.getFilteredTransactionTuples("", "", groupOne.urls)
+            }
+            verify(exactly = 1) {
+                transaction.getFilteredTransactionTuples(
+                    "",
+                    "",
+                    listOf(groupOne, groupTwo).map { it.urls }.flatten()
+                )
+            }
+        }
+    }
+
     private fun createTransactionTupple(id: Long) = HttpTransactionTuple(
         id = id,
         requestDate = null,

--- a/library/src/test/java/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
@@ -1,0 +1,58 @@
+package com.chuckerteam.chucker.internal.ui
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.chuckerteam.chucker.api.Group
+import com.chuckerteam.chucker.internal.data.repository.HttpTransactionRepository
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+
+internal class MainViewModelTest {
+
+    lateinit var sut: MainViewModel
+
+    @MockK
+    lateinit var transaction: HttpTransactionRepository
+
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        sut = MainViewModel(transaction)
+        every { transaction.getSortedTransactionTuples() } returns MutableLiveData()
+    }
+
+    @Test
+    fun `WHEN add group is called THEN Transaction getFilteredTransactionTuples is called`() {
+        val group = Group(name = "Group 1", urls = listOf("url1"))
+
+        every { transaction.getFilteredTransactionTuples(any(), any(), group.urls) } returns MutableLiveData()
+        sut.transactions.observeForTesting {
+            sut.addGroup(group)
+
+            verify(exactly = 1) {
+                transaction.getFilteredTransactionTuples("", "", group.urls)
+            }
+        }
+    }
+}
+
+private fun <T> LiveData<T>.observeForTesting(block: () -> Unit) {
+    val observer = Observer<T> { }
+    try {
+        observeForever(observer)
+        block()
+    } finally {
+        removeObserver(observer)
+    }
+}

--- a/sample/src/main/java/com/chuckerteam/chucker/sample/OkHttpUtils.kt
+++ b/sample/src/main/java/com/chuckerteam/chucker/sample/OkHttpUtils.kt
@@ -3,6 +3,7 @@ package com.chuckerteam.chucker.sample
 import android.content.Context
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
+import com.chuckerteam.chucker.api.Group
 import com.chuckerteam.chucker.api.RetentionManager
 import okhttp3.Call
 import okhttp3.Callback
@@ -20,7 +21,8 @@ fun createOkHttpClient(
     val collector = ChuckerCollector(
         context = context,
         showNotification = true,
-        retentionPeriod = RetentionManager.Period.ONE_HOUR
+        retentionPeriod = RetentionManager.Period.ONE_HOUR,
+        groups = listOf(Group("Delay", listOf("%delay%")), Group("Cookies", listOf("%cookies%")))
     )
 
     @Suppress("MagicNumber")


### PR DESCRIPTION
## :camera: Screenshots

https://user-images.githubusercontent.com/9087318/126991171-99b6a1d4-e04a-4401-9729-e7e9ef76e6e5.mov

## :page_facing_up: Context
Adding possibility to group requests by something useful for the context of an app. The users could do something like group the requests used by some feature.

## :pencil: Changes
Update DAO to filter the requests by multiples URLS.
Update collector to accept a list of Groups

## :no_entry_sign: Breaking
No

## :hammer_and_wrench: How to test
Follow the steps on the video. I added to the sample app the Groups "Delay" and "Cookies"

## :stopwatch: Next steps
I don't know, maybe a possibility to also group by the request method


I need some help to think about the comment on the ViewModel, you'll know about what I'm talking about once you read :P
