### PR TITLE
Escape quotes in curl share

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharable.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharable.kt
@@ -19,7 +19,8 @@ internal class TransactionCurlCommandSharable(
                 if (isCompressed(header)) {
                     compressed = true
                 }
-                writeUtf8(" -H \"${header.name}: ${header.value}\"")
+                val headerValue = escapeHeaderValue(header.value)
+                writeUtf8(" -H \"${header.name}: ${headerValue}\"")
             }
 
             val requestBody = transaction.requestBody
@@ -36,5 +37,10 @@ internal class TransactionCurlCommandSharable(
                 "gzip".contains(header.value, ignoreCase = true) ||
                 "br".contains(header.value, ignoreCase = true)
         )
+    }
+
+    private fun escapeHeaderValue(value: String): String {
+        // escape double quotes from header value to prevent getting an invalid curl
+        return value.replace("\"", "\\\"")
     }
 }


### PR DESCRIPTION
## :camera: Screenshots
Share the curl and paste it into postman
Before my change you get that one:
![Screenshot 2024-04-10 at 16 35 20](https://github.com/ChuckerTeam/chucker/assets/656323/c683a041-d063-494f-9a1a-3a6e2a4dd209)

After my change you get that one
![Screenshot 2024-04-10 at 16 35 04](https://github.com/ChuckerTeam/chucker/assets/656323/348011ae-dff6-4bcd-a8f8-cea2a581c75b)

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
In our project/server we have a header that contain a JSON formatted text and every time someone try to use the curl from chucker the output curl is not working and result to errors.

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->
Will update the PR with that...

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->
No relations

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->
No breaking changes

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->
Ideally with a curl that will have a header with quotes `"`

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
No