### PR TITLE
Add `skipPaths` to selectively skip requests from Chucker

### DIFF
--- a/library-no-op/api/library-no-op.api
+++ b/library-no-op/api/library-no-op.api
@@ -38,6 +38,7 @@ public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
 	public final fun maxContentLength (J)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders (Ljava/lang/Iterable;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipPaths (Ljava/util/List;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 }
 
 public final class com/chuckerteam/chucker/api/ExportFormat : java/lang/Enum {

--- a/library-no-op/api/library-no-op.api
+++ b/library-no-op/api/library-no-op.api
@@ -38,7 +38,7 @@ public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
 	public final fun maxContentLength (J)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders (Ljava/lang/Iterable;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
-	public final fun skipPaths (Ljava/util/List;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipPaths ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 }
 
 public final class com/chuckerteam/chucker/api/ExportFormat : java/lang/Enum {

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -46,7 +46,7 @@ public class ChuckerInterceptor private constructor(
 
         public fun createShortcut(enable: Boolean): Builder = this
 
-        public fun skipPaths(paths: List<String>): Builder = this
+        public fun skipPaths(vararg paths: String): Builder = this
 
         public fun build(): ChuckerInterceptor = ChuckerInterceptor(this)
     }

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -46,6 +46,8 @@ public class ChuckerInterceptor private constructor(
 
         public fun createShortcut(enable: Boolean): Builder = this
 
+        public fun skipPaths(paths: List<String>): Builder = this
+
         public fun build(): ChuckerInterceptor = ChuckerInterceptor(this)
     }
 }

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -38,6 +38,7 @@ public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
 	public final fun maxContentLength (J)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders (Ljava/lang/Iterable;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipPaths (Ljava/util/List;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 }
 
 public final class com/chuckerteam/chucker/api/ExportFormat : java/lang/Enum {

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -38,7 +38,7 @@ public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
 	public final fun maxContentLength (J)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders (Ljava/lang/Iterable;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
-	public final fun skipPaths (Ljava/util/List;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipPaths ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 }
 
 public final class com/chuckerteam/chucker/api/ExportFormat : java/lang/Enum {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -77,10 +77,10 @@ public class ChuckerInterceptor private constructor(
         }
         val response = try {
             chain.proceed(request)
-        } catch (exception: IOException) {
-            transaction.error = exception.toString()
+        } catch (e: IOException) {
+            transaction.error = e.toString()
             collector.onResponseReceived(transaction)
-            throw exception
+            throw e
         }
         return if(shouldProcessTheRequest)
             responseProcessor.process(response,transaction)

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -170,7 +170,7 @@ public class ChuckerInterceptor private constructor(
             this.cacheDirectoryProvider = provider
         }
 
-        public fun skipPaths(skipPaths: List<String>): Builder = apply {
+        public fun skipPaths(vararg skipPaths: String): Builder = apply {
             skipPaths.forEach { candidatePath ->
                 val httpUrl = HttpUrl.Builder()
                     .scheme("https")

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -178,9 +178,10 @@ public class ChuckerInterceptor private constructor(
 
         private fun processSkipPaths(candidatePath: String) {
             if (candidatePath.isNotBlank()) {
-                candidatePath.toHttpUrlOrNull()
+                val nullableHttpUrl = candidatePath.toHttpUrlOrNull()
                     ?: "http://localhost:8080$candidatePath".toHttpUrlOrNull()
-                        ?.let { validHttpUrl ->
+
+                nullableHttpUrl?.let { validHttpUrl ->
                             this@Builder.skipPaths.add(validHttpUrl.encodedPath)
                         }
             }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -7,7 +7,7 @@ import com.chuckerteam.chucker.internal.support.CacheDirectoryProvider
 import com.chuckerteam.chucker.internal.support.PlainTextDecoder
 import com.chuckerteam.chucker.internal.support.RequestProcessor
 import com.chuckerteam.chucker.internal.support.ResponseProcessor
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
@@ -172,18 +172,11 @@ public class ChuckerInterceptor private constructor(
 
         public fun skipPaths(skipPaths: List<String>): Builder = apply {
             skipPaths.forEach { candidatePath ->
-                processSkipPaths(candidatePath)
-            }
-        }
-
-        private fun processSkipPaths(candidatePath: String) {
-            if (candidatePath.isNotBlank()) {
-                val nullableHttpUrl = candidatePath.toHttpUrlOrNull()
-                    ?: "http://localhost:8080$candidatePath".toHttpUrlOrNull()
-
-                nullableHttpUrl?.let { validHttpUrl ->
-                            this@Builder.skipPaths.add(validHttpUrl.encodedPath)
-                        }
+                val httpUrl = HttpUrl.Builder()
+                    .scheme("https")
+                    .host("example.com")
+                    .addPathSegment(candidatePath).build()
+                this@Builder.skipPaths.add(httpUrl.encodedPath)
             }
         }
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -657,11 +657,11 @@ internal class ChuckerInterceptorTest {
             skipPaths = listOf(
                 "",
                 "    ",
-                "bla",
-                "www.bla.c/skip/path",
-                "bla.c/skip/path",
+                "example",
+                "www.example.com/skip/path",
+                "example.com/skip/path",
                 "90",
-                "https://bla/",
+                "https://example/",
                 "/skip/path",
                 "/skip//",
                 "http://localhost:8080/skip/path/ext"
@@ -684,7 +684,7 @@ internal class ChuckerInterceptorTest {
         executeRequestForPath(client,"90","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
-        executeRequestForPath(client,"https://bla/","Hello, world!")
+        executeRequestForPath(client,"https://example/","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
         executeRequestForPath(client,"/skip/path","Hello, world!")

--- a/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -47,7 +47,7 @@ internal class ChuckerInterceptorTest {
     @TempDir
     lateinit var tempDir: File
     private val chuckerInterceptor =
-        ChuckerInterceptorDelegate(cacheDirectoryProvider = { tempDir } )
+        ChuckerInterceptorDelegate(cacheDirectoryProvider = { tempDir })
 
     @ParameterizedTest
     @EnumSource(value = ClientFactory::class)

--- a/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -675,25 +675,25 @@ internal class ChuckerInterceptorTest {
         executeRequestForPath(client,"    ","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
-        executeRequestForPath(client,"www.bla.c/skip/path","Hello, world!")
+        executeRequestForPath(client,"www.example.com/skip/path","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
-        executeRequestForPath(client,"bla.c/skip/path","Hello, world!")
+        executeRequestForPath(client,"example.com/skip/path","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
-        executeRequestForPath(client, "90","Hello, world!")
+        executeRequestForPath(client,"90","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
-        executeRequestForPath(client, "https://bla/","Hello, world!")
+        executeRequestForPath(client,"https://bla/","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
-        executeRequestForPath(client, "/skip/path","Hello, world!")
+        executeRequestForPath(client,"/skip/path","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
-        executeRequestForPath(client, "/skip//","Hello, world!")
+        executeRequestForPath(client,"/skip//","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
-        executeRequestForPath(client, "http://localhost:8080/skip/path/ext","Hello, world!")
+        executeRequestForPath(client,"http://localhost:8080/skip/path/ext","Hello, world!")
         chuckerInterceptorWithoutSkipping.expectNoTransactions()
     }
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
@@ -43,7 +43,7 @@ internal class ChuckerInterceptorDelegate(
         .redactHeaders(headersToRedact)
         .alwaysReadResponseBody(alwaysReadResponseBody)
         .cacheDirectorProvider(cacheDirectoryProvider)
-        .skipPaths(skipPaths = skipPaths.map{it}.toTypedArray())
+        .skipPaths(skipPaths = skipPaths.toTypedArray())
         .apply { decoders.forEach(::addBodyDecoder) }
         .build()
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
@@ -43,7 +43,7 @@ internal class ChuckerInterceptorDelegate(
         .redactHeaders(headersToRedact)
         .alwaysReadResponseBody(alwaysReadResponseBody)
         .cacheDirectorProvider(cacheDirectoryProvider)
-        .skipPaths(skipPaths)
+        .skipPaths(skipPaths = skipPaths.map{it}.toTypedArray())
         .apply { decoders.forEach(::addBodyDecoder) }
         .build()
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
@@ -10,7 +10,6 @@ import com.chuckerteam.chucker.internal.support.CacheDirectoryProvider
 import io.mockk.every
 import io.mockk.mockk
 import okhttp3.Interceptor
-import okhttp3.Request
 import okhttp3.Response
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicLong
@@ -21,7 +20,7 @@ internal class ChuckerInterceptorDelegate(
     alwaysReadResponseBody: Boolean = false,
     cacheDirectoryProvider: CacheDirectoryProvider,
     decoders: List<BodyDecoder> = emptyList(),
-    skipEndpoints: List<(Request) -> Boolean> = emptyList()
+    skipPaths: List<String> = emptyList()
 ) : Interceptor {
     private val idGenerator = AtomicLong()
     private val transactions = CopyOnWriteArrayList<HttpTransaction>()
@@ -44,7 +43,7 @@ internal class ChuckerInterceptorDelegate(
         .redactHeaders(headersToRedact)
         .alwaysReadResponseBody(alwaysReadResponseBody)
         .cacheDirectorProvider(cacheDirectoryProvider)
-        .skipEndpoints(skipEndpoints)
+        .skipPaths(skipPaths)
         .apply { decoders.forEach(::addBodyDecoder) }
         .build()
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
@@ -10,6 +10,7 @@ import com.chuckerteam.chucker.internal.support.CacheDirectoryProvider
 import io.mockk.every
 import io.mockk.mockk
 import okhttp3.Interceptor
+import okhttp3.Request
 import okhttp3.Response
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicLong
@@ -20,6 +21,7 @@ internal class ChuckerInterceptorDelegate(
     alwaysReadResponseBody: Boolean = false,
     cacheDirectoryProvider: CacheDirectoryProvider,
     decoders: List<BodyDecoder> = emptyList(),
+    skipEndpoints: List<(Request) -> Boolean> = emptyList()
 ) : Interceptor {
     private val idGenerator = AtomicLong()
     private val transactions = CopyOnWriteArrayList<HttpTransaction>()
@@ -42,6 +44,7 @@ internal class ChuckerInterceptorDelegate(
         .redactHeaders(headersToRedact)
         .alwaysReadResponseBody(alwaysReadResponseBody)
         .cacheDirectorProvider(cacheDirectoryProvider)
+        .skipEndpoints(skipEndpoints)
         .apply { decoders.forEach(::addBodyDecoder) }
         .build()
 

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/HttpBinHttpTask.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/HttpBinHttpTask.kt
@@ -78,6 +78,7 @@ class HttpBinHttpTask(
         redirectTo("https://ascii.cl?parameter=\"Click on 'URL Encode'!\"").enqueue(noOpCallback)
         postForm("Value 1", "Value with symbols &$%").enqueue(noOpCallback)
         postRawRequestBody(oneShotRequestBody()).enqueue(noOpCallback)
+        anything().enqueue(noOpCallback)
     }
 
     private fun oneShotRequestBody() = object : RequestBody() {
@@ -189,6 +190,9 @@ class HttpBinHttpTask(
 
         @POST("/post")
         fun postRawRequestBody(@Body body: RequestBody): Call<Any?>
+
+        @GET("/anything")
+        fun anything():Call<Any?>
 
         class Data(val thing: String)
     }

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
@@ -28,7 +28,7 @@ fun createOkHttpClient(
         .collector(collector)
         .maxContentLength(250_000L)
         .redactHeaders(emptySet())
-        .skipPaths(listOf("/anything"))
+        .skipPaths("/anything")
         .alwaysReadResponseBody(false)
         .addBodyDecoder(PokemonProtoBodyDecoder())
         .build()

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
@@ -28,7 +28,7 @@ fun createOkHttpClient(
         .collector(collector)
         .maxContentLength(250_000L)
         .redactHeaders(emptySet())
-        .skipPaths("/anything")
+        .skipPaths("anything")
         .alwaysReadResponseBody(false)
         .addBodyDecoder(PokemonProtoBodyDecoder())
         .build()

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
@@ -28,6 +28,7 @@ fun createOkHttpClient(
         .collector(collector)
         .maxContentLength(250_000L)
         .redactHeaders(emptySet())
+        .skipPaths(listOf("/anything"))
         .alwaysReadResponseBody(false)
         .addBodyDecoder(PokemonProtoBodyDecoder())
         .build()


### PR DESCRIPTION
<!-- ## :camera: Screenshots
 Show us what you've changed, we love images. -->

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
Fixes #266 

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->
I added a public API, `skipPaths(paths:List<String>)`, to the `ChuckerInterceptor.Builer`. 
The ChuckerInterceptor decides to process the transaction based on the outcome of the lambda in `skipEndpoints`.
<!--## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->
Adding `skipPaths(..)` to the `ChuckerInterceptor.Build` will be a breaking change. 
## :hammer_and_wrench: How to test
- Added tests to `ChuckerInterceptorTest`
- I've also added another endpoint `/anything` to the [HttpBinHttpTask.kt](sample/src/main/kotlin/com/chuckerteam/chucker/sample/HttpBinHttpTask.kt) and added `/anything` to the skip paths list in the sample app.

<!--## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
