### PR TITLE
Use parametrized type tokens for GSON converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please add your entries according to this format.
 ### Added
 
 ### Fixed
+* Change GSON `TypeToken` creation to allow using Chucker in builds optimized by R8 [#1166]
 
 ### Removed
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -173,16 +173,14 @@ internal class HttpTransaction(
     fun getParsedRequestHeaders(): List<HttpHeader>? {
         return JsonConverter.instance.fromJson<List<HttpHeader>>(
             requestHeaders,
-            object : TypeToken<List<HttpHeader>>() {
-            }.type,
+            TypeToken.getParameterized(List::class.java, HttpHeader::class.java).type,
         )
     }
 
     fun getParsedResponseHeaders(): List<HttpHeader>? {
         return JsonConverter.instance.fromJson<List<HttpHeader>>(
             responseHeaders,
-            object : TypeToken<List<HttpHeader>>() {
-            }.type,
+            TypeToken.getParameterized(List::class.java, HttpHeader::class.java).type,
         )
     }
 


### PR DESCRIPTION
Fixes "TypeToken must be created with a type argument: new TypeToken<...>() {}; When using code shrinkers (ProGuard, R8, ...) make sure that generic signatures are preserved." errors.

## :camera: Screenshots
N/A

## :page_facing_up: Context
One may use Chucker with optimized builds.

## :pencil: Changes
Change how type tokens for lists are created so it works also in optimized/shrinked builds.
Just a different GSON API is now used, no changes in effects.

## :paperclip: Related PR
N/A

## :no_entry_sign: Breaking
Nothing

## :hammer_and_wrench: How to test
Use chucker (standard, not no-op) with a release build type or enable minification in debug build type.

## :stopwatch: Next steps
N/A
