### PR TITLE
fix: Gson ProGuard issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please add your entries according to this format.
 ## Unreleased
 
 * Fixed activity still asking for notification permission when notifications are disabled [#1165]
+* Fixed Gson issue, when using Chucker with ProGuard [#1183]
 
 ### Added
 

--- a/library/proguard-rules.pro
+++ b/library/proguard-rules.pro
@@ -1,1 +1,5 @@
 -keep class com.chuckerteam.chucker.internal.data.entity.HttpTransaction { *; }
+
+# Gson
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken


### PR DESCRIPTION
Preserve `TypeToken` generic signature, to fix issue with ProGuard.

I only added `TypeToken` rule from [Gson example proguard file](https://github.com/google/gson/blob/main/examples/android-proguard-example/proguard.cfg). This fixes the the problem from related issue. I didn't notice any need for adding additional rules.

## :page_facing_up: Context
Fixes #1183

## :pencil: Changes
Added ProGuard consumer rules, to avoid Gson TypeToken releated crash.

## :hammer_and_wrench: How to test
Test in release mode with ProGuard enabled.
