### PR TITLE
Bump Kotlin to 1.7.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 buildscript {
     ext {
-        kotlinVersion = '1.6.10'
+        kotlinVersion = '1.7.10'
         androidGradleVersion = '7.2.1'
-        coroutineVersion = '1.6.3'
+        coroutineVersion = '1.6.4'
 
         // Google libraries
         activityVersion = '1.5.0'
         appCompatVersion = '1.4.2'
         constraintLayoutVersion = '2.1.4'
         materialComponentsVersion = '1.6.1'
-        roomVersion = '2.4.2'
+        roomVersion = '2.4.3'
         fragmentVersion = '1.5.0'
         lifecycleVersion = '2.4.1'
         androidXCoreVersion = '2.1.0'

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -34,13 +34,13 @@ internal interface HttpTransactionDao {
     suspend fun update(transaction: HttpTransaction): Int
 
     @Query("DELETE FROM transactions")
-    suspend fun deleteAll()
+    suspend fun deleteAll(): Int
 
     @Query("SELECT * FROM transactions WHERE id = :id")
     fun getById(id: Long): LiveData<HttpTransaction?>
 
     @Query("DELETE FROM transactions WHERE requestDate <= :threshold")
-    suspend fun deleteBefore(threshold: Long)
+    suspend fun deleteBefore(threshold: Long): Int
 
     @Query("SELECT * FROM transactions")
     suspend fun getAll(): List<HttpTransaction>


### PR DESCRIPTION
## :page_facing_up: Context
I had to manually bump Kotlin to 1.7.10 as the compilation was failing on our Room classes.

## :paperclip: Related PR
Closes #846 
Closes #850 

## :hammer_and_wrench: How to test
Tests are attached

## :stopwatch: Next steps
N/A
