### PR TITLE
Fix apollo deprecation

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -65,11 +65,13 @@ android {
 }
 
 apollo {
-    packageName.set("com.chuckerteam.chucker.sample")
-    schemaFile.set(file("src/main/graphql/com/chuckerteam/chucker/sample/schema.json.graphql"))
-    srcDir("src/main/graphql")
-    excludes.add("**/schema.json.graphql")
-    excludes.add("**/schema.json")
+    service("rickandmortyapi") {
+        packageName.set("com.chuckerteam.chucker.sample")
+        schemaFile.set(file("src/main/graphql/com/chuckerteam/chucker/sample/schema.json.graphql"))
+        srcDir("src/main/graphql")
+        excludes.add("**/schema.json.graphql")
+        excludes.add("**/schema.json")
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## :page_facing_up: Context
This fixes the deprecation we have on the Apollo Gradle Plugin:

```
> Configure project :sample
Apollo: using the default service is deprecated and will be removed in a future version. Please define your service explicitly:

apollo {
  service("service") {
    packageName.set("com.chuckerteam.chucker.sample")
  }
}
```

## :pencil: Changes
See above

## :paperclip: Related PR
n/a

## :no_entry_sign: Breaking
n/a

## :hammer_and_wrench: How to test
If the app builds, we're good to go 👍 