### PR TITLE
Bug fix - Scroll to Search Navigation Bar Visibility Fix

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -254,7 +254,11 @@ internal class TransactionPayloadFragment :
         currentSearchScrollIndex = -1
 
         if (newText.isNotBlank() && newText.length > NUMBER_OF_IGNORED_SYMBOLS) {
-            val listOfSearchQuery = payloadAdapter.highlightQueryWithColors(newText, backgroundSpanColor, foregroundSpanColor)
+            val listOfSearchQuery = payloadAdapter.highlightQueryWithColors(
+                newText,
+                backgroundSpanColor,
+                foregroundSpanColor
+            )
             if (listOfSearchQuery.isNotEmpty()) {
                 scrollableIndices.addAll(listOfSearchQuery)
             } else {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -254,9 +254,13 @@ internal class TransactionPayloadFragment :
         currentSearchScrollIndex = -1
 
         if (newText.isNotBlank() && newText.length > NUMBER_OF_IGNORED_SYMBOLS) {
-            scrollableIndices.addAll(
-                payloadAdapter.highlightQueryWithColors(newText, backgroundSpanColor, foregroundSpanColor)
-            )
+            val listOfSearchQuery = payloadAdapter.highlightQueryWithColors(newText, backgroundSpanColor, foregroundSpanColor)
+            if (listOfSearchQuery.isNotEmpty()) {
+                scrollableIndices.addAll(listOfSearchQuery)
+            } else {
+                payloadAdapter.resetHighlight()
+                makeToolbarSearchSummaryVisible(false)
+            }
         } else {
             payloadAdapter.resetHighlight()
             makeToolbarSearchSummaryVisible(false)


### PR DESCRIPTION
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
Issue - Search for something on the response page, the search results are visible along with the nav bar, but when we append something to the query, that leads to zero search results, highlighting is reset, but the nav bar with old search results is still visible.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->
#988 

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->
- Search for a word available on the response page, and append something making it a query that won't have any results. the nav bar and the highlighted results should be reset. 
