### PR TITLE
compile/target SDK to 34

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,10 @@ buildscript {
         coroutineVersion = '1.7.3'
 
         // Google libraries
-        activityVersion = '1.7.2'
+        activityVersion = '1.8.0'
         appCompatVersion = '1.6.1'
         constraintLayoutVersion = '2.1.4'
-        materialComponentsVersion = '1.9.0'
+        materialComponentsVersion = '1.10.0'
         fragmentVersion = '1.6.1'
         roomVersion = '2.5.2'
         lifecycleVersion = '2.6.2'
@@ -106,8 +106,8 @@ task clean(type: Delete) {
 
 ext {
     minSdkVersion = 21
-    targetSdkVersion = 33
-    compileSdkVersion = 33
+    targetSdkVersion = 34
+    compileSdkVersion = 34
 }
 
 nexusStaging {


### PR DESCRIPTION
## :page_facing_up: Context
Bumping compile/target SDK to the latest stable.

## :pencil: Changes
Also
Closes #1108
Closes #1109
as those two PRs were blocked by this

## :paperclip: Related PR
n/a

## :no_entry_sign: Breaking
n/a

## :hammer_and_wrench: How to test
I've tested this locally and the sample app renders correctly.