### PR TITLE
Downgrade AGP from 8.x to 7.x to fix build error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         kotlinVersion = '1.8.21'
-        androidGradleVersion = '8.0.1'
+        androidGradleVersion = '7.4.2'
         coroutineVersion = '1.7.1'
 
         // Google libraries


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->
N/A

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
We downgrade JDK version from 17 to 11 in this PR https://github.com/ChuckerTeam/chucker/pull/1025
But AGP 8.x still requires JDK 17, so all 4.0.0's SNAPSHOT CI build are failing now.

Note: This PR is for fixing https://github.com/ChuckerTeam/chucker/issues/1044

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

Downgrade the AGP version from 8.0.1 to 7.4.2

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

https://github.com/ChuckerTeam/chucker/pull/1025
https://github.com/ChuckerTeam/chucker/pull/1006

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->
No

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->
Confirm the CI build will be success

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
