### PR TITLE
🔍  Filter transactions based on `graphqlOperationName`

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -12,7 +12,10 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
 
     override fun getFilteredTransactionTuples(code: String, path: String): LiveData<List<HttpTransactionTuple>> {
         val pathQuery = if (path.isNotEmpty()) "%$path%" else "%"
-        return transactionDao.getFilteredTuples("$code%", pathQuery)
+        return transactionDao.getFilteredTuples("$code%",
+            pathQuery =  pathQuery,
+            graphQlQuery =  pathQuery
+        )
     }
 
     override fun getTransaction(transactionId: Long): LiveData<HttpTransaction?> {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -14,6 +14,10 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
         val pathQuery = if (path.isNotEmpty()) "%$path%" else "%"
         return transactionDao.getFilteredTuples("$code%",
             pathQuery =  pathQuery,
+            /**
+            * Refer <a href='https://github.com/ChuckerTeam/chucker/issues/847">Issue #847</a> for
+            * more context
+            */
             graphQlQuery =  pathQuery
         )
     }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -25,8 +25,7 @@ internal interface HttpTransactionDao {
             "transactions WHERE responseCode LIKE :codeQuery AND (path LIKE :pathQuery OR " +
             "graphQlOperationName LIKE :pathQuery) ORDER BY requestDate DESC"
     )
