### PR TITLE
Adding viewpager 2 for TransactionPagerAdapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
         lifecycleVersion = '2.6.2'
         androidXCoreVersion = '2.2.0'
         paletteKtxVersion = '1.0.0'
+        viewpager2Version = '1.0.0'
         kspVersion = '1.9.10-1.0.13'
 
         // Networking

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     implementation "com.google.android.material:material:$materialComponentsVersion"
     implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
     implementation "androidx.palette:palette-ktx:$paletteKtxVersion"
+    implementation "androidx.viewpager2:viewpager2:$viewpager2Version"
 
     implementation "androidx.activity:activity-ktx:$activityVersion"
     implementation "androidx.fragment:fragment-ktx:$fragmentVersion"

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionActivity.kt
@@ -9,7 +9,7 @@ import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
-import androidx.viewpager.widget.ViewPager
+import androidx.viewpager2.widget.ViewPager2
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.databinding.ChuckerActivityTransactionBinding
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
@@ -21,6 +21,7 @@ import com.chuckerteam.chucker.internal.support.TransactionDetailsSharable
 import com.chuckerteam.chucker.internal.support.shareAsFile
 import com.chuckerteam.chucker.internal.support.shareAsUtf8Text
 import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
+import com.google.android.material.tabs.TabLayoutMediator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -41,7 +42,9 @@ internal class TransactionActivity : BaseChuckerActivity() {
             setContentView(root)
             setSupportActionBar(toolbar)
             setupViewPager(viewPager)
-            tabLayout.setupWithViewPager(viewPager)
+            TabLayoutMediator(tabLayout, viewPager) { tab, position ->
+                tab.text = (viewPager.adapter as TransactionPagerAdapter).getPageTitle(position)
+            }.attach()
         }
 
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
@@ -146,10 +149,10 @@ internal class TransactionActivity : BaseChuckerActivity() {
         return true
     }
 
-    private fun setupViewPager(viewPager: ViewPager) {
-        viewPager.adapter = TransactionPagerAdapter(this, supportFragmentManager)
-        viewPager.addOnPageChangeListener(
-            object : ViewPager.SimpleOnPageChangeListener() {
+    private fun setupViewPager(viewPager: ViewPager2) {
+        viewPager.adapter = TransactionPagerAdapter(this, this)
+        viewPager.registerOnPageChangeCallback(
+            object : ViewPager2.OnPageChangeCallback() {
                 override fun onPageSelected(position: Int) {
                     selectedTabPosition = position
                 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPagerAdapter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPagerAdapter.kt
@@ -2,27 +2,29 @@ package com.chuckerteam.chucker.internal.ui.transaction
 
 import android.content.Context
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentStatePagerAdapter
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.chuckerteam.chucker.R
 
-internal class TransactionPagerAdapter(context: Context, fm: FragmentManager) :
-    FragmentStatePagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+internal class TransactionPagerAdapter(
+    context: Context,
+    fragmentActivity: FragmentActivity,
+) : FragmentStateAdapter(fragmentActivity) {
 
     private val titles = arrayOf(
         context.getString(R.string.chucker_overview),
         context.getString(R.string.chucker_request),
-        context.getString(R.string.chucker_response)
+        context.getString(R.string.chucker_response),
     )
 
-    override fun getItem(position: Int): Fragment = when (position) {
+    override fun createFragment(position: Int): Fragment = when (position) {
         0 -> TransactionOverviewFragment()
         1 -> TransactionPayloadFragment.newInstance(PayloadType.REQUEST)
         2 -> TransactionPayloadFragment.newInstance(PayloadType.RESPONSE)
         else -> throw IllegalArgumentException("no item")
     }
 
-    override fun getCount(): Int = titles.size
+    override fun getItemCount(): Int = titles.size
 
-    override fun getPageTitle(position: Int): CharSequence = titles[position]
+    fun getPageTitle(position: Int): CharSequence = titles[position]
 }

--- a/library/src/main/res/layout/chucker_activity_transaction.xml
+++ b/library/src/main/res/layout/chucker_activity_transaction.xml
@@ -35,7 +35,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager
+    <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/viewPager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->
changed old viewpager with viewpager 2 for transaction activity
## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
FragmentStatePagerAdapter is deprecated

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
