### PR TITLE
Fix main branch snapshot CI setting

### DIFF
--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -2,7 +2,7 @@ name: Publish Snapshot
 on:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ If you're migrating **from Chucker v2.0 to v3.0**, please expect multiple breaki
 
 ## Snapshots 📦
 
-Development of Chucker happens in the [`develop`](https://github.com/ChuckerTeam/chucker/tree/develop) branch. Every push to `develop` will trigger a publishing of a `SNAPSHOT` artifact for the upcoming version. You can get those snapshots artifacts directly from Sonatype with:
+Development of Chucker happens in the [`main`](https://github.com/ChuckerTeam/chucker/tree/main) branch. Every push to `main` will trigger a publishing of a `SNAPSHOT` artifact for the upcoming version. You can get those snapshots artifacts directly from Sonatype with:
 
 ```gradle
 repositories {
@@ -200,15 +200,15 @@ dependencies {
 }
 ```
 
-Moreover, you can still use [JitPack](https://jitpack.io/#ChuckerTeam/chucker) as it builds every branch. So the top of `develop` is available here:
+Moreover, you can still use [JitPack](https://jitpack.io/#ChuckerTeam/chucker) as it builds every branch. So the top of `main` is available here:
 
 ```gradle
 repositories {
     maven { url "https://jitpack.io" }
 }
 dependencies {
-  debugImplementation "com.github.chuckerteam.chucker:library:develop-SNAPSHOT"
-  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:develop-SNAPSHOT"
+  debugImplementation "com.github.chuckerteam.chucker:library:main-SNAPSHOT"
+  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:main-SNAPSHOT"
 }
 ```
 


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->
N/A

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
The `develop` branch is not exist any more. But the CI is still configured to use `develop` branch to trigger SNAPSHOT build.
So the Sonatype maven repository doesn't provide latest SNAPSHOT build.

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

Update the `Publish Snapshot` job to use `main` branch instead of `develop` branch

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

https://github.com/ChuckerTeam/chucker/issues/1044

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
