### PR TITLE
Do not kill the app on Leaked Closeable

### DIFF
--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -75,7 +75,6 @@ class MainActivity : AppCompatActivity() {
             StrictMode.VmPolicy.Builder()
                 .detectLeakedClosableObjects()
                 .penaltyLog()
-                .penaltyDeath()
                 .build()
         )
 


### PR DESCRIPTION
## :page_facing_up: Context
Our Sample app is crashing due to `LeakedClosableViolation`. I believe there is an underlying leak in the framework somewhere. I've reported this to Google here:
https://issuetracker.google.com/issues/270704908

In the meanwhile, I'd move the `LeakedClosableViolation` to just log and don't crash the app till we understand what's causing the change.

## :hammer_and_wrench: How to test
Try the sample app and verify it doesn't crash with:

```
StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks. Callsite: close
  at android.os.StrictMode$AndroidCloseGuardReporter.report(StrictMode.java:1992)
  at dalvik.system.CloseGuard.warnIfOpen(CloseGuard.java:347)
  at sun.nio.fs.UnixSecureDirectoryStream.finalize(UnixSecureDirectoryStream.java:580)
  at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:291)
  at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:278)
  at java.lang.Daemons$Daemon.run(Daemons.java:139)
  at java.lang.Thread.run(Thread.java:920)
```

## :stopwatch: Next steps
We'll need to re-enable this at some point, not sure how (create an issue for it)?
