### PR TITLE
It's not a push notification, it's a notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can customize chucker providing an instance of a `ChuckerCollector`:
 // Create the Collector
 val chuckerCollector = ChuckerCollector(
         context = this,
-        // Toggles visibility of the push notification
+        // Toggles visibility of the notification
         showNotification = true,
         // Allows to customize the retention period of collected data
         retentionPeriod = RetentionManager.Period.ONE_HOUR


### PR DESCRIPTION
The Chucker notification is incorrectly referred to as a push notification.

## :camera: Screenshots
 Documentation change only.

## :page_facing_up: Context
Just correcting some terminology.

## :pencil: Changes
Just removed one word from the Readme

## :paperclip: Related PR
None.

## :no_entry_sign: Breaking
No breaking changes.

## :hammer_and_wrench: How to test
Read the Readme.

## :stopwatch: Next steps
No next steps.