-    fun getFilteredTuples(codeQuery: String, pathQuery: String):
-        LiveData<List<HttpTransactionTuple>>
+    fun getFilteredTuples(codeQuery: String, pathQuery: String): LiveData<List<HttpTransactionTuple>>
 
     @Insert
     suspend fun insert(transaction: HttpTransaction): Long?

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -22,10 +22,11 @@ internal interface HttpTransactionDao {
     @Query(
         "SELECT id, requestDate, tookMs, protocol, method, host, path, scheme, responseCode, " +
         "requestPayloadSize, responsePayloadSize, error, graphQLDetected, graphQlOperationName FROM " +
-            "transactions WHERE responseCode LIKE :codeQuery AND path LIKE :pathQuery " +
-            "ORDER BY requestDate DESC"
+            "transactions WHERE responseCode LIKE :codeQuery AND (path LIKE :pathQuery OR " +
+            "graphQlOperationName LIKE :pathQuery) ORDER BY requestDate DESC"
     )
-    fun getFilteredTuples(codeQuery: String, pathQuery: String): LiveData<List<HttpTransactionTuple>>
+    fun getFilteredTuples(codeQuery: String, pathQuery: String):
+        LiveData<List<HttpTransactionTuple>>
 
     @Insert
     suspend fun insert(transaction: HttpTransaction): Long?

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -23,9 +23,10 @@ internal interface HttpTransactionDao {
         "SELECT id, requestDate, tookMs, protocol, method, host, path, scheme, responseCode, " +
         "requestPayloadSize, responsePayloadSize, error, graphQLDetected, graphQlOperationName FROM " +
             "transactions WHERE responseCode LIKE :codeQuery AND (path LIKE :pathQuery OR " +
-            "graphQlOperationName LIKE :pathQuery) ORDER BY requestDate DESC"
+            "graphQlOperationName LIKE :graphQlQuery) ORDER BY requestDate DESC"
     )
-    fun getFilteredTuples(codeQuery: String, pathQuery: String): LiveData<List<HttpTransactionTuple>>
+    fun getFilteredTuples(codeQuery: String, pathQuery: String, graphQlQuery: String = ""):
+        LiveData<List<HttpTransactionTuple>>
 
     @Insert
     suspend fun insert(transaction: HttpTransaction): Long?

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
@@ -155,13 +155,20 @@ internal class HttpTransactionDatabaseRepositoryTest {
             createRequest("def").withResponseData().apply {
                 requestDate = 300L
             }
+        val transactionFour =
+            createRequest("graphql").withResponseData().apply {
+                requestDate = 400L
+                graphQlDetected = true
+                graphQlOperationName = "GefDefQuery"
+            }
 
         testObject.insertTransaction(transactionOne)
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
+        testObject.insertTransaction(transactionFour)
 
         testObject.getFilteredTransactionTuples(code = "", path = "def").observeForever { result ->
-            assertTuples(listOf(transactionThree, transactionTwo), result)
+            assertTuples(listOf(transactionFour,transactionThree, transactionTwo), result)
         }
     }
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepositoryTest.kt
@@ -155,20 +155,13 @@ internal class HttpTransactionDatabaseRepositoryTest {
             createRequest("def").withResponseData().apply {
                 requestDate = 300L
             }
-        val transactionFour =
-            createRequest("graphql").withResponseData().apply {
-                requestDate = 400L
-                graphQlDetected = true
-                graphQlOperationName = "GefDefQuery"
-            }
 
         testObject.insertTransaction(transactionOne)
         testObject.insertTransaction(transactionTwo)
         testObject.insertTransaction(transactionThree)
-        testObject.insertTransaction(transactionFour)
 
         testObject.getFilteredTransactionTuples(code = "", path = "def").observeForever { result ->
-            assertTuples(listOf(transactionFour,transactionThree, transactionTwo), result)
+            assertTuples(listOf(transactionThree, transactionTwo), result)
         }
     }
 
@@ -196,6 +189,70 @@ internal class HttpTransactionDatabaseRepositoryTest {
 
         testObject.getFilteredTransactionTuples(code = "4", path = "").observeForever { result ->
             assertTuples(listOf(transactionThree, transactionOne), result)
+        }
+    }
+
+    @Test
+    fun `transaction tuples are filtered by qraphQlOperationName`() = runBlocking {
+        val transactionOne =
+            createRequest("abc").withResponseData().apply {
+                requestDate = 200L
+                responseCode = 418
+            }
+        val transactionTwo =
+            createRequest("abcdef").withResponseData().apply {
+                requestDate = 100L
+                responseCode = 200
+            }
+        val transactionThree =
+            createRequest("def").withResponseData().apply {
+                requestDate = 300L
+                responseCode = 400
+            }
+        val transactionFour =
+            createRequest("def").withResponseData().apply {
+                requestDate = 400L
+                responseCode = 200
+                graphQlOperationName = "GetDefQuery"
+            }
+        testObject.insertTransaction(transactionOne)
+        testObject.insertTransaction(transactionTwo)
+        testObject.insertTransaction(transactionThree)
+        testObject.insertTransaction(transactionFour)
+        testObject.getFilteredTransactionTuples(code = "", path = "GetDe").observeForever { result ->
+            assertTuples(listOf(transactionFour), result)
+        }
+    }
+
+    @Test
+    fun `transaction tuples are not filtered by qraphQlOperationName when graphQLQuery is empty`() = runBlocking {
+        val transactionOne =
+            createRequest("abc").withResponseData().apply {
+                requestDate = 200L
+                responseCode = 418
+            }
+        val transactionTwo =
+            createRequest("abcdef").withResponseData().apply {
+                requestDate = 100L
+                responseCode = 200
+            }
+        val transactionThree =
+            createRequest("def").withResponseData().apply {
+                requestDate = 300L
+                responseCode = 400
+            }
+        val transactionFour =
+            createRequest("graphql").withResponseData().apply {
+                requestDate = 400L
+                responseCode = 200
+                graphQlOperationName = "GetDefQuery"
+            }
+        testObject.insertTransaction(transactionOne)
+        testObject.insertTransaction(transactionTwo)
+        testObject.insertTransaction(transactionThree)
+        testObject.insertTransaction(transactionFour)
+        testObject.getFilteredTransactionTuples(code = "", path = "").observeForever { result ->
+            assertTuples(listOf(transactionFour,transactionThree, transactionOne, transactionTwo), result)
         }
     }
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -184,13 +184,21 @@ internal class HttpTransactionDaoTest {
             createRequest("def").withResponseData().apply {
                 requestDate = 300L
             }
+        val transactionFour =
+            createRequest("graphql").withResponseData().apply {
+                requestDate = 400L
+                graphQlDetected = true
+                graphQlOperationName = "GefAbcQuery"
+            }
+
 
         insertTransaction(transactionOne)
         insertTransaction(transactionTwo)
         insertTransaction(transactionThree)
+        insertTransaction(transactionFour)
 
         testObject.getFilteredTuples(codeQuery = "418", pathQuery = "%abc%").observeForever { result ->
-            assertTuples(listOf(transactionOne, transactionTwo), result)
+            assertTuples(listOf(transactionFour, transactionOne, transactionTwo), result)
         }
     }
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -221,7 +221,7 @@ internal class HttpTransactionDaoTest {
         insertTransaction(transactionThree)
         insertTransaction(transactionFour)
 
-        testObject.getFilteredTuples(codeQuery = "200", pathQuery = "%get%", graphQlQuery = "%get%")
+        testObject.getFilteredTuples(codeQuery = "%", pathQuery = "%get%", graphQlQuery = "%get%")
             .observeForever { result ->
             assertTuples(listOf(transactionFour), result)
         }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -184,21 +184,46 @@ internal class HttpTransactionDaoTest {
             createRequest("def").withResponseData().apply {
                 requestDate = 300L
             }
+
+        insertTransaction(transactionOne)
+        insertTransaction(transactionTwo)
+        insertTransaction(transactionThree)
+
+        testObject.getFilteredTuples(codeQuery = "418", pathQuery = "%abc%").observeForever { result ->
+            assertTuples(listOf(transactionOne, transactionTwo), result)
+        }
+    }
+
+    @Test
+    fun `transaction tuples are filtered by graphQLOperationName`() = runBlocking {
+        val transactionOne =
+            createRequest("abc").withResponseData().apply {
+                requestDate = 200L
+            }
+        val transactionTwo =
+            createRequest("abcdef").withResponseData().apply {
+                requestDate = 100L
+            }
+        val transactionThree =
+            createRequest("def").withResponseData().apply {
+                requestDate = 300L
+            }
         val transactionFour =
             createRequest("graphql").withResponseData().apply {
+                method = "POST"
                 requestDate = 400L
-                graphQlDetected = true
-                graphQlOperationName = "GefAbcQuery"
+                responseCode = 200
+                graphQlOperationName = "GetDefQuery"
             }
-
 
         insertTransaction(transactionOne)
         insertTransaction(transactionTwo)
         insertTransaction(transactionThree)
         insertTransaction(transactionFour)
 
-        testObject.getFilteredTuples(codeQuery = "418", pathQuery = "%abc%").observeForever { result ->
-            assertTuples(listOf(transactionFour, transactionOne, transactionTwo), result)
+        testObject.getFilteredTuples(codeQuery = "200", pathQuery = "%get%", graphQlQuery = "%get%")
+            .observeForever { result ->
+            assertTuples(listOf(transactionFour), result)
         }
     }
 


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

<img src="https://user-images.githubusercontent.com/97124666/200592914-56e69493-6461-4eb7-ba03-dfb8a0818810.gif" width="300" height="550"/>

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
[issue#847](https://github.com/ChuckerTeam/chucker/issues/847)
## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->
1. Added a clause to the `getFilteredTuples` in the `HttpTransactionDao.kt` which enables filtering on the basis of `GraphQLOperationName`.  
In order to avoid any breaking changes the `pathQuery` argument is utilized to filter on the basis of `graphQLOperationName`.
I'm wondering if the argument name could be renamed to `filterQuery`? 
2. Tests in `HttpTransactionDatabaseRepositoryTest.kt` & `HttpTransactionDaoTest.kt` have been updated
## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->
🚫 
## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->
🚫 
## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->
1. Launch Chucker Sample.
2. Click on `DO HTTP ACTIVITY` & `DO GRAPHQL ACTIVITY`
3. Click `LAUNCH CHUCKER ACTIVITY`
4. Click on the Search icon. And type "sea"
Chucker should filter the transactions and display a GraphQL transaction with the operation name as `SearchCharacters`
## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
