### PR TITLE
Improved error message when trying to save empty bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Please add your entries according to this format.
 * Fixed RTL issue in payload view [#733]
 * Fixed StrictMode ThreadPolicy violations [#737]
 * Fixed Memory Leak with Toasts: Use applicationContext instead of Activity [#810]
-* Improved error message when trying to save empty bodies [#]
+* Improved error message when trying to save empty bodies [#1038]
 
 ### Removed
 
@@ -529,6 +529,7 @@ Initial release.
 [#321]: https://github.com/ChuckerTeam/chucker/issues/321
 [#366]: https://github.com/ChuckerTeam/chucker/issues/366
 [#367]: https://github.com/ChuckerTeam/chucker/issues/367
+[#388]: https://github.com/ChuckerTeam/chucker/issues/388
 [#394]: https://github.com/ChuckerTeam/chucker/issues/394
 [#410]: https://github.com/ChuckerTeam/chucker/issues/410
 [#422]: https://github.com/ChuckerTeam/chucker/issues/422
@@ -559,5 +560,5 @@ Initial release.
 [#930]: https://github.com/ChuckerTeam/chucker/pull/930
 [#970]: https://github.com/ChuckerTeam/chucker/pull/970
 [#975]: https://github.com/ChuckerTeam/chucker/pull/975
-[#388]: https://github.com/ChuckerTeam/chucker/issues/388
 [#988]: https://github.com/ChuckerTeam/chucker/pull/988
+[#1038]: https://github.com/ChuckerTeam/chucker/pull/1038

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Please add your entries according to this format.
 * Fixed RTL issue in payload view [#733]
 * Fixed StrictMode ThreadPolicy violations [#737]
 * Fixed Memory Leak with Toasts: Use applicationContext instead of Activity [#810]
+* Improved error message when trying to save empty bodies [#]
 
 ### Removed
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -235,7 +235,16 @@ internal class TransactionPayloadFragment :
     }
 
     private fun createFileToSaveBody() {
-        saveToFile.launch("$DEFAULT_FILE_PREFIX${System.currentTimeMillis()}")
+        val transaction = viewModel.transaction.value
+        if (transaction != null && isBodyEmpty(payloadType, transaction)) {
+            Toast.makeText(
+                activity,
+                R.string.chucker_file_not_saved_body_is_empty,
+                Toast.LENGTH_SHORT
+            ).show()
+        } else {
+            saveToFile.launch("$DEFAULT_FILE_PREFIX${System.currentTimeMillis()}")
+        }
     }
 
     override fun onQueryTextSubmit(query: String): Boolean = false
@@ -409,6 +418,13 @@ internal class TransactionPayloadFragment :
             return@withContext true
         }
     }
+
+    private fun isBodyEmpty(type: PayloadType, transaction: HttpTransaction): Boolean =
+        when {
+            type == PayloadType.REQUEST && transaction.requestBody == null -> true
+            type == PayloadType.RESPONSE && transaction.responseBody == null -> true
+            else -> false
+        }
 
     companion object {
         private const val ARG_TYPE = "type"

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="chucker_save_failed_to_open_document">Failed to open file chooser</string>
     <string name="chucker_file_saved">File saved successfully!</string>
     <string name="chucker_file_not_saved">Failed to save file</string>
+    <string name="chucker_file_not_saved_body_is_empty">Nothing to save as the body is empty</string>
     <string name="chucker_body_empty">(body is empty)</string>
     <string name="chucker_body_omitted">(encoded or binary body omitted)</string>
     <string name="chucker_search">Search</string>


### PR DESCRIPTION
## :camera: Screenshots
![untitled](https://github.com/ChuckerTeam/chucker/assets/3001957/08f0d369-2dd7-4351-8bae-aaa6d5fb3795)

## :page_facing_up: Context
Fixes #1030

## :pencil: Changes
I'm preventing the file selector to start entirely if the body is empty, and returning a more informative error message to user.

## :no_entry_sign: Breaking
n/a

## :hammer_and_wrench: How to test
See gif.

## :stopwatch: Next steps
None
