### PR TITLE
Fix HAR output issue

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/Response.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/Response.kt
@@ -2,6 +2,7 @@ package com.chuckerteam.chucker.internal.data.har.log.entry
 
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.har.log.entry.response.Content
+import com.chuckerteam.chucker.internal.data.har.log.entry.response.Content.Companion.EMPTY
 import com.google.gson.annotations.SerializedName
 
 // https://github.com/ahmadnassri/har-spec/blob/master/versions/1.2.md#response
@@ -24,7 +25,7 @@ internal data class Response(
         statusText = transaction.responseMessage ?: "",
         httpVersion = transaction.protocol ?: "",
         headers = transaction.getParsedResponseHeaders()?.map { Header(it) } ?: emptyList(),
-        content = transaction.responsePayloadSize?.run { Content(transaction) },
+        content = transaction.responsePayloadSize?.run { Content(transaction) } ?: EMPTY,
         headersSize = transaction.responseHeadersSize ?: 0,
         bodySize = transaction.getHarResponseBodySize(),
         totalSize = transaction.getResponseTotalSize()

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/response/Content.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/har/log/entry/response/Content.kt
@@ -13,6 +13,15 @@ internal data class Content(
     @SerializedName("encoding") val encoding: String? = null,
     @SerializedName("comment") val comment: String? = null
 ) {
+
+    companion object {
+        internal val EMPTY = Content(
+            size = 0L,
+            compression = 0,
+            mimeType = "text/plain",
+            text = ""
+        )
+    }
     constructor(transaction: HttpTransaction) : this(
         size = transaction.responsePayloadSize,
         mimeType = transaction.responseContentType ?: "application/octet-stream",


### PR DESCRIPTION
## :camera: Screenshots
![Screenshot 2023-05-03 at 10 34 22 AM](https://user-images.githubusercontent.com/801410/236004544-59baf2dd-0576-4f2d-975f-4a69a11aa47e.png)

<!-- Show us what you've changed, we love images. -->

## :page_facing_up: Context
The existing implementation for the HAR output of transactions had a small bug in that transaction entries with an empty response body were being converted to HAR entries with a missing `content` object, violating the HAR spec. 
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

## :pencil: Changes
Updated the HAR output logic to render an empty content object in the output JSON for transactions with empty transaction bodies. 
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

## :paperclip: Related PR
N/A
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
N/A
<!-- Is there something breaking the API? Any class or method signature changed? -->

## :hammer_and_wrench: How to test
I dev tested this by generating a HAR file from the list of transactions within my app before/after these changes were made. When testing before and attempting to open the generated HAR file within the Chrome Network Tools debugger, the file was unable to be parsed, and when I tested after, it parsed and navigated successfully.

![Screenshot 2023-05-03 at 11 05 34 AM](https://user-images.githubusercontent.com/801410/236006431-c34b2773-46f3-4a48-9592-febe496425c7.png)

<!-- Is there a special case to test your changes? -->

## :stopwatch: Next steps
Potential future improvements could be to use a non pretty-printed Gson serializer object to output the HAR contents to save on whitespace inflating the output file size.
<!-- Do we have to plan something else after the merge? -->
