### PR TITLE
Add examples of possible missing headers in FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ If you're looking for the **latest stable version**, you can always find it in `
 
 ## FAQ ❓
 
-* Why are some of my request headers missing?
+* Why are some of my request headers (e.g. `Content-Encoding` or `Accept-Encoding`) missing?
 * Why are retries and redirects not being captured discretely?
 * Why are my encoded request/response bodies not appearing as plain text?
 


### PR DESCRIPTION
## :page_facing_up: Context
To have less issues, like #608, decided to add mention of headers which might be missed when Chucker is applied as application interceptor

## :pencil: Changes
- Updated README
