### PR TITLE
Memory Leak with Toasts: Use applicationContext instead of Activity

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/Sharable.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/Sharable.kt
@@ -45,16 +45,17 @@ internal suspend fun Sharable.shareAsFile(
     clipDataLabel: String,
 ): Intent? {
     val cache = activity.cacheDir
+    val applicationContext = activity.applicationContext
     if (cache == null) {
         Logger.warn("Failed to obtain a valid cache directory for file export")
-        Toast.makeText(activity.applicationContext, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
+        Toast.makeText(applicationContext, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
         return null
     }
 
     val file = FileFactory.create(cache, fileName)
     if (file == null) {
         Logger.warn("Failed to create an export file")
-        Toast.makeText(activity.applicationContext, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
+        Toast.makeText(applicationContext, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
         return null
     }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/Sharable.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/Sharable.kt
@@ -47,14 +47,14 @@ internal suspend fun Sharable.shareAsFile(
     val cache = activity.cacheDir
     if (cache == null) {
         Logger.warn("Failed to obtain a valid cache directory for file export")
-        Toast.makeText(activity, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
+        Toast.makeText(activity.applicationContext, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
         return null
     }
 
     val file = FileFactory.create(cache, fileName)
     if (file == null) {
         Logger.warn("Failed to create an export file")
-        Toast.makeText(activity, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
+        Toast.makeText(activity.applicationContext, R.string.chucker_export_no_file, Toast.LENGTH_SHORT).show()
         return null
     }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/BaseChuckerActivity.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/BaseChuckerActivity.kt
@@ -28,6 +28,6 @@ internal abstract class BaseChuckerActivity : AppCompatActivity() {
     }
 
     fun showToast(message: String) {
-        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+        Toast.makeText(this.applicationContext, message, Toast.LENGTH_SHORT).show()
     }
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -136,12 +136,11 @@ internal class MainActivity :
     }
 
     private fun exportTransactions(fileName: String, block: suspend (List<HttpTransaction>) -> Sharable) {
+        val applicationContext = this.applicationContext
         lifecycleScope.launch {
             val transactions = viewModel.getAllTransactions()
             if (transactions.isNullOrEmpty()) {
-                Toast
-                    .makeText(this@MainActivity, R.string.chucker_export_empty_text, Toast.LENGTH_SHORT)
-                    .show()
+                showToast(applicationContext.getString(R.string.chucker_export_empty_text))
                 return@launch
             }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -43,6 +43,7 @@ internal class TransactionPayloadFragment :
 
     private val saveToFile = registerForActivityResult(ActivityResultContracts.CreateDocument()) { uri ->
         val transaction = viewModel.transaction.value
+        val applicationContext = requireContext().applicationContext
         if (uri != null && transaction != null) {
             lifecycleScope.launch {
                 val result = saveToFile(payloadType, uri, transaction)
@@ -51,11 +52,11 @@ internal class TransactionPayloadFragment :
                 } else {
                     R.string.chucker_file_not_saved
                 }
-                Toast.makeText(requireContext().applicationContext, toastMessageId, Toast.LENGTH_SHORT).show()
+                Toast.makeText(applicationContext, toastMessageId, Toast.LENGTH_SHORT).show()
             }
         } else {
             Toast.makeText(
-                requireContext().applicationContext,
+                applicationContext,
                 R.string.chucker_save_failed_to_open_document,
                 Toast.LENGTH_SHORT
             ).show()

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -51,11 +51,11 @@ internal class TransactionPayloadFragment :
                 } else {
                     R.string.chucker_file_not_saved
                 }
-                Toast.makeText(context, toastMessageId, Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext().applicationContext, toastMessageId, Toast.LENGTH_SHORT).show()
             }
         } else {
             Toast.makeText(
-                requireContext(),
+                requireContext().applicationContext,
                 R.string.chucker_save_failed_to_open_document,
                 Toast.LENGTH_SHORT
             ).show()


### PR DESCRIPTION
Saw a memory leak pop up in LeakCanary.  May be related to Toasts using Activity Context.

Android Docs suggest using ApplicationContext for Toasts: https://developer.android.com/guide/topics/ui/notifiers/toasts

## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->
<img width="914" alt="Screen Shot 2022-04-26 at 8 23 44 AM" src="https://user-images.githubusercontent.com/264948/165303633-bd17aedb-639f-42f0-82ec-822f38076215.png">

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

Issue found in Leak Canary.

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

Found all instances of `.makeText(` and ensured it's being passed `applicationContext`.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

No.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

Use these features of the library and ensure that the toasts are still properly shown.

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->

This is it, just merging.


----

Leak Trace from Leak Canary:
```
┬───
│ GC Root: Thread object
│
├─ ...RealLocalThumbManager$Thumbnailer instance
│    Leaking: NO (...Application↓ is not leaking)
│    Thread name: 'LocalThumbManager$Thumbnailer'
│    mContext instance of ...Application
│    ↓ RealLocalThumbManager$Thumbnailer.mContext
├─ ...Application instance
│    Leaking: NO (Application is a singleton)
│    mBase instance of android.app.ContextImpl
│    ↓ Application.mLoadedApk
│                  ~~~~~~~~~~
├─ android.app.LoadedApk instance
│    Leaking: UNKNOWN
│    Retaining 1.0 MB in 14258 objects
│    mApplication instance of ...Application
│    Receivers
│    ..HyperionService@333835072
│    ....HyperionService$OpenMenuReceiver@333837384
│    .....Application@325642976
│    ....LockReceiver@330442336
│    ....SystemBroadcastReceiver@329566192
│    ....K60@333852472
│    ....AppStateInitializerKt$registerReceivers$1@333852536
│    ....ak@333852600
│    ....f@333852656
│    ....ProxyChangeListener$ProxyReceiver@333852720
│    ....CancelUploadsIntentReceiver@333852784
│    ....ny0@327172256
│    ....w50@333852880
│    ....z6@333852936
│    ....VisibilityTracker@333853000
│    ....dl@333853072
│    ....Dispatcher$NetworkBroadcastReceiver@330534912
│    ....eo0@333853136
│    ....D6@333853200
│    ↓ LoadedApk.mServices
│                ~~~~~~~~~
├─ android.util.ArrayMap instance
│    Leaking: UNKNOWN
│    Retaining 999.3 kB in 14190 objects
│    ↓ ArrayMap.mArray
│               ~~~~~~
├─ java.lang.Object[] array
│    Leaking: UNKNOWN
│    Retaining 999.3 kB in 14188 objects
│    ↓ Object[4]
│            ~~~
╰→ com.chuckerteam.chucker.internal.ui.MainActivity instance
​     Leaking: YES (ObjectWatcher was watching this because com.chuckerteam.chucker.internal.ui.MainActivity received Activity#onDestroy() callback and Activity#mDestroyed is true)
​     Retaining 997.1 kB in 14153 objects
​     key = 0f6874e8-79a2-493d-b176-ab5db9ebdff6
​     watchDurationMillis = 6171
​     retainedDurationMillis = 1171
​     mApplication instance of ...Application
​     mBase instance of androidx.appcompat.view.ContextThemeWrapper
```