### PR TITLE
Adding chucker to diff. build types

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ dependencies {
   releaseImplementation "com.github.chuckerteam.chucker:library-no-op:3.5.2"
 }
 ```
+If you're using different build types for your project for example `releaseDebug` like below
+```
+releaseDebug {
+      minifyEnabled false
+      debuggable true
+      shrinkResources false
+      versionNameSuffix "-releaseDebug"
+    }
+```
+then, you need to add dependency by following the format `[buildType]Implementation`
+for example : buildType above is `releaseDebug`
+then add dependency like :-
+```groovy
+dependencies {
+    releaseDebugImplementation "com.github.chuckerteam.chucker:library:3.5.2"           // for chucker enabled
+    releaseDebugImplementation "com.github.chuckerteam.chucker:library-no-op:3.5.2"     // for chucker disabled
+}
+```
 
 To start using Chucker, just plug it a new `ChuckerInterceptor` to your OkHttp Client Builder:
 


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
The current method of adding dependency doesn't work for build types apart from `debug` and `release`

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->
Updated the implementation guide so that it can be implemented across android apps with different `buildTypes` as well.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

- Create new buildType with any name apart from `debug` and `release`
- Build the project and it'll fail.
- Now follow the implementation guide added with this PR.
- This will enable/disable the chucker for that particular `buildType`

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
