### PR TITLE
Update README.md to recommend usage as network interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To start using Chucker, just plug in a new `ChuckerInterceptor` to your OkHttp C
 
 ```kotlin
 val client = OkHttpClient.Builder()
-                .addInterceptor(ChuckerInterceptor(context))
+                .addNetworkInterceptor(ChuckerInterceptor(context)) // You can choose to use Chucker as either an application or network interceptor, depending on your requirements.
                 .build()
 ```
 


### PR DESCRIPTION
## :page_facing_up: Context
Seems like people want chucker to work as a charles replacement. Even something "simple" such as cache hits won't show as cache hits in chucker while they will in charles. I will admittedly say that I don't have a deep understanding of network vs app interceptor, so I guess someone with more info can argue for an app interceptor vs network. but I think networkInterceptor is probably a better default?