### PR TITLE
Drop redundant `apply` on buffers

### DIFF
--- a/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionListDetailsSharable.kt
+++ b/library/src/main/java/com/chuckerteam/chucker/internal/support/TransactionListDetailsSharable.kt
@@ -12,13 +12,11 @@ internal class TransactionListDetailsSharable(
 ) : Sharable {
     private val transactions = transactions.map { TransactionDetailsSharable(it, encodeUrls) }
 
-    override fun toSharableContent(context: Context): Source = Buffer().apply {
-        writeUtf8(
-            transactions.joinToString(
-                separator = "\n${context.getString(string.chucker_export_separator)}\n",
-                prefix = "${context.getString(string.chucker_export_prefix)}\n",
-                postfix = "\n${context.getString(string.chucker_export_postfix)}\n"
-            ) { it.toSharableUtf8Content(context) }
-        )
-    }
+    override fun toSharableContent(context: Context): Source = Buffer().writeUtf8(
+        transactions.joinToString(
+            separator = "\n${context.getString(string.chucker_export_separator)}\n",
+            prefix = "${context.getString(string.chucker_export_prefix)}\n",
+            postfix = "\n${context.getString(string.chucker_export_postfix)}\n",
+        ) { it.toSharableUtf8Content(context) }
+    )
 }

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorDecodingTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorDecodingTest.kt
@@ -55,7 +55,7 @@ internal class ChuckerInterceptorDecodingTest {
         )
         val client = factory.create(chuckerInterceptor)
 
-        val body = Buffer().apply { writeUtf8("Hello, world!") }
+        val body = Buffer().writeUtf8("Hello, world!")
         server.enqueue(MockResponse().setBody(body))
         val request = Request.Builder().url(serverUrl).build()
 

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -80,7 +80,7 @@ internal class ChuckerInterceptorTest {
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
     fun `gzipped response body is gunzipped for Chucker`(factory: ClientFactory) {
-        val bytes = Buffer().apply { writeUtf8("Hello, world!") }
+        val bytes = Buffer().writeUtf8("Hello, world!")
         val gzippedBytes = Buffer().apply {
             GzipSink(this).use { sink -> sink.write(bytes, bytes.size) }
         }
@@ -98,7 +98,7 @@ internal class ChuckerInterceptorTest {
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
     fun `gzipped response body is gunzipped for consumer`(factory: ClientFactory) {
-        val bytes = Buffer().apply { writeUtf8("Hello, world!") }
+        val bytes = Buffer().writeUtf8("Hello, world!")
         val gzippedBytes = Buffer().apply {
             GzipSink(this).use { sink -> sink.write(bytes, bytes.size) }
         }
@@ -186,7 +186,7 @@ internal class ChuckerInterceptorTest {
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
     fun `plain text response body is available to Chucker`(factory: ClientFactory) {
-        val body = Buffer().apply { writeUtf8("Hello, world!") }
+        val body = Buffer().writeUtf8("Hello, world!")
         server.enqueue(MockResponse().setBody(body))
         val request = Request.Builder().url(serverUrl).build()
 
@@ -201,7 +201,7 @@ internal class ChuckerInterceptorTest {
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
     fun `plain text response body is available to consumer`(factory: ClientFactory) {
-        val body = Buffer().apply { writeUtf8("Hello, world!") }
+        val body = Buffer().writeUtf8("Hello, world!")
         server.enqueue(MockResponse().setBody(body))
         val request = Request.Builder().url(serverUrl).build()
 
@@ -328,7 +328,7 @@ internal class ChuckerInterceptorTest {
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
     fun `response is available to consumer if Chucker fails to save data`(factory: ClientFactory) {
-        val body = Buffer().apply { writeUtf8("Hello, world!") }
+        val body = Buffer().writeUtf8("Hello, world!")
         server.enqueue(MockResponse().setBody(body))
         val request = Request.Builder().url(serverUrl).build()
 
@@ -346,7 +346,7 @@ internal class ChuckerInterceptorTest {
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
     fun `transaction is available to Chucker if it fails to save data`(factory: ClientFactory) {
-        val body = Buffer().apply { writeUtf8("Hello, world!") }
+        val body = Buffer().writeUtf8("Hello, world!")
         server.enqueue(MockResponse().setBody(body))
         val request = Request.Builder().url(serverUrl).build()
 
@@ -366,7 +366,7 @@ internal class ChuckerInterceptorTest {
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
     fun `transaction is available to Chucker if it has no data cache`(factory: ClientFactory) {
-        val body = Buffer().apply { writeUtf8("Hello, world!") }
+        val body = Buffer().writeUtf8("Hello, world!")
         server.enqueue(MockResponse().setBody(body))
         val request = Request.Builder().url(serverUrl).build()
 
@@ -382,7 +382,7 @@ internal class ChuckerInterceptorTest {
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
     fun `response is available to consumer if Chucker has no data cache`(factory: ClientFactory) {
-        val body = Buffer().apply { writeUtf8("Hello, world!") }
+        val body = Buffer().writeUtf8("Hello, world!")
         server.enqueue(MockResponse().setBody(body))
         val request = Request.Builder().url(serverUrl).build()
 

--- a/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -564,7 +564,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun `headers size are computed before being redacted`(factory: ClientFactory) {
+    fun `header sizes are computed before being redacted`(factory: ClientFactory) {
         val chuckerInterceptor = ChuckerInterceptorDelegate(
             maxContentLength = SEGMENT_SIZE,
             headersToRedact = setOf("Header-To-Redact"),
@@ -612,7 +612,7 @@ internal class ChuckerInterceptorTest {
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)
-    fun `one short request body is available to server`(factory: ClientFactory) {
+    fun `one shot request body is available to server`(factory: ClientFactory) {
         server.enqueue(MockResponse())
         val client = factory.create(chuckerInterceptor)
 

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/ReportingSinkTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/ReportingSinkTest.kt
@@ -71,7 +71,7 @@ internal class ReportingSinkTest {
 
     private class TestSource(contentLength: Int = 1_000) : Source {
         val content: ByteString = ByteString.of(*Random.nextBytes(contentLength))
-        private val buffer = Buffer().apply { write(content) }
+        private val buffer = Buffer().write(content)
 
         override fun read(sink: Buffer, byteCount: Long): Long = buffer.read(sink, byteCount)
 

--- a/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
+++ b/library/src/test/java/com/chuckerteam/chucker/internal/support/TeeSourceTest.kt
@@ -84,7 +84,7 @@ internal class TeeSourceTest {
 
     private class TestSource(contentLength: Int = 1_000) : Source {
         val content: ByteString = ByteString.of(*Random.nextBytes(contentLength))
-        private val buffer = Buffer().apply { write(content) }
+        private val buffer = Buffer().write(content)
 
         override fun read(sink: Buffer, byteCount: Long): Long = buffer.read(sink, byteCount)
 


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

Small refactoring while investigating #714.

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

Fixed some typos and removed redundant use of `apply` on `okio.Buffer`.