### PR TITLE
Add save all transactions functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please add your entries according to this format.
 * Fixed share of curl when header values contain quotes [#1211]
 
 ### Added
+* Added _save as text_ and _save as .har file_ options to save all transactions [#1214]
 
 ### Fixed
 * Change GSON `TypeToken` creation to allow using Chucker in builds optimized by R8 [#1166]

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     ksp "androidx.room:room-compiler:$roomVersion"
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion"
 
     implementation "com.google.code.gson:gson:$gsonVersion"
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FileSaver.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FileSaver.kt
@@ -8,7 +8,18 @@ import okio.Source
 import okio.buffer
 import okio.sink
 
+/**
+ * Utility class to save a file from a [Source] to a [Uri].
+ */
 public object FileSaver {
+    /**
+     * Saves the data from the [source] to the file at the [uri] using the [contentResolver].
+     *
+     * @param source The source of the data to save.
+     * @param uri The URI of the file to save the data to.
+     * @param contentResolver The content resolver to use to save the data.
+     * @return `true` if the data was saved successfully, `false` otherwise.
+     */
     public suspend fun saveFile(
         source: Source,
         uri: Uri,

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FileSaver.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FileSaver.kt
@@ -4,7 +4,6 @@ import android.content.ContentResolver
 import android.net.Uri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import okio.BufferedSink
 import okio.Source
 import okio.buffer
 import okio.sink
@@ -19,7 +18,7 @@ public object FileSaver {
             runCatching {
                 contentResolver.openOutputStream(uri)?.use { outputStream ->
                     outputStream.sink().buffer().use { sink ->
-                        saveToFile(sink, source)
+                        sink.writeAll(source)
                     }
                 }
             }.onFailure {
@@ -28,12 +27,5 @@ public object FileSaver {
             }
             return@withContext true
         }
-    }
-
-    private fun saveToFile(
-        sink: BufferedSink,
-        source: Source,
-    ) {
-        sink.writeAll(source)
     }
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FileSaver.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FileSaver.kt
@@ -24,8 +24,8 @@ public object FileSaver {
         source: Source,
         uri: Uri,
         contentResolver: ContentResolver,
-    ): Boolean {
-        return withContext(Dispatchers.IO) {
+    ): Boolean =
+        withContext(Dispatchers.IO) {
             runCatching {
                 contentResolver.openOutputStream(uri)?.use { outputStream ->
                     outputStream.sink().buffer().use { sink ->
@@ -38,5 +38,4 @@ public object FileSaver {
             }
             return@withContext true
         }
-    }
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FileSaver.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FileSaver.kt
@@ -1,0 +1,39 @@
+package com.chuckerteam.chucker.internal.support
+
+import android.content.ContentResolver
+import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okio.BufferedSink
+import okio.Source
+import okio.buffer
+import okio.sink
+
+public object FileSaver {
+    public suspend fun saveFile(
+        source: Source,
+        uri: Uri,
+        contentResolver: ContentResolver,
+    ): Boolean {
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                contentResolver.openOutputStream(uri)?.use { outputStream ->
+                    outputStream.sink().buffer().use { sink ->
+                        saveToFile(sink, source)
+                    }
+                }
+            }.onFailure {
+                Logger.error("Failed to save data to a file", it)
+                return@withContext false
+            }
+            return@withContext true
+        }
+    }
+
+    private fun saveToFile(
+        sink: BufferedSink,
+        source: Source,
+    ) {
+        sink.writeAll(source)
+    }
+}

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
+import androidx.core.view.MenuCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -25,6 +26,7 @@ import com.chuckerteam.chucker.api.Chucker
 import com.chuckerteam.chucker.databinding.ChuckerActivityMainBinding
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.model.DialogData
+import com.chuckerteam.chucker.internal.support.FileSaver
 import com.chuckerteam.chucker.internal.support.HarUtils
 import com.chuckerteam.chucker.internal.support.Logger
 import com.chuckerteam.chucker.internal.support.Sharable
@@ -32,12 +34,17 @@ import com.chuckerteam.chucker.internal.support.TransactionDetailsHarSharable
 import com.chuckerteam.chucker.internal.support.TransactionListDetailsSharable
 import com.chuckerteam.chucker.internal.support.shareAsFile
 import com.chuckerteam.chucker.internal.support.showDialog
+import com.chuckerteam.chucker.internal.ui.MainActivity.ExportType.HAR
+import com.chuckerteam.chucker.internal.ui.MainActivity.ExportType.TEXT
 import com.chuckerteam.chucker.internal.ui.transaction.TransactionActivity
 import com.chuckerteam.chucker.internal.ui.transaction.TransactionAdapter
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okio.Source
+import okio.buffer
+import okio.source
 
 internal class MainActivity :
     BaseChuckerActivity(),
@@ -61,6 +68,16 @@ internal class MainActivity :
                 )
                 Logger.error("Notification permission denied. Can't show transactions info")
             }
+        }
+
+    private val saveTextToFile =
+        registerForActivityResult(ActivityResultContracts.CreateDocument(TEXT.mimeType)) { uri ->
+            onSaveToFileActivityResult(uri, TEXT)
+        }
+
+    private val saveHarToFile =
+        registerForActivityResult(ActivityResultContracts.CreateDocument(HAR.mimeType)) { uri ->
+            onSaveToFileActivityResult(uri, HAR)
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -111,6 +128,7 @@ internal class MainActivity :
             ) == PackageManager.PERMISSION_GRANTED -> {
                 // We have permission, all good
             }
+
             shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS) -> {
                 Snackbar.make(
                     mainBinding.root,
@@ -125,6 +143,7 @@ internal class MainActivity :
                     }
                 }.show()
             }
+
             else -> {
                 permissionRequest.launch(Manifest.permission.POST_NOTIFICATIONS)
             }
@@ -132,7 +151,8 @@ internal class MainActivity :
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.chucker_transactions_list, menu)
+        menuInflater.inflate(R.menu.chucker_transactions_list, menu) //
+        MenuCompat.setGroupDividerEnabled(menu, true)
         setUpSearch(menu)
         return super.onCreateOptionsMenu(menu)
     }
