### PR TITLE
Switch to publishing with the AGP publishing DSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ buildscript {
         // Debug and quality control
         binaryCompatibilityValidator = '0.10.0'
         detektVersion = '1.20.0'
-        dokkaVersion = '1.6.10'
         ktLintGradleVersion = '10.3.0'
         leakcanaryVersion = '2.9.1'
 
@@ -51,7 +50,6 @@ buildscript {
         classpath "com.android.tools.build:gradle:$androidGradleVersion"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:$junitGradlePluignVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktLintGradleVersion"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:$binaryCompatibilityValidator"

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,114 +1,78 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: 'org.jetbrains.dokka'
 
 group = GROUP
 version = VERSION_NAME
 
-def dokka = tasks['dokkaJavadoc']
-
-dokkaJavadoc {
-    dokkaSourceSets {
-        configureEach {
-            includeNonPublic.set(false)
-            reportUndocumented.set(true)
-            skipEmptyPackages.set(true)
-
-            perPackageOption {
-                matchingRegex.set(".*\\.internal.*")
-                suppress.set(true)
+publishing {
+    repositories {
+        maven {
+            name "snapshot"
+            url = "https://oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username = findProperty("NEXUS_USERNAME")
+                password = findProperty("NEXUS_PASSWORD")
+            }
+        }
+        maven {
+            name "staging"
+            url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+            credentials {
+                username = findProperty("NEXUS_USERNAME")
+                password = findProperty("NEXUS_PASSWORD")
             }
         }
     }
-}
-
-
-task javadocJar(type: Jar, dependsOn: dokka) {
-    archiveClassifier.set('javadoc')
-    from dokka.outputDirectory
-}
-
-task sourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    from android.sourceSets.main.java.srcDirs
-}
-
-artifacts {
-    archives javadocJar
-    archives sourcesJar
-}
-
-afterEvaluate {
-    publishing {
-        repositories {
-            maven {
-                name "snapshot"
-                url = "https://oss.sonatype.org/content/repositories/snapshots"
-                credentials {
-                    username = findProperty("NEXUS_USERNAME")
-                    password = findProperty("NEXUS_PASSWORD")
-                }
-            }
-            maven {
-                name "staging"
-                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2"
-                credentials {
-                    username = findProperty("NEXUS_USERNAME")
-                    password = findProperty("NEXUS_PASSWORD")
-                }
-            }
-        }
-        publications {
-            release(MavenPublication) {
+    publications {
+        release(MavenPublication) {
+            afterEvaluate {
                 from components.release
-                artifact javadocJar
-                artifact sourcesJar
-                artifactId = project.name
-                pom {
-                    name = POM_REPO_NAME
-                    description = POM_DESCRIPTION
+            }
+            artifactId = project.name
+            pom {
+                name = POM_REPO_NAME
+                description = POM_DESCRIPTION
+                url = POM_URL
+                licenses {
+                    license {
+                        name = POM_LICENSE_NAME
+                        url = POM_LICENSE_URL
+                    }
+                }
+                scm {
+                    connection = POM_SCM_CONNECTION
+                    developerConnection = POM_SCM_CONNECTION
                     url = POM_URL
-                    licenses {
-                        license {
-                            name = POM_LICENSE_NAME
-                            url = POM_LICENSE_URL
-                        }
+                }
+                developers {
+                    developer {
+                        id = 'cortinico'
+                        name = 'Nicola Corti'
+                        email = 'corti.nico@gmail.com'
                     }
-                    scm {
-                        connection = POM_SCM_CONNECTION
-                        developerConnection = POM_SCM_CONNECTION
-                        url = POM_URL
+                    developer {
+                        id = 'vbuberen'
+                        name = 'Volodymyr Buberenko'
+                        email = 'v.buberenko@gmail.com'
                     }
-                    developers {
-                        developer {
-                            id = 'cortinico'
-                            name = 'Nicola Corti'
-                            email = 'corti.nico@gmail.com'
-                        }
-                        developer {
-                            id = 'vbuberen'
-                            name = 'Volodymyr Buberenko'
-                            email = 'v.buberenko@gmail.com'
-                        }
-                        developer {
-                            id = 'olivierperez'
-                            name = 'Olivier Perez'
-                            email = 'olivier@olivierperez.fr'
-                        }
+                    developer {
+                        id = 'olivierperez'
+                        name = 'Olivier Perez'
+                        email = 'olivier@olivierperez.fr'
                     }
                 }
             }
         }
     }
+}
 
-    def signingKey = findProperty("SIGNING_KEY")
-    def signingPwd = findProperty("SIGNING_PWD")
-    if (signingKey && signingPwd) {
-        signing {
-            useInMemoryPgpKeys(signingKey, signingPwd)
-            sign publishing.publications.release
-        }
-    } else {
-        logger.info("Signing Disable as the PGP key was not found")
+def signingKey = findProperty("SIGNING_KEY")
+def signingPwd = findProperty("SIGNING_PWD")
+if (signingKey && signingPwd) {
+    signing {
+        useInMemoryPgpKeys(signingKey, signingPwd)
+        sign publishing.publications.release
     }
+} else {
+    logger.info("Signing Disable as the PGP key was not found")
 }

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -27,6 +27,13 @@ android {
         // Don't fail build if some dependencies outdated
         disable 'GradleDependency'
     }
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -46,6 +46,13 @@ android {
     }
 
     resourcePrefix 'chucker_'
+
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## :page_facing_up: Context
Currently, the build outputs a warning about the AGP publishing DSL and requires to move to the new way of publishing Android Libraries. I'm addressing it here.

## :pencil: Changes
- Removed the explicit Dokka configuration, AGP is encapsulating it.
- Defined a single variant pubblication for both `library` and `library-no-op` picking their release variant

## :hammer_and_wrench: How to test
Verified locally with `gw publishToMavenLocal`. A Snapshot will also be published.