### PR TITLE
Fix RTL issue in payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Please add your entries according to this format.
 * Fixed request headers not being redacted in case of failures [#545].
 * Fixed wrongful processing of one shot and duplex requests [#544].
 * Fixed writing to database on the main thread [#487].
+* Fixed RTL issue in payload view
 
 ### Removed
 

--- a/library/src/main/res/layout/chucker_transaction_item_body_line.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_body_line.xml
@@ -5,6 +5,7 @@
     android:layout_height="wrap_content"
     android:textIsSelectable="true"
     android:minLines="1"
+    android:textDirection="ltr"
     android:gravity="start"
     android:layout_marginHorizontal="@dimen/chucker_doub_grid"
     android:typeface="monospace" />


### PR DESCRIPTION
All TextView(s) must be LTR because in RTL language the payload will be affected and we have some problems

## :camera: Screenshots
<img width="401" alt="Screen Shot 2021-12-04 at 11 02 34 AM" src="https://user-images.githubusercontent.com/11220808/144701677-6950ae1c-5eb8-46f2-8ade-8e3582aa6051.png">


## :page_facing_up: Context
When our app is RTL mode we have some problems with payload texts.

## :pencil: Changes
I added force LTR text direction in payload items.