### PR TITLE
fix : display the toolbar subtitle properly [#1217]

### DIFF
--- a/library/src/main/res/layout/chucker_activity_main.xml
+++ b/library/src/main/res/layout/chucker_activity_main.xml
@@ -10,7 +10,7 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout"
         android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -20,6 +20,8 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:paddingBottom="4dp"
+            app:subtitleTextAppearance="?attr/textAppearanceSubtitle2"
             app:popupTheme="@style/Chucker.Theme" />
 
     </com.google.android.material.appbar.AppBarLayout>


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->
<img width="396" alt="Screenshot 2024-04-24 at 10 16 59" src="https://github.com/ChuckerTeam/chucker/assets/1329281/5b54444f-c0c5-40e5-b6ee-6db5dd5cf1b7">

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
Layout updated.

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->
A layout xml file

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->
No