### PR TITLE
Gradle to 7.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## :page_facing_up: Context
Just bumping Gradle to 7.2 as it was older (7.3 is also near). This doesn't get bumped automatically by dependabot.

## :hammer_and_wrench: How to test
CI

## :stopwatch: Next steps
n/a
