### PR TITLE
it's not push notification, it's a notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _A fork of [Chuck](https://github.com/jgilfelt/chuck)_
 
 Chucker simplifies the inspection of **HTTP(S) requests/responses** fired by your Android App. Chucker works as an **OkHttp Interceptor** persisting all those events inside your application, and providing a UI for inspecting and sharing their content.
 
-Apps using Chucker will display a **push notification** showing a summary of ongoing HTTP activity. Tapping on the notification launches the full Chucker UI. Apps can optionally suppress the notification, and launch the Chucker UI directly from within their own interface.
+Apps using Chucker will display a **notification** showing a summary of ongoing HTTP activity. Tapping on the notification launches the full Chucker UI. Apps can optionally suppress the notification, and launch the Chucker UI directly from within their own interface.
 
 <p align="center">
   <img src="assets/chucker-http.gif" alt="chucker http sample" width="50%"/>


### PR DESCRIPTION
https://developer.android.com/guide/topics/ui/notifiers/notifications
"A notification is a message that Android displays outside your app's UI"

push notification requires some network traffic, which I believe is not the case

## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
