### PR TITLE
Support EventListener to decorate HttpTransaction recordings

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerEventListener.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerEventListener.kt
@@ -1,0 +1,75 @@
+package com.chuckerteam.chucker.api
+
+import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
+import okhttp3.Call
+import okhttp3.EventListener
+import okhttp3.Handshake
+import okhttp3.Protocol
+import java.io.IOException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Proxy
+
+internal class ChuckerEventListener constructor(
+    private val onCallEnded: ((Call) -> Unit)
+) : EventListener() {
+
+    val httpTransaction = HttpTransaction()
+
+    override fun callStart(call: Call) {
+        super.callStart(call)
+        httpTransaction.callStartDate = System.currentTimeMillis()
+    }
+
+    override fun callEnd(call: Call) {
+        super.callEnd(call)
+        onCallEnded(call)
+        httpTransaction.callEndDate = System.currentTimeMillis()
+    }
+
+    override fun callFailed(call: Call, ioe: IOException) {
+        super.callFailed(call, ioe)
+        onCallEnded(call)
+    }
+
+    override fun canceled(call: Call) {
+        super.canceled(call)
+        onCallEnded(call)
+    }
+
+    override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
+        super.connectStart(call, inetSocketAddress, proxy)
+        httpTransaction.connectStartDate = System.currentTimeMillis()
+    }
+
+    override fun connectEnd(
+        call: Call,
+        inetSocketAddress: InetSocketAddress,
+        proxy: Proxy,
+        protocol: Protocol?
+    ) {
+        super.connectEnd(call, inetSocketAddress, proxy, protocol)
+        httpTransaction.connectEndDate = System.currentTimeMillis()
+    }
+
+    override fun dnsStart(call: Call, domainName: String) {
+        super.dnsStart(call, domainName)
+        httpTransaction.dnsStartDate = System.currentTimeMillis()
+    }
+
+    override fun dnsEnd(call: Call, domainName: String, inetAddressList: List<InetAddress>) {
+        super.dnsEnd(call, domainName, inetAddressList)
+        httpTransaction.dnsEndDate = System.currentTimeMillis()
+    }
+
+    override fun secureConnectStart(call: Call) {
+        super.secureConnectStart(call)
+        httpTransaction.secureConnectStartDate = System.currentTimeMillis()
+    }
+
+    override fun secureConnectEnd(call: Call, handshake: Handshake?) {
+        super.secureConnectEnd(call, handshake)
+        httpTransaction.secureConnectEndDate = System.currentTimeMillis()
+    }
+
+}

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -56,6 +56,14 @@ internal class HttpTransaction(
     @ColumnInfo(name = "responseImageData") var responseImageData: ByteArray?,
     @ColumnInfo(name = "graphQlDetected") var graphQlDetected: Boolean = false,
     @ColumnInfo(name = "graphQlOperationName") var graphQlOperationName: String?,
+    @ColumnInfo(name = "callStartDate") var callStartDate: Long?,
+    @ColumnInfo(name = "callEndDate") var callEndDate: Long?,
+    @ColumnInfo(name = "connectStartDate") var connectStartDate: Long?,
+    @ColumnInfo(name = "connectEndDate") var connectEndDate: Long?,
+    @ColumnInfo(name = "secureConnectStartDate") var secureConnectStartDate: Long?,
+    @ColumnInfo(name = "secureConnectEndDate") var secureConnectEndDate: Long?,
+    @ColumnInfo(name = "dnsStartDate") var dnsStartDate: Long?,
+    @ColumnInfo(name = "dnsEndDate") var dnsEndDate: Long?,
 ) {
 
     @Ignore
@@ -85,7 +93,15 @@ internal class HttpTransaction(
         responseHeadersSize = null,
         responseBody = null,
         responseImageData = null,
-        graphQlOperationName = null
+        graphQlOperationName = null,
+        callStartDate = null,
+        callEndDate = null,
+        connectStartDate = null,
+        connectEndDate = null,
+        secureConnectStartDate = null,
+        secureConnectEndDate = null,
+        dnsStartDate = null,
+        dnsEndDate = null,
     )
 
     enum class Status {
@@ -109,6 +125,42 @@ internal class HttpTransaction(
 
     val durationString: String?
         get() = tookMs?.let { "$it ms" }
+    val callDurationString: String?
+        get() {
+            val start = callStartDate ?: return null
+            val end = callEndDate ?: return null
+            return (end - start).let { "$it ms" }
+        }
+
+    val connectDuration: Long?
+        get() {
+            val start = connectStartDate ?: return null
+            val end = connectEndDate ?: return null
+            return (end - start)
+        }
+    val connectDurationString: String?
+        get() = connectDuration?.let { "$it ms" }
+
+
+    val secureConnectDuration: Long?
+        get() {
+            val start = secureConnectStartDate ?: return null
+            val end = secureConnectEndDate ?: return null
+            return (end - start)
+        }
+
+    val secureConnectDurationString: String?
+        get() = secureConnectDuration?.let { "$it ms" }
+
+    val dnsDuration: Long?
+        get() {
+            val start = dnsStartDate ?: return null
+            val end = dnsEndDate ?: return null
+            return (end - start)
+        }
+
+    val dnsDurationString: String?
+        get() = dnsDuration?.let { "$it ms" }
 
     val requestSizeString: String
         get() = formatBytes(requestPayloadSize ?: 0)
@@ -211,6 +263,7 @@ internal class HttpTransaction(
             contentType.contains("xml", ignoreCase = true) -> FormatUtils.formatXml(body)
             contentType.contains("x-www-form-urlencoded", ignoreCase = true) ->
                 FormatUtils.formatUrlEncodedForm(body)
+
             else -> body
         }
     }
@@ -295,6 +348,14 @@ internal class HttpTransaction(
             (isResponseBodyEncoded == other.isResponseBodyEncoded) &&
             (responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) != false) &&
             (graphQlOperationName == other.graphQlOperationName) &&
-            (graphQlDetected == other.graphQlDetected)
+            (graphQlDetected == other.graphQlDetected) &&
+            (callStartDate == other.callStartDate) &&
+            (callEndDate == other.callEndDate) &&
+            (connectStartDate == other.connectStartDate) &&
+            (connectEndDate == other.connectEndDate) &&
+            (secureConnectStartDate == other.secureConnectStartDate) &&
+            (secureConnectEndDate == other.secureConnectEndDate) &&
+            (dnsStartDate == other.dnsStartDate) &&
+            (dnsEndDate == other.dnsEndDate)
     }
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/Timings.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/Timings.kt
@@ -17,6 +17,9 @@ internal data class Timings(
 ) {
     constructor(transaction: HttpTransaction) : this(
         wait = transaction.tookMs ?: 0,
+        dns = transaction.dnsDuration,
+        connect = transaction.connectDuration ?: 0,
+        ssl = transaction.secureConnectDuration
     )
 
     fun getTime(): Long {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -30,7 +30,7 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
 
     override suspend fun insertTransaction(transaction: HttpTransaction) {
         val id = transactionDao.insert(transaction)
-        transaction.id = id ?: 0
+        transaction.id = id
     }
 
     override suspend fun updateTransaction(transaction: HttpTransaction): Int {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 
-@Database(entities = [HttpTransaction::class], version = 9, exportSchema = false)
+@Database(entities = [HttpTransaction::class], version = 10, exportSchema = false)
 internal abstract class ChuckerDatabase : RoomDatabase() {
 
     abstract fun transactionDao(): HttpTransactionDao

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -28,7 +28,7 @@ internal interface HttpTransactionDao {
     fun getFilteredTuples(codeQuery: String, pathQuery: String): LiveData<List<HttpTransactionTuple>>
 
     @Insert
-    suspend fun insert(transaction: HttpTransaction): Long?
+    suspend fun insert(transaction: HttpTransaction): Long
 
     @Update(onConflict = OnConflictStrategy.REPLACE)
     suspend fun update(transaction: HttpTransaction): Int

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/HttpTransactionFactory.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/HttpTransactionFactory.kt
@@ -1,0 +1,37 @@
+package com.chuckerteam.chucker.internal.support
+
+import com.chuckerteam.chucker.api.ChuckerEventListener
+import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
+import okhttp3.Call
+import okhttp3.EventListener
+import java.util.concurrent.ConcurrentHashMap
+
+internal class RealChuckerEventListenerFactory : EventListener.Factory, HttpTransactionFactory {
+
+    private val httpTransactionHolder = ConcurrentHashMap<Call, ChuckerEventListener>()
+
+    override fun create(call: Call): EventListener {
+        val eventListener = ChuckerEventListener { httpTransactionHolder.remove(it) }
+        httpTransactionHolder[call] = eventListener
+
+        return eventListener
+    }
+
+    override fun getHttpTransaction(call: Call): HttpTransaction {
+        return httpTransactionHolder[call]?.httpTransaction
+            ?: error("HttpTransaction required before the Call was created")
+    }
+
+}
+
+internal interface HttpTransactionFactory {
+    fun getHttpTransaction(call: Call): HttpTransaction
+}
+
+internal class SimpleHttpTransactionFactory : HttpTransactionFactory {
+    override fun getHttpTransaction(call: Call): HttpTransaction {
+        return HttpTransaction()
+    }
+
+}
+

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionOverviewFragment.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.Observer
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerFragmentTransactionOverviewBinding
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
@@ -37,9 +36,8 @@ internal class TransactionOverviewFragment : Fragment() {
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         menu.findItem(R.id.save_body).isVisible = false
         viewModel.doesUrlRequireEncoding.observe(
-            viewLifecycleOwner,
-            Observer { menu.findItem(R.id.encode_url).isVisible = it }
-        )
+            viewLifecycleOwner
+        ) { menu.findItem(R.id.encode_url).isVisible = it }
 
         super.onCreateOptionsMenu(menu, inflater)
     }
@@ -48,9 +46,8 @@ internal class TransactionOverviewFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         viewModel.transaction.combineLatest(viewModel.encodeUrl).observe(
-            viewLifecycleOwner,
-            Observer { (transaction, encodeUrl) -> populateUI(transaction, encodeUrl) }
-        )
+            viewLifecycleOwner
+        ) { (transaction, encodeUrl) -> populateUI(transaction, encodeUrl) }
     }
 
     private fun populateUI(transaction: HttpTransaction?, encodeUrl: Boolean) {
@@ -84,6 +81,10 @@ internal class TransactionOverviewFragment : Fragment() {
             requestTime.text = transaction?.requestDateString
             responseTime.text = transaction?.responseDateString
             duration.text = transaction?.durationString
+            callDuration.text = transaction?.callDurationString
+            connectDuration.text = transaction?.connectDurationString
+            secureConnectDuration.text = transaction?.secureConnectDurationString
+            dnsDuration.text = transaction?.dnsDurationString
             requestSize.text = transaction?.requestSizeString
             responseSize.text = transaction?.responseSizeString
             totalSize.text = transaction?.totalSizeString

--- a/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_overview.xml
@@ -283,7 +283,87 @@
       app:layout_constraintTop_toBottomOf="@id/barrierResponseTime"
       tools:text="405 ms" />
 
-    <TextView
+      <TextView
+          style="@style/Chucker.TextAppearance.Label"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:text="Call duration"
+          app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/duration" />
+
+      <TextView
+          android:id="@+id/call_duration"
+          style="@style/Chucker.TextAppearance.Value"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+          app:layout_constraintTop_toBottomOf="@id/duration"
+          tools:text="705 ms" />
+
+      <TextView
+          style="@style/Chucker.TextAppearance.Label"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:text="Connect"
+          app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@id/call_duration" />
+
+      <TextView
+          android:id="@+id/connect_duration"
+          style="@style/Chucker.TextAppearance.Value"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+          app:layout_constraintTop_toBottomOf="@id/call_duration"
+          tools:text="105 ms" />
+
+      <TextView
+          style="@style/Chucker.TextAppearance.Label"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:text="SSL connect"
+          app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
+          app:layout_constraintHorizontal_bias="1.0"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@+id/connect_duration" />
+
+      <TextView
+          android:id="@+id/secure_connect_duration"
+          style="@style/Chucker.TextAppearance.Value"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="17dp"
+          app:layout_constraintTop_toBottomOf="@+id/connect_duration"
+          app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+          app:layout_constraintEnd_toEndOf="parent"
+          tools:text="109 ms" />
+
+      <TextView
+          style="@style/Chucker.TextAppearance.Label"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          android:text="Dns"
+          app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
+          app:layout_constraintHorizontal_bias="1.0"
+          app:layout_constraintStart_toStartOf="parent"
+          app:layout_constraintTop_toBottomOf="@+id/secure_connect_duration" />
+
+      <TextView
+          android:id="@+id/dns_duration"
+          style="@style/Chucker.TextAppearance.Value"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintHorizontal_bias="0.0"
+          app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+          app:layout_constraintTop_toBottomOf="@+id/secure_connect_duration"
+          tools:text="86 ms" />
+
+      <TextView
       android:id="@+id/requestSizeLabel"
       style="@style/Chucker.TextAppearance.Label"
       android:layout_width="0dp"
@@ -292,20 +372,20 @@
       android:text="@string/chucker_request_size"
       app:layout_constraintEnd_toStartOf="@id/overviewGuideline"
       app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@id/duration" />
+      app:layout_constraintTop_toBottomOf="@id/dns_duration" />
 
-    <TextView
-      android:id="@+id/requestSize"
-      style="@style/Chucker.TextAppearance.Value"
-      android:layout_width="0dp"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="@dimen/chucker_base_grid"
-      app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintStart_toStartOf="@id/overviewGuideline"
-      app:layout_constraintTop_toBottomOf="@id/duration"
-      tools:text="53 KB" />
+      <TextView
+          android:id="@+id/requestSize"
+          style="@style/Chucker.TextAppearance.Value"
+          android:layout_width="0dp"
+          android:layout_height="wrap_content"
+          app:layout_constraintEnd_toEndOf="parent"
+          app:layout_constraintHorizontal_bias="0.0"
+          app:layout_constraintStart_toStartOf="@id/overviewGuideline"
+          app:layout_constraintTop_toTopOf="@+id/requestSizeLabel"
+          tools:text="53 KB" />
 
-    <androidx.constraintlayout.widget.Barrier
+      <androidx.constraintlayout.widget.Barrier
       android:id="@+id/barrierRequestSize"
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -41,9 +41,6 @@ class MainActivity : AppCompatActivity() {
                     task.run()
                 }
             }
-            doGraphql.setOnClickListener {
-                GraphQlTask(client).run()
-            }
 
             launchChuckerDirectly.visibility = if (Chucker.isOp) View.VISIBLE else View.GONE
             launchChuckerDirectly.setOnClickListener { launchChuckerDirectly() }

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
@@ -32,6 +32,8 @@ fun createOkHttpClient(
         .addBodyDecoder(PokemonProtoBodyDecoder())
         .build()
 
+    val eventListenerFactory = chuckerInterceptor.useEventListener()
+
     return OkHttpClient.Builder()
         // Add a ChuckerInterceptor instance to your OkHttp client as an application or a network interceptor.
         // Learn more about interceptor types here – https://square.github.io/okhttp/interceptors.
@@ -39,6 +41,7 @@ fun createOkHttpClient(
         .addInterceptor(chuckerInterceptor.activeForType(InterceptorType.APPLICATION, interceptorTypeProvider))
         .addNetworkInterceptor(chuckerInterceptor.activeForType(InterceptorType.NETWORK, interceptorTypeProvider))
         .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
+        .eventListenerFactory(eventListenerFactory)
         .build()
 }
 


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

![image](https://user-images.githubusercontent.com/2102422/199328169-6033ed70-ac6d-47df-b5ba-96594306d19a.png)


## :page_facing_up: Context
Added EventListener to decorate recordings for HttoTransaction.

This will allow to record duration for:
- Call
- Connect
- Secure Connect
- Dns

## todo 
- create tests

I am not sure if this feature is interesting for a Chucker user, but wanted to send a PR to start a discussion of it