### PR TITLE
Correct permission name to `android.permission.POST_NOTIFICATIONS` in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,16 +155,16 @@ interceptorBuilder.addBodyDecoder(ProtoDecoder).build()
 
 ### Notification Permission 🔔
 
-Starting with Android 13, your apps needs to request the `POST_NOTIFICATION` permission to the user in order to show notifications.
+Starting with Android 13, your apps needs to request the `android.permission.POST_NOTIFICATIONS` permission to the user in order to show notifications.
 As Chucker also shows notifications to show network activity you need to handle permission request depending on your app features.
 Without this permission Chucker will track network activity, but there will be no notifications on devices with Android 13 and newer.
 
 There are 2 possible cases:
 1. If your app is already sending notifications, you don't need to do anything as Chucker will
-show a notification as soon as the `POST_NOTIFICATION` permission is granted to your app.
+show a notification as soon as the `android.permission.POST_NOTIFICATIONS` permission is granted to your app.
 1. If your app does not send notifications you would need to open Chucker directly (can be done via shortcut, which is added to your app by default when Chucker is added)
 and click `Allow` in the dialog with permission request. In case you don't allow this permission or dismiss that dialog by mistake, on every Chucker launch there will be
-a snackbar with a button to open your app settings where you can change permissions settings. Note, you need to grant `POST_NOTIFICATION` to your app in Settings as there
+a snackbar with a button to open your app settings where you can change permissions settings. Note, you need to grant `android.permission.POST_NOTIFICATIONS` to your app in Settings as there
 will be no separate app in Apps list in Settings.
 
 ## Migrating 🚗


### PR DESCRIPTION
## :camera: Screenshots
This is only a documentation change.

## :page_facing_up: Context
Hi! The permission name used in the docs isn't correct: `POST_NOTIFICATION`, it should be `POST_NOTIFICATIONS` (plural) - although for completeness' sake, I'm proposing that this be `android.permission.POST_NOTIFICATIONS`.

Interestingly the [official docs have the same issue in at least one place](https://source.android.com/docs/core/display/notification-perm):

![google-docs](https://github.com/ChuckerTeam/chucker/assets/1025059/fc54f0a1-5511-4cfe-b22f-3d2537d78058)

Although clicking through that link shows the correct naming: https://developer.android.com/develop/ui/views/notifications/notification-permission: 
![correct](https://github.com/ChuckerTeam/chucker/assets/1025059/d7059496-1275-48a5-9e2b-e6b576754d9b)

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
