### PR TITLE
Fix `DiskReadViolation` on ChuckerCollector

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerCollector.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerCollector.kt
@@ -47,7 +47,9 @@ public class ChuckerCollector @JvmOverloads constructor(
      */
     internal fun onRequestSent(transaction: HttpTransaction) {
         scope.launch {
-            RepositoryProvider.transaction().insertTransaction(transaction)
+            withContext(Dispatchers.IO) {
+                RepositoryProvider.transaction().insertTransaction(transaction)
+            }
 
             if (showNotification) {
                 notificationHelper.show(transaction)
@@ -65,7 +67,9 @@ public class ChuckerCollector @JvmOverloads constructor(
      */
     internal fun onResponseReceived(transaction: HttpTransaction) {
         scope.launch {
-            val updated = RepositoryProvider.transaction().updateTransaction(transaction)
+            val updated = withContext(Dispatchers.IO) {
+                RepositoryProvider.transaction().updateTransaction(transaction)
+            }
             if (showNotification && updated > 0) {
                 notificationHelper.show(transaction)
             }


### PR DESCRIPTION
## :page_facing_up: Context
The sample app is insta-crashing when doing http activity.
That happens because we're calling `RepositoryProvider.transaction()....` on the UI thread.

## 🔴 Video
| Before | After |
| -- | -- |
| ![before](https://user-images.githubusercontent.com/3001957/221365546-b79f4533-ad7f-47d6-8166-0debf02f9cbf.mp4) | ![after](https://user-images.githubusercontent.com/3001957/221365560-c9e73d9c-14d4-426e-b7bc-36211d601489.mp4) |

## :no_entry_sign: Breaking
nope

## :hammer_and_wrench: How to test
See the atteched video

## :stopwatch: Next steps
n/a