### PR TITLE
Fix sample app on smaller devices

### DIFF
--- a/sample/src/main/res/layout-land/activity_main_sample.xml
+++ b/sample/src/main/res/layout-land/activity_main_sample.xml
@@ -84,7 +84,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/do_http"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/doub_grid_size"
         android:layout_marginBottom="@dimen/doub_grid_size"
         android:text="@string/do_http_activity"
@@ -96,7 +96,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/do_graphql"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/doub_grid_size"
         android:layout_marginBottom="@dimen/doub_grid_size"
         android:text="@string/do_graphql_activity"
@@ -108,7 +108,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/launch_chucker_directly"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/doub_grid_size"
         android:text="@string/launch_chucker_directly"
         app:layout_constraintEnd_toEndOf="parent"
@@ -119,7 +119,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/export_to_file"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/doub_grid_size"
         android:layout_marginEnd="@dimen/doub_grid_size"
         android:text="@string/export_to_file"
@@ -133,7 +133,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/export_to_file_har"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/doub_grid_size"
         android:text="@string/export_to_file_har"
         app:layout_constraintBottom_toBottomOf="@+id/export_to_file"

--- a/sample/src/main/res/layout/activity_main_sample.xml
+++ b/sample/src/main/res/layout/activity_main_sample.xml
@@ -8,31 +8,18 @@
     tools:context="com.chuckerteam.chucker.sample.MainActivity">
 
     <TextView
-        android:id="@+id/title"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/doub_grid_size"
-        android:gravity="center"
-        android:text="@string/intro_title"
-        android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
-        app:layout_constraintBottom_toTopOf="@+id/description"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed"
-        app:layout_constraintWidth_max="@dimen/max_width" />
-
-    <TextView
         android:id="@+id/description"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:text="@string/intro_body"
+        android:layout_marginBottom="@dimen/norm_grid_size"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
-        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintBottom_toTopOf="@+id/interceptor_type_label"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title"
+        app:layout_constraintTop_toBottomOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
     <com.google.android.material.textview.MaterialTextView
@@ -41,10 +28,10 @@
         android:layout_height="wrap_content"
         android:text="@string/interceptor_type"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
-        app:layout_constraintBottom_toTopOf="@+id/interceptor_type_group"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/guideline"
+        app:layout_constraintTop_toBottomOf="@+id/description"
+        app:layout_constraintBottom_toTopOf="@+id/interceptor_type_group"
         app:layout_constraintVertical_chainStyle="packed"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
@@ -80,7 +67,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/do_http"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/doub_grid_size"
         android:text="@string/do_http_activity"
         app:layout_constraintEnd_toEndOf="parent"
@@ -91,7 +78,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/do_graphql"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:text="@string/do_graphql_activity"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -101,7 +88,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/launch_chucker_directly"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/doub_grid_size"
         android:text="@string/launch_chucker_directly"
         app:layout_constraintBottom_toTopOf="@id/export_to_file"
@@ -113,7 +100,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/export_to_file"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/doub_grid_size"
         android:text="@string/export_to_file"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -126,7 +113,7 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/export_to_file_har"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:text="@string/export_to_file_har"
         app:layout_constraintBottom_toBottomOf="@+id/export_to_file"
         app:layout_constraintEnd_toEndOf="parent"
@@ -134,12 +121,5 @@
         app:layout_constraintStart_toEndOf="@+id/export_to_file"
         app:layout_constraintTop_toTopOf="@+id/export_to_file"
         app:layout_constraintWidth_max="@dimen/max_width" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.4" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Chucker Sample</string>
+    <string name="app_name">Chucker Sample App</string>
     <string name="interceptor_type"><a href="https://square.github.io/okhttp/interceptors/">Interceptor type</a>:</string>
     <string name="application_type">Application</string>
     <string name="network_type">Network</string>


### PR DESCRIPTION
## :page_facing_up: Context
I've just noticed that the sample app looks really odd on my mdpi emulator. I'm fixing the layout here.

## :camera: Screenshots
| Before | After |
| -- | -- |
| ![Screenshot_1677327199](https://user-images.githubusercontent.com/3001957/221356506-16eb8a81-d742-44d8-b790-e015f1fa5123.png) | ![Screenshot_1677327535](https://user-images.githubusercontent.com/3001957/221356513-e5704581-038c-49b1-9521-1374bd8ce608.png) |

## :pencil: Changes
I've also removed the `title` as we already have the app bar occupying space.

## :paperclip: Related PR
n/a

## :no_entry_sign: Breaking
none

## :hammer_and_wrench: How to test
See the screenshots

## :stopwatch: Next steps
n/a