### PR TITLE
Add ` --no-parallel` to 3.x branch

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -26,7 +26,7 @@ jobs:
         path: '~/.m2/repository/'
 
     - name: Publish to the Staging Repository
-      run: ./gradlew publishReleasePublicationToStagingRepository
+      run: ./gradlew publishReleasePublicationToStagingRepository --no-parallel
       env:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -31,7 +31,7 @@ jobs:
         path: '~/.m2/repository/'
 
     - name: Publish to the Snapshot Repository
-      run: ./gradlew publishReleasePublicationToSnapshotRepository
+      run: ./gradlew publishReleasePublicationToSnapshotRepository --no-parallel
       env:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}


### PR DESCRIPTION
## :page_facing_up: Context
I'm adding the `--no-parallel` flag to publishing on the `3.x` branch. The flag was added only to the `develop` branch so far, I'm replicating it to `3.x` as well.

## :paperclip: Related PR
This is basically re-applying part of #641 on the `3.x` branch.

## :no_entry_sign: Breaking
n/a

## :hammer_and_wrench: How to test
There is no real way to test this. Let's see if we need to release another version from `3.x` if we end up in the same problem as #661 