### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @ChuckerTeam/default-reviewers


### PR DESCRIPTION
## :page_facing_up: Context
This creates the `CODEOWNERS` so we get automatically added as required reviewers whenever a new PR is incoming. That's controlled via the https://github.com/orgs/ChuckerTeam/teams/default-reviewers team.