@@ -156,6 +176,7 @@ internal class MainActivity :
                 )
                 true
             }
+
             R.id.share_text -> {
                 showDialog(
                     getExportDialogData(R.string.chucker_export_text_http_confirmation),
@@ -168,6 +189,7 @@ internal class MainActivity :
                 )
                 true
             }
+
             R.id.share_har -> {
                 showDialog(
                     getExportDialogData(R.string.chucker_export_har_http_confirmation),
@@ -186,6 +208,17 @@ internal class MainActivity :
                 )
                 true
             }
+
+            R.id.save_text -> {
+                showSaveDialog(TEXT)
+                true
+            }
+
+            R.id.save_har -> {
+                showSaveDialog(HAR)
+                true
+            }
+
             else -> {
                 super.onOptionsItemSelected(item)
             }
@@ -247,6 +280,93 @@ internal class MainActivity :
             positiveButtonText = getString(R.string.chucker_export),
             negativeButtonText = getString(R.string.chucker_cancel),
         )
+
+    private fun getSaveDialogData(
+        @StringRes dialogMessage: Int,
+    ): DialogData =
+        DialogData(
+            title = getString(R.string.chucker_save),
+            message = getString(dialogMessage),
+            positiveButtonText = getString(R.string.chucker_save),
+            negativeButtonText = getString(R.string.chucker_cancel),
+        )
+
+    private fun showSaveDialog(exportType: ExportType) {
+        showDialog(
+            getSaveDialogData(
+                when (exportType) {
+                    TEXT -> R.string.chucker_save_text_http_confirmation
+                    HAR -> R.string.chucker_save_har_http_confirmation
+                },
+            ),
+            onPositiveClick = {
+                when (exportType) {
+                    TEXT -> saveTextToFile.launch(EXPORT_TXT_FILE_NAME)
+                    HAR -> saveHarToFile.launch(EXPORT_HAR_FILE_NAME)
+                }
+            },
+            onNegativeClick = null,
+        )
+    }
+
+    private fun onSaveToFileActivityResult(
+        uri: Uri?,
+        exportType: ExportType,
+    ) {
+        if (uri == null) {
+            Toast.makeText(
+                applicationContext,
+                R.string.chucker_save_failed_to_open_document,
+                Toast.LENGTH_SHORT,
+            ).show()
+            return
+        }
+        lifecycleScope.launch {
+            val source =
+                runCatching {
+                    prepareDataToSave(exportType)
+                }.getOrNull() ?: return@launch
+            val result = FileSaver.saveFile(source, uri, contentResolver)
+            val toastMessageId =
+                if (result) {
+                    R.string.chucker_file_saved
+                } else {
+                    R.string.chucker_file_not_saved
+                }
+            Toast.makeText(applicationContext, toastMessageId, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private suspend fun prepareDataToSave(exportType: ExportType): Source? {
+        val transactions = viewModel.getAllTransactions()
+        if (transactions.isEmpty()) {
+            showToast(applicationContext.getString(R.string.chucker_save_empty_text))
+            return null
+        }
+        return withContext(Dispatchers.IO) {
+            when (exportType) {
+                TEXT -> {
+                    TransactionListDetailsSharable(
+                        transactions,
+                        encodeUrls = false,
+                    ).toSharableContent(this@MainActivity)
+                }
+
+                HAR -> {
+                    HarUtils.harStringFromTransactions(
+                        transactions,
+                        getString(R.string.chucker_name),
+                        getString(R.string.chucker_version),
+                    ).byteInputStream().source().buffer()
+                }
+            }
+        }
+    }
+
+    private enum class ExportType(val mimeType: String) {
+        TEXT("text/plain"),
+        HAR("application/har+json"),
+    }
 
     companion object {
         private const val EXPORT_TXT_FILE_NAME = "transactions.txt"

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -151,7 +151,7 @@ internal class MainActivity :
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        menuInflater.inflate(R.menu.chucker_transactions_list, menu) //
+        menuInflater.inflate(R.menu.chucker_transactions_list, menu)
         MenuCompat.setGroupDividerEnabled(menu, true)
         setUpSearch(menu)
         return super.onCreateOptionsMenu(menu)

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -427,8 +427,8 @@ internal class TransactionPayloadFragment :
     private fun prepareDataToSave(
         type: PayloadType,
         transaction: HttpTransaction,
-    ): Source {
-        return when (type) {
+    ): Source =
+        when (type) {
             PayloadType.REQUEST -> {
                 transaction.requestBody?.byteInputStream()?.source()
                     ?: throw IOException(TRANSACTION_EXCEPTION)
@@ -439,7 +439,6 @@ internal class TransactionPayloadFragment :
                     ?: throw IOException(TRANSACTION_EXCEPTION)
             }
         }
-    }
 
     private fun isBodyEmpty(
         type: PayloadType,

--- a/library/src/main/res/menu/chucker_transaction.xml
+++ b/library/src/main/res/menu/chucker_transaction.xml
@@ -38,7 +38,7 @@
     </item>
     <item
         android:icon="@drawable/chucker_ic_save_white"
-        android:title="@string/chucker_save"
+        android:title="@string/chucker_save_body"
         android:id="@+id/save_body"
         android:visible="false"
         app:showAsAction="ifRoom">

--- a/library/src/main/res/menu/chucker_transactions_list.xml
+++ b/library/src/main/res/menu/chucker_transactions_list.xml
@@ -13,13 +13,23 @@
         android:title="@string/chucker_export"
         app:showAsAction="ifRoom">
         <menu>
-            <group>
+            <group
+                android:id="@+id/share_group">
                 <item
                     android:id="@+id/share_text"
                     android:title="@string/chucker_share_as_text" />
                 <item
                     android:id="@+id/share_har"
                     android:title="@string/chucker_share_as_har" />
+            </group>
+            <group
+                android:id="@+id/save_group">
+                <item
+                    android:id="@+id/save_text"
+                    android:title="@string/chucker_save_as_text" />
+                <item
+                    android:id="@+id/save_har"
+                    android:title="@string/chucker_save_as_har" />
             </group>
         </menu>
     </item>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -25,13 +25,17 @@
     <string name="chucker_no">No</string>
     <string name="chucker_share">Share</string>
     <string name="chucker_export">Export</string>
+    <string name="chucker_save">Save</string>
     <string name="chucker_export_empty_text">Nothing to export</string>
     <string name="chucker_export_no_file">Failed to create file for export</string>
     <string name="chucker_share_as_text">Share as text</string>
     <string name="chucker_share_as_curl">Share as curl command</string>
     <string name="chucker_share_as_file">Share as file</string>
     <string name="chucker_share_as_har">Share as .har file</string>
-    <string name="chucker_save">Save body to file</string>
+    <string name="chucker_save_as_text">Save as text</string>
+    <string name="chucker_save_as_har">Save as .har file</string>
+    <string name="chucker_save_body">Save body to file</string>
+    <string name="chucker_save_empty_text">Nothing to save</string>
     <string name="chucker_save_failed_to_open_document">Failed to open file chooser</string>
     <string name="chucker_file_saved">File saved successfully!</string>
     <string name="chucker_file_not_saved">Failed to save file</string>
@@ -49,6 +53,8 @@
     <string name="chucker_clear_http_confirmation">Do you want to clear complete network calls history?</string>
     <string name="chucker_export_text_http_confirmation">Do you want to export all network transactions as a text file?</string>
     <string name="chucker_export_har_http_confirmation">Do you want to export all network transactions as a .har file?</string>
+    <string name="chucker_save_text_http_confirmation">Do you want to save all network transactions as a text file?</string>
+    <string name="chucker_save_har_http_confirmation">Do you want to save all network transactions as a .har file?</string>
     <string name="chucker_export_separator">==================</string>
     <string name="chucker_export_prefix">/* Export Start */</string>
     <string name="chucker_export_postfix">/*  Export End  */</string>

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/FileSaverTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/FileSaverTest.kt
@@ -9,40 +9,59 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import okio.source
+import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.rules.TemporaryFolder
 
 @ExtendWith(NoLoggerRule::class)
 internal class FileSaverTest {
+    @Rule
+    @JvmField
+    val temporaryFolder = TemporaryFolder()
+
+    init {
+        temporaryFolder.create()
+    }
+
+    private val file = temporaryFolder.newFile(TEST_FILENAME)
+
+    private val uri =
+        mockk<Uri> {
+            every { scheme } returns TEST_FILE_SCHEME
+            every { path } returns file.path
+        }
+    private val contentResolver =
+        mockk<ContentResolver> {
+            every { openOutputStream(any()) } returns uri.toFile().outputStream()
+        }
+
     @Test
-    fun saveFile() =
+    fun `normal content test`() =
         runTest {
             val source = TEST_FILE_CONTENT.byteInputStream().source()
-            val uri =
-                mockk<Uri> {
-                    every { scheme } returns TEST_FILE_SCHEME
-                    every { path } returns TEST_FILENAME
-                }
-            val contentResolver =
-                mockk<ContentResolver> {
-                    every { openOutputStream(any()) } returns uri.toFile().outputStream()
-                }
-
-            val file = uri.toFile()
-
-            file.createNewFile()
 
             FileSaver.saveFile(source, uri, contentResolver)
 
             assertThat(file.length()).isEqualTo(TEST_FILE_CONTENT.length)
             assertThat(file.readText()).isEqualTo(TEST_FILE_CONTENT)
+        }
 
-            file.delete()
+    @Test
+    fun `empty content test`() =
+        runTest {
+            val source = TEST_EMPTY_FILE_CONTENT.byteInputStream().source()
+
+            FileSaver.saveFile(source, uri, contentResolver)
+
+            assertThat(file.length()).isEqualTo(TEST_EMPTY_FILE_CONTENT.length)
+            assertThat(file.readText()).isEqualTo(TEST_EMPTY_FILE_CONTENT)
         }
 
     private companion object {
         private const val TEST_FILENAME = "test_file"
         private const val TEST_FILE_SCHEME = "file"
         private const val TEST_FILE_CONTENT = "Hello world!"
+        private const val TEST_EMPTY_FILE_CONTENT = ""
     }
 }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/FileSaverTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/FileSaverTest.kt
@@ -1,0 +1,48 @@
+package com.chuckerteam.chucker.internal.support
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.core.net.toFile
+import com.chuckerteam.chucker.util.NoLoggerRule
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okio.source
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(NoLoggerRule::class)
+internal class FileSaverTest {
+    @Test
+    fun saveFile() =
+        runTest {
+            val source = TEST_FILE_CONTENT.byteInputStream().source()
+            val uri =
+                mockk<Uri> {
+                    every { scheme } returns TEST_FILE_SCHEME
+                    every { path } returns TEST_FILENAME
+                }
+            val contentResolver =
+                mockk<ContentResolver> {
+                    every { openOutputStream(any()) } returns uri.toFile().outputStream()
+                }
+
+            val file = uri.toFile()
+
+            file.createNewFile()
+
+            FileSaver.saveFile(source, uri, contentResolver)
+
+            assertThat(file.length()).isEqualTo(TEST_FILE_CONTENT.length)
+            assertThat(file.readText()).isEqualTo(TEST_FILE_CONTENT)
+
+            file.delete()
+        }
+
+    private companion object {
+        private const val TEST_FILENAME = "test_file"
+        private const val TEST_FILE_SCHEME = "file"
+        private const val TEST_FILE_CONTENT = "Hello world!"
+    }
+}


### PR DESCRIPTION
## :camera: Screenshots
<img width="379" alt="image" src="https://github.com/ChuckerTeam/chucker/assets/25252563/9ee8a35a-4a8d-4e5d-ab15-b6060061f2d6">


## :page_facing_up: Context
I usually test my apps on an emulator that isn't connected to Google services. This means I can't directly share transactions with others, as I don't have suitable apps for that purpose. Instead, it's much easier for me to save transactions locally and then share the file from my computer using Device Explorer.
Chucker only supported sharing transaction details as text or HAR but lacked direct file saving capabilities (you could save only a one request/response body).
This PR adds a feature to save all transactions on the local storage. New save buttons are located within share menu separated from share buttons group by divider.

## :pencil: Changes

- Introduced "Save as Text" and "Save as HAR" buttons to the share menu, grouped together and visually separated from existing share options.
- Implemented save-to-file logic, allowing users to save transactions data locally in either plain text or HAR format.
- Developed a FileSaver object to streamline the file-saving process within the library.
- Included a JUnit test to ensure the FileSaver.saveFile method writes files correctly to the given URI and with the expected content.

## :hammer_and_wrench: How to test
Click on the share button in the app bar and then click on _save as text_ / _save as .har file_. Check created files in a directory you specified.