### PR TITLE
Fix various build warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,12 +77,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter {
-            content {
-                includeModule("org.jetbrains.trove4j", "trove4j")
-                includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
-            }
-        }
     }
 
     tasks.withType(Test) {

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -1,5 +1,5 @@
 build:
-  maxIssues: 1
+  maxIssues: 0
   weights:
     # complexity: 2
     # LongParameterList: 1
@@ -14,6 +14,9 @@ complexity:
   ComplexCondition:
     active: true
     threshold: 5
+  LongMethod:
+    active: true
+    excludes: ['**/test/**', '**/androidTest/**']
   LongParameterList:
     active: true
     ignoreDefaultParameters: true

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/Chucker.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 /**
  * No-op implementation.
  */
-@Suppress("UnusedPrivateMember")
+@Suppress("UnusedPrivateMember", "UNUSED_PARAMETER")
 public object Chucker {
 
     @Suppress("MayBeConst ") // https://github.com/ChuckerTeam/chucker/pull/169#discussion_r362341353

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -5,7 +5,7 @@ import android.content.Context
 /**
  * No-op implementation.
  */
-@Suppress("UnusedPrivateMember")
+@Suppress("UnusedPrivateMember", "UNUSED_PARAMETER")
 public class ChuckerCollector @JvmOverloads constructor(
     context: Context,
     public var showNotification: Boolean = true,

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -8,7 +8,7 @@ import java.io.IOException
 /**
  * No-op implementation.
  */
-@Suppress("UnusedPrivateMember")
+@Suppress("UnusedPrivateMember", "UNUSED_PARAMETER")
 public class ChuckerInterceptor private constructor(
     builder: Builder,
 ) : Interceptor {

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/RetentionManager.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/RetentionManager.kt
@@ -5,7 +5,7 @@ import android.content.Context
 /**
  * No-op implementation.
  */
-@Suppress("UnusedPrivateMember")
+@Suppress("UnusedPrivateMember", "UNUSED_PARAMETER")
 public class RetentionManager @JvmOverloads constructor(
     context: Context,
     retentionPeriod: Any? = null

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/har/ContentTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/har/ContentTest.kt
@@ -9,20 +9,20 @@ internal class ContentTest {
     fun `content is created correctly with size`() {
         val content = HarTestUtils.createContent("GET")
 
-        assertThat(content?.size).isEqualTo(1000)
+        assertThat(content.size).isEqualTo(1000)
     }
 
     @Test
     fun `content is created correctly with mime type`() {
         val content = HarTestUtils.createContent("GET")
 
-        assertThat(content?.mimeType).isEqualTo("application/json")
+        assertThat(content.mimeType).isEqualTo("application/json")
     }
 
     @Test
     fun `content is created correctly with fields and values`() {
         val content = HarTestUtils.createContent("GET")
 
-        assertThat(content?.text).isEqualTo("""{"field": "value"}""")
+        assertThat(content.text).isEqualTo("""{"field": "value"}""")
     }
 }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/har/EntryTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/har/EntryTest.kt
@@ -17,7 +17,7 @@ internal class EntryTest {
         val transaction = HarTestUtils.createTransaction("GET")
         val entry = HarTestUtils.createEntry("GET")
 
-        assertThat(Entry.DateFormat.get()!!.parse(entry?.startedDateTime))
+        assertThat(Entry.DateFormat.get()!!.parse(entry!!.startedDateTime))
             .isEqualTo(Date(transaction.requestDate!!))
     }
 


### PR DESCRIPTION
## :page_facing_up: Context
Just noticed we have a variety of build warnings I'd like to resolve as they're noisy and not really valuable.

## :pencil: Changes
- Remove jcenter()
- Set maxIssues for detekt to 0, and suppressed `LongMethod` on tests
- Suppressed UNUSED_PARAMETER on `library-no-op`
- Fixed several type inference issues in our tests

## :hammer_and_wrench: How to test
Essentially wait for a green CI.
