### PR TITLE
Fix post-release typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Please add your entries according to this format.
 ### Added
 * Add `skipPaths` to selectively skip requests from Chucker [#970]
 * Add syntax highlighting to the request/response body when is JSON [#930]
-* Decoding of request and response bodies can now be customized. In order to do this a `BodyDecoder` interface needs to be implemented and installed in the `ChuckerInterceptor` via `ChuckerInterceptor.addBinaryDecoder(decoder)` method. Decoded bodies are then displayed in the Chucker UI. [#555]
+* Decoding of request and response bodies can now be customized. In order to do this a `BinaryDecoder` interface needs to be implemented and installed in the `ChuckerInterceptor` via `ChuckerInterceptor.addBinaryDecoder(decoder)` method. Decoded bodies are then displayed in the Chucker UI. [#555]
 * Create dynamic shortcut when `ChuckerInterceptor` added. Users can opt out of this feature using `createShortcut(false)` in `ChuckerInterceptor.Builder` [#588]
 * Brotli compression support [#563]
 * Added `writeTransactions` method to `ChuckerCollector` to export transactions to a file programmatically [#784]
@@ -50,10 +50,10 @@ Please add your entries according to this format.
 
 ### Changed
 
-* Updated OkHttp to 4.9.3
+* Updated OkHttp to 4.11.0
 * Updated Material to 1.8.0
-* Updated AGP to 8.0.0
-* Updated Kotlin to 1.8.20
+* Updated AGP to 8.0.2
+* Updated Kotlin to 1.8.22
 
 ## Version 3.5.2 *(2021-07-28)*
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ interceptor.redactHeader("Auth-Token", "User-Session");
 Chucker by default handles only plain text, Gzip compressed or Brotli compressed. If you use a binary format like, for example, Protobuf or Thrift it won't be automatically handled by Chucker. You can, however, install a custom decoder that is capable of reading data from different encodings.
 
 ```kotlin
-object ProtoDecoder : BinaryDecoder {
+object ProtoDecoder : BodyDecoder {
     fun decodeRequest(request: Request, body: ByteString): String? = if (request.isExpectedProtoRequest) {
         decodeProtoBody(body)
     } else {


### PR DESCRIPTION
## :page_facing_up: Context
I've noticed a couple of typos in the README and in the CHANGELOG after we released 4.0.0.
Fixing them here.