### PR TITLE
Adding collapsable/expand JSON payloads feature.

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
@@ -306,8 +306,9 @@ internal sealed class TransactionPayloadViewHolder(view: View) : RecyclerView.Vi
 
                 when {
                     value.isJsonPrimitive -> {
-                        val text = "\"" + value.asString + "\","
-                        bodyBinding.txtStartValue.text = text
+                        val text = if (value.isJsonNull) "null" else "\"${value.asString}\""
+
+                        bodyBinding.txtStartValue.text = text.plus(",")
                         bodyBinding.txtEndValue.visibility = View.GONE
                     }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
@@ -305,7 +305,7 @@ internal sealed class TransactionPayloadViewHolder(view: View) : RecyclerView.Vi
                 bodyBinding.txtKey.text = keyText
 
                 when {
-                    value.isJsonPrimitive -> {
+                    value.isJsonPrimitive || value.isJsonNull -> {
                         val text = if (value.isJsonNull) "null" else "\"${value.asString}\""
 
                         bodyBinding.txtStartValue.text = text.plus(",")

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -515,7 +515,7 @@ internal class TransactionPayloadFragment :
             .also { it.isLenient = true }
 
         newList.add(
-            TransactionPayloadItem.BodyJsonItem(
+            TransactionPayloadItem.BodyCollapsableItem(
                 jsonElement = JsonParser.parseReader(reader)
             )
         )

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -12,6 +12,7 @@ import android.text.SpannableStringBuilder
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
@@ -209,7 +210,7 @@ internal class TransactionPayloadFragment :
             menu.findItem(R.id.collapse).apply {
                 isVisible = true
                 setOnMenuItemClickListener {
-                    viewModel.toggleCollapsableJson()
+                    handleCollapseMenu()
                     true
                 }
             }
@@ -241,6 +242,26 @@ internal class TransactionPayloadFragment :
         PayloadType.RESPONSE -> {
             (false == transaction?.isResponseBodyEncoded) && (0L != (transaction.responsePayloadSize))
         }
+    }
+
+    private fun MenuItem.handleCollapseMenu() {
+        viewModel.toggleCollapsableJson()
+
+        setTitle(
+            if (viewModel.isUsingCollapsableJson) {
+                R.string.chucker_expand_all
+            } else {
+                R.string.chucker_collapse_all
+            }
+        )
+
+        setIcon(
+            if (viewModel.isUsingCollapsableJson) {
+                R.drawable.chucker_ic_expand_all
+            } else {
+                R.drawable.chucker_ic_collapse_all
+            }
+        )
     }
 
     override fun onAttach(context: Context) {
@@ -483,7 +504,7 @@ internal class TransactionPayloadFragment :
     private fun MutableList<TransactionPayloadItem>.getCollapsableOrDefault(): List<TransactionPayloadItem> {
         val default = this
 
-        return if (viewModel.useJsonCollapsable) {
+        return if (viewModel.isUsingCollapsableJson) {
             try {
                 mapToJsonElements()
             } catch (t: JsonSyntaxException) {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -35,8 +35,8 @@ import com.chuckerteam.chucker.internal.support.combineLatest
 import com.chuckerteam.chucker.internal.support.gone
 import com.chuckerteam.chucker.internal.support.visible
 import com.google.gson.JsonParser
+import com.google.gson.JsonSyntaxException
 import com.google.gson.stream.JsonReader
-import com.google.gson.stream.MalformedJsonException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -486,7 +486,7 @@ internal class TransactionPayloadFragment :
         return if (viewModel.useJsonCollapsable) {
             try {
                 mapToJsonElements()
-            } catch (t: MalformedJsonException) {
+            } catch (t: JsonSyntaxException) {
                 Toast.makeText(context, t.message, Toast.LENGTH_LONG).show()
                 Logger.error(t.message ?: "Error when formatting json")
                 viewModel.toggleCollapsableJson()

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
@@ -15,6 +15,10 @@ internal class TransactionViewModel(transactionId: Long) : ViewModel() {
 
     val encodeUrl: LiveData<Boolean> = mutableEncodeUrl
 
+    private var _useJsonCollapsable: Boolean = false
+    val useJsonCollapsable: Boolean
+        get() = _useJsonCollapsable
+
     val transactionTitle: LiveData<String> = RepositoryProvider.transaction()
         .getTransaction(transactionId)
         .combineLatest(encodeUrl) { transaction, encodeUrl ->
@@ -34,10 +38,12 @@ internal class TransactionViewModel(transactionId: Long) : ViewModel() {
     val doesRequestBodyRequireEncoding: LiveData<Boolean> = RepositoryProvider.transaction()
         .getTransaction(transactionId)
         .map { transaction ->
-            transaction?.requestContentType?.contains("x-www-form-urlencoded", ignoreCase = true) ?: false
+            transaction?.requestContentType?.contains("x-www-form-urlencoded", ignoreCase = true)
+                ?: false
         }
 
-    val transaction: LiveData<HttpTransaction?> = RepositoryProvider.transaction().getTransaction(transactionId)
+    val transaction: LiveData<HttpTransaction?> =
+        RepositoryProvider.transaction().getTransaction(transactionId)
 
     val formatRequestBody: LiveData<Boolean> = doesRequestBodyRequireEncoding
         .combineLatest(encodeUrl) { requiresEncoding, encodeUrl ->
@@ -48,6 +54,11 @@ internal class TransactionViewModel(transactionId: Long) : ViewModel() {
 
     fun encodeUrl(encode: Boolean) {
         mutableEncodeUrl.value = encode
+    }
+
+    fun toggleCollapsableJson() {
+        _useJsonCollapsable = !_useJsonCollapsable
+        mutableEncodeUrl.value = encodeUrl.value // Just to fire observer again
     }
 }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionViewModel.kt
@@ -16,7 +16,7 @@ internal class TransactionViewModel(transactionId: Long) : ViewModel() {
     val encodeUrl: LiveData<Boolean> = mutableEncodeUrl
 
     private var _useJsonCollapsable: Boolean = false
-    val useJsonCollapsable: Boolean
+    val isUsingCollapsableJson: Boolean
         get() = _useJsonCollapsable
 
     val transactionTitle: LiveData<String> = RepositoryProvider.transaction()

--- a/library/src/main/res/drawable/chucker_ic_collapse_all.xml
+++ b/library/src/main/res/drawable/chucker_ic_collapse_all.xml
@@ -1,5 +1,10 @@
-<vector android:height="24dp" android:tint="#F5F5F5"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M7.41,18.59L8.83,20 12,16.83 15.17,20l1.41,-1.41L12,14l-4.59,4.59zM16.59,5.41L15.17,4 12,7.17 8.83,4 7.41,5.41 12,10l4.59,-4.59z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#F5F5F5"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7.41,18.59L8.83,20 12,16.83 15.17,20l1.41,-1.41L12,14l-4.59,4.59zM16.59,5.41L15.17,4 12,7.17 8.83,4 7.41,5.41 12,10l4.59,-4.59z" />
 </vector>

--- a/library/src/main/res/drawable/chucker_ic_collapse_all.xml
+++ b/library/src/main/res/drawable/chucker_ic_collapse_all.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#F5F5F5"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7.41,18.59L8.83,20 12,16.83 15.17,20l1.41,-1.41L12,14l-4.59,4.59zM16.59,5.41L15.17,4 12,7.17 8.83,4 7.41,5.41 12,10l4.59,-4.59z"/>
+</vector>

--- a/library/src/main/res/drawable/chucker_ic_expand_all.xml
+++ b/library/src/main/res/drawable/chucker_ic_expand_all.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#F5F5F5"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M5,9l1.41,1.41l5.59,-5.58l5.59,5.58l1.41,-1.41l-7,-7z" />
+
+    <group
+        android:name="rotationGroup"
+        android:pivotX="12"
+        android:pivotY="12"
+        android:rotation="180">
+        <path
+            android:fillColor="@android:color/white"
+            android:pathData="M5,9l1.41,1.41l5.59,-5.58l5.59,5.58l1.41,-1.41l-7,-7z" />
+    </group>
+</vector>

--- a/library/src/main/res/drawable/chucker_ic_expand_all.xml
+++ b/library/src/main/res/drawable/chucker_ic_expand_all.xml
@@ -2,19 +2,9 @@
     android:width="24dp"
     android:height="24dp"
     android:tint="#F5F5F5"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportWidth="960"
+    android:viewportHeight="960">
     <path
         android:fillColor="@android:color/white"
-        android:pathData="M5,9l1.41,1.41l5.59,-5.58l5.59,5.58l1.41,-1.41l-7,-7z" />
-
-    <group
-        android:name="rotationGroup"
-        android:pivotX="12"
-        android:pivotY="12"
-        android:rotation="180">
-        <path
-            android:fillColor="@android:color/white"
-            android:pathData="M5,9l1.41,1.41l5.59,-5.58l5.59,5.58l1.41,-1.41l-7,-7z" />
-    </group>
+        android:pathData="M200,760v-240h80v160h160v80L200,760ZM680,440v-160L520,280v-80h240v240h-80Z" />
 </vector>

--- a/library/src/main/res/drawable/chuncker_ic_arrow_down.xml
+++ b/library/src/main/res/drawable/chuncker_ic_arrow_down.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#F5F5F5"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6 -6,-6 1.41,-1.41z"/>
+</vector>

--- a/library/src/main/res/layout/chucker_transaction_item_body_collapsable.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_body_collapsable.xml
@@ -37,7 +37,6 @@
             android:textColor="@color/chucker_json_key_color"
             android:textDirection="ltr"
             android:textIsSelectable="true"
-            android:textStyle="bold"
             android:typeface="monospace"
             app:layout_constraintStart_toEndOf="@id/imgExpand"
             app:layout_constraintTop_toTopOf="@id/imgExpand"

--- a/library/src/main/res/layout/chucker_transaction_item_body_collapsable.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_body_collapsable.xml
@@ -34,6 +34,7 @@
             android:layout_height="wrap_content"
             android:gravity="start"
             android:minLines="1"
+            android:layout_marginTop="4dp"
             android:textColor="@color/chucker_json_key_color"
             android:textDirection="ltr"
             android:textIsSelectable="true"

--- a/library/src/main/res/layout/chucker_transaction_item_body_json.xml
+++ b/library/src/main/res/layout/chucker_transaction_item_body_json.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
+    android:focusable="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/clRoot"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.appcompat.widget.AppCompatImageView
+            android:id="@+id/imgExpand"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/chuncker_ic_arrow_down"
+            app:tint="@color/chucker_json_key_color"
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/txtKey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            android:minLines="1"
+            android:textColor="@color/chucker_json_key_color"
+            android:textDirection="ltr"
+            android:textIsSelectable="true"
+            android:textStyle="bold"
+            android:typeface="monospace"
+            app:layout_constraintStart_toEndOf="@id/imgExpand"
+            app:layout_constraintTop_toTopOf="@id/imgExpand"
+            app:layout_goneMarginStart="0dp"
+            tools:text="data" />
+
+        <TextView
+            android:id="@+id/txtDivider"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/chucker_base_grid"
+            android:text="@string/chucker_item_list_section_divider"
+            app:layout_constraintBottom_toBottomOf="@id/txtKey"
+            app:layout_constraintStart_toEndOf="@id/txtKey"
+            app:layout_constraintTop_toTopOf="@id/txtKey" />
+
+        <TextView
+            android:id="@+id/txtStartValue"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/chucker_base_grid"
+            android:gravity="start"
+            android:textColor="@color/chucker_json_value_color"
+            android:textDirection="ltr"
+            android:textIsSelectable="true"
+            android:typeface="monospace"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toEndOf="@id/txtDivider"
+            app:layout_constraintTop_toTopOf="@id/txtKey"
+            tools:text="{" />
+
+        <TextView
+            android:id="@+id/txtEndValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/chucker_base_grid"
+            android:textColor="@color/chucker_json_value_color"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@id/txtKey"
+            app:layout_constraintTop_toBottomOf="@id/rvSectionData"
+            app:layout_constraintVertical_bias="0"
+            tools:text="}" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvSectionData"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/chucker_base_grid"
+            android:visibility="gone"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toTopOf="@id/txtEndValue"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/txtEndValue"
+            app:layout_constraintTop_toBottomOf="@id/txtStartValue"
+            tools:itemCount="5"
+            tools:visibility="visible" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/menu/chucker_transaction.xml
+++ b/library/src/main/res/menu/chucker_transaction.xml
@@ -49,6 +49,6 @@
         android:title="@string/chucker_collapse_all"
         android:id="@+id/collapse"
         android:visible="false"
-        app:showAsAction="ifRoom">
+        app:showAsAction="always">
     </item>
 </menu>

--- a/library/src/main/res/menu/chucker_transaction.xml
+++ b/library/src/main/res/menu/chucker_transaction.xml
@@ -45,9 +45,17 @@
     </item>
 
     <item
+        android:id="@+id/collapse"
         android:icon="@drawable/chucker_ic_collapse_all"
         android:title="@string/chucker_collapse_all"
-        android:id="@+id/collapse"
+        android:visible="false"
+        app:showAsAction="always">
+    </item>
+
+    <item
+        android:id="@+id/expand"
+        android:icon="@drawable/chucker_ic_expand_all"
+        android:title="@string/chucker_expand_all"
         android:visible="false"
         app:showAsAction="always">
     </item>

--- a/library/src/main/res/menu/chucker_transaction.xml
+++ b/library/src/main/res/menu/chucker_transaction.xml
@@ -43,4 +43,12 @@
         android:visible="false"
         app:showAsAction="ifRoom">
     </item>
+
+    <item
+        android:icon="@drawable/chucker_ic_collapse_all"
+        android:title="@string/chucker_collapse_all"
+        android:id="@+id/collapse"
+        android:visible="false"
+        app:showAsAction="ifRoom">
+    </item>
 </menu>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="chucker_share_as_file">Share as file</string>
     <string name="chucker_share_as_har">Share as .har file</string>
     <string name="chucker_save">Save body to file</string>
+    <string name="chucker_expand_all">Expand all</string>
     <string name="chucker_collapse_all">Collapse all</string>
     <string name="chucker_save_failed_to_open_document">Failed to open file chooser</string>
     <string name="chucker_file_saved">File saved successfully!</string>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -32,6 +32,7 @@
     <string name="chucker_share_as_file">Share as file</string>
     <string name="chucker_share_as_har">Share as .har file</string>
     <string name="chucker_save">Save body to file</string>
+    <string name="chucker_collapse_all">Collapse all</string>
     <string name="chucker_save_failed_to_open_document">Failed to open file chooser</string>
     <string name="chucker_file_saved">File saved successfully!</string>
     <string name="chucker_file_not_saved">Failed to save file</string>
@@ -64,4 +65,5 @@
     <string name="chucker_graphql_operation_is_empty"> &lt;Unable to discover GraphQL operation name&gt;</string>
     <string name="chucker_scroll_buttons_for_search">Buttons to scroll the search items</string>
     <string name="chucker_search_results_title">Search Results:</string>
+    <string name="chucker_item_list_section_divider">:</string>
 </resources>


### PR DESCRIPTION
## :camera: Screenshots

https://github.com/ChuckerTeam/chucker/assets/11152015/7ff16e80-45de-466d-a8c3-adf6ce4f3db8

https://github.com/ChuckerTeam/chucker/assets/11152015/07f460e6-b1bd-4a59-b344-42f5197e490a


## :page_facing_up: Context
First of all, thank you so much for this awesome library!!!
I'm mobile developer, and I've been using this library in my job every single day. In some situations, I have to share my screen with a backend developer to show that the payload response has a bug and it should to be fixed on backend side.
However, it often becomes complicated to do so because the payload is too large and the search bar doesn't help much some times.
This change adds one more ViewHolder type where it is possible to collapse/expand JSON payloads, helping us to find  some portion of the JSON more easily, specially when it has a lot of nested objects/arrays.

## :stopwatch: Next steps
1 - Remove unnecessary  commas when the payload is collapsed.
2 - Improve searching text when the payload is collapsed.
