### PR TITLE
Use JDK Toolchain for 11

### DIFF
--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -10,12 +10,12 @@ android {
             '-module-name', "com.github.ChuckerTeam.Chucker.library-no-op",
             "-Xexplicit-api=strict"
         ]
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+    kotlin {
+        jvmToolchain(11)
     }
 
     buildFeatures {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,12 +21,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+    kotlin {
+        jvmToolchain(11)
     }
 
     buildFeatures {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -55,12 +55,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+    kotlin {
+        jvmToolchain(11)
     }
 }
 


### PR DESCRIPTION
## :page_facing_up: Context
When we bumped to AGP 8, I also updated JDK version to 17.
The problem is that now the .jar are created with source/target version of Java 17, so they're unusable on older version of Java.
This fixes it.

## :paperclip: Related PR
Fixes #1019
Fixes #1010

## :no_entry_sign: Breaking
Nop

## :hammer_and_wrench: How to test
The CI should be able to build

## :stopwatch: Next steps
N/A
