### PR TITLE
Add base.gradle to simplify gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,12 +102,6 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-ext {
-    minSdkVersion = 21
-    targetSdkVersion = 30
-    compileSdkVersion = 30
-}
-
 nexusStaging {
     username = findProperty("NEXUS_USERNAME")
     password = findProperty("NEXUS_PASSWORD")

--- a/gradle/base.gradle
+++ b/gradle/base.gradle
@@ -1,0 +1,16 @@
+apply plugin: "kotlin-android"
+
+android {
+    compileSdkVersion 30
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 30
+    }
+    buildFeatures {
+        buildConfig = false
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+}

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -1,22 +1,13 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+apply from: "$rootDir/gradle/base.gradle"
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
-
-    compileOptions {
-        kotlinOptions.freeCompilerArgs += [
+    kotlinOptions {
+        freeCompilerArgs += [
             '-module-name', "com.github.ChuckerTeam.Chucker.library-no-op",
             "-Xexplicit-api=strict"
         ]
-    }
-
-    buildFeatures {
-        buildConfig = false
-    }
-
-    defaultConfig {
-        minSdkVersion rootProject.minSdkVersion
     }
 
     lintOptions {
@@ -31,7 +22,6 @@ android {
 
 dependencies {
     api "com.squareup.okhttp3:okhttp:$okhttpVersion"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,29 +1,22 @@
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
+apply from: "$rootDir/gradle/base.gradle"
+
 android {
-    compileSdkVersion rootProject.compileSdkVersion
-
-    compileOptions {
-        kotlinOptions.freeCompilerArgs += [
-            '-module-name', "com.github.ChuckerTeam.Chucker.library",
-            "-Xexplicit-api=strict"
-        ]
-    }
-
     defaultConfig {
-        minSdkVersion rootProject.minSdkVersion
         consumerProguardFiles 'proguard-rules.pro'
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 
     buildFeatures {
         viewBinding = true
-        buildConfig = false
+    }
+
+    kotlinOptions {
+        freeCompilerArgs += [
+            '-module-name', "com.github.ChuckerTeam.Chucker.library",
+            "-Xexplicit-api=strict"
+        ]
     }
 
     lintOptions {
@@ -48,8 +41,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-
     implementation "com.google.android.material:material:$materialComponentsVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "androidx.palette:palette-ktx:$paletteKtxVersion"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,21 +1,14 @@
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
 apply plugin: 'com.squareup.wire'
 
 wire {
     kotlin {}
 }
 
+apply from: "$rootDir/gradle/base.gradle"
+
 android {
-    sourceSets {
-        getByName("main").java.srcDirs += "$buildDir/generated/source/wire/"
-    }
-
-    compileSdkVersion rootProject.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion rootProject.minSdkVersion
-        targetSdkVersion rootProject.targetSdkVersion
         applicationId "com.chuckerteam.chucker.sample"
         versionName VERSION_NAME
         versionCode VERSION_CODE.toInteger()
@@ -23,7 +16,10 @@ android {
 
     buildFeatures {
         viewBinding = true
-        buildConfig = false
+    }
+
+    sourceSets {
+        getByName("main").java.srcDirs += "$buildDir/generated/source/wire/"
     }
 
     buildTypes {
@@ -55,20 +51,11 @@ android {
         // Don't fail build if some dependencies outdated
         disable 'GradleDependency'
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions.jvmTarget = "1.8"
 }
 
 dependencies {
     debugImplementation project(':library')
     releaseImplementation project(':library-no-op')
-
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
 
     implementation "com.google.android.material:material:$materialComponentsVersion"
     implementation "androidx.appcompat:appcompat:$appCompatVersion"


### PR DESCRIPTION
## :page_facing_up: Context
Gradle configs in 3 modules have redundant properties in android closure, can extract them into a single file and import like what [gradle-mvn-push.gradle](https://github.com/ChuckerTeam/chucker/blob/develop/gradle/gradle-mvn-push.gradle) did.
## :pencil: Changes
Add `/gradle/base.gradle` and `apply from: "$rootDir/gradle/base.gradle"` in modules.