### PR TITLE
Add Regex skipPath/skipDomain to Builder, fixes #1236

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please add your entries according to this format.
 
 ### Added
 * Added _save as text_ and _save as .har file_ options to save all transactions [#1214]
+* Added `skipPaths(paths Regex)`, `skipDomains(domains Regex)` and  `skipDomains(domains... String)` to skip paths/domains from chucker [#1236]
 
 ### Fixed
 * Change GSON `TypeToken` creation to allow using Chucker in builds optimized by R8 [#1166]

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -21,6 +21,7 @@ complexity:
     active: true
     ignoreDefaultParameters: true
   TooManyFunctions:
+    thresholdInClasses: 13
     active: true
     ignoreOverridden: true
 

--- a/library-no-op/api/library-no-op.api
+++ b/library-no-op/api/library-no-op.api
@@ -38,6 +38,9 @@ public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
 	public final fun maxContentLength (J)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders (Ljava/lang/Iterable;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipDomains (Lkotlin/text/Regex;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipDomains ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipPaths (Lkotlin/text/Regex;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun skipPaths ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 }
 

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -45,7 +45,13 @@ public class ChuckerInterceptor private constructor(
 
         public fun createShortcut(enable: Boolean): Builder = this
 
-        public fun skipPaths(vararg paths: String): Builder = this
+        public fun skipPaths(vararg skipPaths: String): Builder = this
+
+        public fun skipPaths(skipPaths: Regex): Builder = this
+
+        public fun skipDomains(vararg skipDomains: String): Builder = this
+
+        public fun skipDomains(skipDomains: Regex): Builder = this
 
         public fun build(): ChuckerInterceptor = ChuckerInterceptor(this)
     }

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -45,13 +45,13 @@ public class ChuckerInterceptor private constructor(
 
         public fun createShortcut(enable: Boolean): Builder = this
 
-        public fun skipPaths(vararg skipPaths: String): Builder = this
+        public fun skipPaths(vararg paths: String): Builder = this
 
-        public fun skipPaths(skipPaths: Regex): Builder = this
+        public fun skipPaths(paths: Regex): Builder = this
 
-        public fun skipDomains(vararg skipDomains: String): Builder = this
+        public fun skipDomains(vararg domains: String): Builder = this
 
-        public fun skipDomains(skipDomains: Regex): Builder = this
+        public fun skipDomains(domains: Regex): Builder = this
 
         public fun build(): ChuckerInterceptor = ChuckerInterceptor(this)
     }

--- a/library/api/library.api
+++ b/library/api/library.api
@@ -38,6 +38,9 @@ public final class com/chuckerteam/chucker/api/ChuckerInterceptor$Builder {
 	public final fun maxContentLength (J)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders (Ljava/lang/Iterable;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun redactHeaders ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipDomains (Lkotlin/text/Regex;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipDomains ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
+	public final fun skipPaths (Lkotlin/text/Regex;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 	public final fun skipPaths ([Ljava/lang/String;)Lcom/chuckerteam/chucker/api/ChuckerInterceptor$Builder;
 }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -200,9 +200,9 @@ public class ChuckerInterceptor private constructor(
          * Sets a list of [String] to skip paths. When any of the [String] matches
          * a request path, the request will be skipped.
          */
-        public fun skipPaths(vararg skipPaths: String): Builder =
+        public fun skipPaths(vararg paths: String): Builder =
             apply {
-                skipPaths.forEach { candidatePath ->
+                paths.forEach { candidatePath ->
                     val httpUrl =
                         HttpUrl.Builder()
                             .scheme("https")
@@ -224,9 +224,9 @@ public class ChuckerInterceptor private constructor(
          *  ".*path/ends/with/dev$".toRegex(),
          * ```
          */
-        public fun skipPaths(skipPaths: Regex): Builder =
+        public fun skipPaths(paths: Regex): Builder =
             apply {
-                this.skipPathsRegex.add(skipPaths)
+                this.skipPathsRegex.add(paths)
             }
 
         /**
@@ -238,9 +238,9 @@ public class ChuckerInterceptor private constructor(
          * example.com, subdomain.example.com, exam-ple.com, eXaMpLe.CoM, example.co.uk
          * ```
          */
-        public fun skipDomains(vararg skipDomains: String): Builder =
+        public fun skipDomains(vararg domains: String): Builder =
             apply {
-                this@Builder.skipDomains.addAll(skipDomains.map { it.lowercase() })
+                this@Builder.skipDomains.addAll(domains.map { it.lowercase() })
             }
 
         /**
@@ -255,9 +255,9 @@ public class ChuckerInterceptor private constructor(
          *  ".*.dev$".toRegex(),
          * ```
          */
-        public fun skipDomains(skipDomains: Regex): Builder =
+        public fun skipDomains(domains: Regex): Builder =
             apply {
-                this.skipDomainRegex.add(skipDomains)
+                this.skipDomainRegex.add(domains)
             }
 
         /**

--- a/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorSkipRequestTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorSkipRequestTest.kt
@@ -41,10 +41,12 @@ internal class ChuckerInterceptorSkipRequestTest {
         executeRequestForPath(client, "/", "Response from /")
         val transaction = chuckerInterceptorWithoutSkipping.expectTransaction()
         assertThat(transaction.responseBody).isEqualTo("Response from /")
+        chuckerInterceptorWithoutSkipping.expectNoTransactions()
 
         executeRequestForPath(client, "/skip/path", "Response from /skip/path")
         val secondTransaction = chuckerInterceptorWithoutSkipping.expectTransaction()
         assertThat(secondTransaction.responseBody).isEqualTo("Response from /skip/path")
+        chuckerInterceptorWithoutSkipping.expectNoTransactions()
     }
 
     @ParameterizedTest

--- a/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorSkipRequestTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorSkipRequestTest.kt
@@ -1,0 +1,315 @@
+package com.chuckerteam.chucker.api
+
+import com.chuckerteam.chucker.util.ChuckerInterceptorDelegate
+import com.chuckerteam.chucker.util.ClientFactory
+import com.chuckerteam.chucker.util.NoLoggerRule
+import com.chuckerteam.chucker.util.readByteStringBody
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Rule
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.io.File
+
+@ExtendWith(NoLoggerRule::class)
+internal class ChuckerInterceptorSkipRequestTest {
+    @get:Rule
+    val server = MockWebServer()
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @ParameterizedTest
+    @EnumSource(value = ClientFactory::class)
+    fun `chucker skips requests when skipPaths are provided as a regular expression`(factory: ClientFactory) {
+        val chuckerInterceptorWithSkipping =
+            ChuckerInterceptorDelegate(
+                cacheDirectoryProvider = { tempDir },
+                skipPathsRegex =
+                    listOf(
+                        ".*(jpg|jpeg|png|gif|webp)$".toRegex(),
+                        ".*path/to/skip.*".toRegex(),
+                        ".*skipme.*".toRegex(RegexOption.IGNORE_CASE),
+                    ),
+            )
+
+        val client = factory.create(chuckerInterceptorWithSkipping)
+
+        executeRequestForEncodedPath(client, "/path/to/image/my-image.jpg", "Ends with jpg")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(
+            client,
+            "/path/to/image with space/my-image.jpg",
+            "Ends with jpg, has space in path",
+        )
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "/path/to/image/my-image.jpeg", "Ends with jpeg")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "/path/to/image/my-image.png", "Ends with png")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "/path/to/image/my-image.gif", "Ends with gif")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "/path/to/image/my-image.webp", "Ends with webp")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "path/to/skip", "matches path to skip")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "/path/to/skip/", "matches path to skip")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "no/path/to/skip/here", "matches path to skip")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(
+            client,
+            "/path/to/skip/here",
+            "matches path to skip with extra path segment",
+        )
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(
+            client,
+            "more/path/to/skip/here",
+            "matches path to skip with extra path segments",
+        )
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(
+            client,
+            "/path/to/skip/my-image.jpg",
+            "Matches both skip paths",
+        )
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(
+            client,
+            "/path/to/image/skipme.txt",
+            "Has 'skipme' in file name",
+        )
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "/path/to/skipme/file.mp4", "Has 'skipme' in path")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(
+            client,
+            "/path/to/image/image.skipme/",
+            "Has 'skipme' in extension",
+        )
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "/path/to/image/SKIPME.txt", "Case sensitive")
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ClientFactory::class)
+    fun `chucker does not skip requests when skipPaths are provided and doesn't match`(factory: ClientFactory) {
+        val chuckerInterceptorWithSkipping =
+            ChuckerInterceptorDelegate(
+                cacheDirectoryProvider = { tempDir },
+                skipPathsRegex =
+                    listOf(
+                        ".*(jpg|jpeg|png|gif|webp)$".toRegex(),
+                        ".*path/to/skip.*".toRegex(),
+                        ".*skipme.*".toRegex(),
+                    ),
+            )
+
+        val client = factory.create(chuckerInterceptorWithSkipping)
+
+        executeRequestForEncodedPath(client, "/path/to/image/my-image.JPEG", "Case sensitive")
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "/valid/path", "Random path to execute")
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "/path/to/image/SKIPME.txt", "Case sensitive")
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(
+            client,
+            "/path/to/image/my-image.jpg/",
+            "Doesn't end with jpg, has trailing slash",
+        )
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        executeRequestForEncodedPath(client, "***", "Doesn't match any path")
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+    }
+
+    @Test
+    fun `chucker skips requests when skip domains are provided and matches`() {
+        val chuckerInterceptorWithSkipping =
+            ChuckerInterceptorDelegate(
+                cacheDirectoryProvider = { tempDir },
+                skipDomains =
+                    listOf(
+                        "skip-that.com",
+                        "sub-domain.skip-this.com",
+                        "skip.com",
+                    ),
+                skipDomainsRegex =
+                    listOf(
+                        ".*skipme.*".toRegex(),
+                        ".*skipper.com".toRegex(),
+                    ),
+            )
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skipme.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("SKIPME.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skipme.dev"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("doskipmehere.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("subdomain.skipme.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skipme.domain.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skipper.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("SkIpPeR.COM"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("prefix-skipper.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skip-that.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("SuB-dOmAin.SKIP-this.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skip.com"))
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+    }
+
+    @Test
+    fun `chucker should not skip requests when skip domains are provided and does not match`() {
+        val chuckerInterceptorWithSkipping =
+            ChuckerInterceptorDelegate(
+                cacheDirectoryProvider = { tempDir },
+                skipDomains =
+                    listOf(
+                        "skip-that.com",
+                        "sub-domain.skip-this.com",
+                        "skip.com",
+                    ),
+                skipDomainsRegex =
+                    listOf(
+                        ".*skipme.*".toRegex(),
+                        ".*skipper.com".toRegex(),
+                    ),
+            )
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skipper.com.co"))
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skipper.domain.com"))
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("domain.com"))
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("domain.com", "/skipme/in/path"))
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skip-that.co"))
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skip-that.co.m"))
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("sub-domain.skip-that.com"))
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("inner.sub-domain.skip-this.com"))
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+
+        chuckerInterceptorWithSkipping.intercept(getChainFor("skip.ca"))
+        chuckerInterceptorWithSkipping.expectTransaction()
+        // Ensure no more pending transactions
+        chuckerInterceptorWithSkipping.expectNoTransactions()
+    }
+
+    private fun getChainFor(
+        host: String,
+        path: String = "/",
+    ) = mockk<Interceptor.Chain> {
+        every { request() } returns
+            mockk {
+                every { url } returns
+                    HttpUrl.Builder().scheme("https").host(host)
+                        .addEncodedPathSegments(path).build()
+                every { headers } returns Headers.Builder().build()
+                every { method } returns "GET"
+                every { body } returns null
+            }
+        every { proceed(any<Request>()) } returns
+            mockk(relaxed = true) {
+                every { headers } returns Headers.Builder().build()
+                every { body } returns null
+            }
+    }
+
+    private fun executeRequestForEncodedPath(
+        okHttpClient: OkHttpClient,
+        path: String,
+        responseBody: String,
+    ) {
+        val request = Request.Builder().url(server.url(path)).build()
+        server.enqueue(MockResponse().setBody(responseBody))
+        okHttpClient.newCall(request).execute().readByteStringBody()
+    }
+}

--- a/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -94,6 +94,8 @@ internal class ChuckerInterceptorTest {
 
         assertThat(transaction.isRequestBodyEncoded).isFalse()
         assertThat(transaction.responseBody).isEqualTo("Hello, world!")
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest
@@ -126,6 +128,8 @@ internal class ChuckerInterceptorTest {
         val transaction = chuckerInterceptor.expectTransaction()
 
         assertThat(transaction.responseBody).isNull()
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest
@@ -163,6 +167,8 @@ internal class ChuckerInterceptorTest {
         assertThat(transaction.isRequestBodyEncoded).isFalse()
         assertThat(transaction.responseBody).contains("\"brotli\": true")
         assertThat(transaction.responseBody).contains("\"Accept-Encoding\": \"br\"")
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest
@@ -198,6 +204,8 @@ internal class ChuckerInterceptorTest {
 
         assertThat(transaction.isRequestBodyEncoded).isFalse()
         assertThat(transaction.responseBody).isEqualTo("Hello, world!")
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest
@@ -224,6 +232,8 @@ internal class ChuckerInterceptorTest {
         val transaction = chuckerInterceptor.expectTransaction()
 
         assertThat(transaction.responseBody).isNull()
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest
@@ -263,6 +273,8 @@ internal class ChuckerInterceptorTest {
                 2 * SEGMENT_SIZE,
             ),
         )
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest
@@ -309,6 +321,8 @@ internal class ChuckerInterceptorTest {
 
         val transaction = chuckerInterceptor.expectTransaction()
         assertThat(transaction.responseBody?.length).isEqualTo(1_000)
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest
@@ -385,6 +399,8 @@ internal class ChuckerInterceptorTest {
         val transaction = chuckerInterceptor.expectTransaction()
         assertThat(transaction.responseBody).isNull()
         assertThat(transaction.responsePayloadSize).isEqualTo(body.size)
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest
@@ -419,6 +435,8 @@ internal class ChuckerInterceptorTest {
         val transaction = chuckerInterceptor.expectTransaction()
         assertThat(transaction.responseBody).isEqualTo("Hello, world!")
         assertThat(transaction.responsePayloadSize).isEqualTo(body.size)
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest
@@ -455,6 +473,8 @@ internal class ChuckerInterceptorTest {
         val transaction = chuckerInterceptor.expectTransaction()
         assertThat(transaction.responseBody).isEqualTo(providedJson)
         assertThat(transaction.responsePayloadSize).isEqualTo(body.size)
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     private data class Expected(val string: String, val boolean: Boolean, val secondString: String)
@@ -498,6 +518,8 @@ internal class ChuckerInterceptorTest {
         assertThat(transaction.isRequestBodyEncoded).isFalse()
         assertThat(transaction.requestBody).isEqualTo("Hello, world!")
         assertThat(transaction.requestPayloadSize).isEqualTo(request.body!!.contentLength())
+
+        chuckerInterceptor.expectNoTransactions()
     }
 
     @ParameterizedTest

--- a/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorTest.kt
@@ -12,9 +12,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.gson.Gson
 import com.google.gson.JsonParseException
 import com.google.gson.stream.JsonReader
-import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -655,88 +653,5 @@ internal class ChuckerInterceptorTest {
         val serverRequestContent = server.takeRequest().body.readByteString()
 
         assertThat(serverRequestContent.utf8()).isEqualTo("Hello, world!")
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = ClientFactory::class)
-    fun `chucker processes all requests when no skipEndpoints are provided`(factory: ClientFactory) {
-        val chuckerInterceptorWithoutSkipping =
-            ChuckerInterceptorDelegate(
-                cacheDirectoryProvider = { tempDir },
-            )
-        val client = factory.create(chuckerInterceptorWithoutSkipping)
-        executeRequestForPath(client, "/", "Response from /")
-        val transaction = chuckerInterceptorWithoutSkipping.expectTransaction()
-        assertThat(transaction.responseBody).isEqualTo("Response from /")
-
-        executeRequestForPath(client, "/skip/path", "Response from /skip/path")
-        val secondTransaction = chuckerInterceptorWithoutSkipping.expectTransaction()
-        assertThat(secondTransaction.responseBody).isEqualTo("Response from /skip/path")
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = ClientFactory::class)
-    fun `chucker skips requests when skipPaths are provided`(factory: ClientFactory) {
-        val chuckerInterceptorWithoutSkipping =
-            ChuckerInterceptorDelegate(
-                cacheDirectoryProvider = { tempDir },
-                skipPaths =
-                    listOf(
-                        "",
-                        "    ",
-                        "example",
-                        "www.example.com/skip/path",
-                        "example.com/skip/path",
-                        "90",
-                        "https://example/",
-                        "/skip/path",
-                        "/skip//",
-                        "http://localhost:8080/skip/path/ext",
-                    ),
-            )
-        val client = factory.create(chuckerInterceptorWithoutSkipping)
-
-        executeRequestForPath(client, "", "Hello, world!")
-        chuckerInterceptorWithoutSkipping.expectNoTransactions()
-
-        executeRequestForPath(client, "    ", "Hello, world!")
-        chuckerInterceptorWithoutSkipping.expectNoTransactions()
-
-        executeRequestForPath(client, "www.example.com/skip/path", "Hello, world!")
-        chuckerInterceptorWithoutSkipping.expectNoTransactions()
-
-        executeRequestForPath(client, "example.com/skip/path", "Hello, world!")
-        chuckerInterceptorWithoutSkipping.expectNoTransactions()
-
-        executeRequestForPath(client, "90", "Hello, world!")
-        chuckerInterceptorWithoutSkipping.expectNoTransactions()
-
-        executeRequestForPath(client, "https://example/", "Hello, world!")
-        chuckerInterceptorWithoutSkipping.expectNoTransactions()
-
-        executeRequestForPath(client, "/skip/path", "Hello, world!")
-        chuckerInterceptorWithoutSkipping.expectNoTransactions()
-
-        executeRequestForPath(client, "/skip//", "Hello, world!")
-        chuckerInterceptorWithoutSkipping.expectNoTransactions()
-
-        executeRequestForPath(client, "http://localhost:8080/skip/path/ext", "Hello, world!")
-        chuckerInterceptorWithoutSkipping.expectNoTransactions()
-    }
-
-    private fun executeRequestForPath(
-        okHttpClient: OkHttpClient,
-        path: String,
-        responseBody: String,
-    ) {
-        val httpUrl =
-            HttpUrl.Builder().scheme("https")
-                .host("testexample.com")
-                .addPathSegment(path)
-                .build()
-
-        val request = Request.Builder().url(server.url(httpUrl.encodedPath)).build()
-        server.enqueue(MockResponse().setBody(responseBody))
-        okHttpClient.newCall(request).execute().readByteStringBody()
     }
 }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
@@ -49,8 +49,8 @@ internal class ChuckerInterceptorDelegate(
             .redactHeaders(headersToRedact)
             .alwaysReadResponseBody(alwaysReadResponseBody)
             .cacheDirectorProvider(cacheDirectoryProvider)
-            .skipPaths(skipPaths = skipPaths.toTypedArray())
-            .skipDomains(skipDomains = skipDomains.toTypedArray())
+            .skipPaths(paths = skipPaths.toTypedArray())
+            .skipDomains(domains = skipDomains.toTypedArray())
             .apply { skipPathsRegex.forEach(::skipPaths) }
             .apply { skipDomainsRegex.forEach(::skipDomains) }
             .apply { decoders.forEach(::addBodyDecoder) }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/util/ChuckerInterceptorDelegate.kt
@@ -21,6 +21,9 @@ internal class ChuckerInterceptorDelegate(
     cacheDirectoryProvider: CacheDirectoryProvider,
     decoders: List<BodyDecoder> = emptyList(),
     skipPaths: List<String> = emptyList(),
+    skipPathsRegex: List<Regex> = emptyList(),
+    skipDomains: List<String> = emptyList(),
+    skipDomainsRegex: List<Regex> = emptyList(),
 ) : Interceptor {
     private val idGenerator = AtomicLong()
     private val transactions = CopyOnWriteArrayList<HttpTransaction>()
@@ -47,6 +50,9 @@ internal class ChuckerInterceptorDelegate(
             .alwaysReadResponseBody(alwaysReadResponseBody)
             .cacheDirectorProvider(cacheDirectoryProvider)
             .skipPaths(skipPaths = skipPaths.toTypedArray())
+            .skipDomains(skipDomains = skipDomains.toTypedArray())
+            .apply { skipPathsRegex.forEach(::skipPaths) }
+            .apply { skipDomainsRegex.forEach(::skipDomains) }
             .apply { decoders.forEach(::addBodyDecoder) }
             .build()
 

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
@@ -31,6 +31,11 @@ fun createOkHttpClient(
             .maxContentLength(250_000L)
             .redactHeaders(emptySet())
             .skipPaths("anything")
+            // Filter Images
+//            .skipPaths(".*(jpg|jpeg|png|gif|webp|svg|bmp|ico)$".toRegex())
+            // Filter domains
+//            .skipDomains("httpbin.org", "postman-echo.com")
+//            .skipDomains(".*akamai.com".toRegex())
             .alwaysReadResponseBody(false)
             .addBodyDecoder(PokemonProtoBodyDecoder())
             .build()


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

When `.skipPaths(".*(jpg|jpeg|png|gif|webp|svg|bmp|ico)$".toRegex())` is set

https://github.com/ChuckerTeam/chucker/assets/1086927/a22c0560-92f6-4662-a02a-6f480444995b

When `.skipDomain(".*akamai.com".toRegex(), "httpbin.org".toRegex())` is set

https://github.com/ChuckerTeam/chucker/assets/1086927/2268e059-5580-4c1c-b108-7ef5b7f398df


## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
Fixes https://github.com/ChuckerTeam/chucker/issues/1236

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->
* Added two new functions to [Builder](https://github.com/ChuckerTeam/chucker/blob/0527438f292dbdebe798e572106c8cf62687b8dc/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt#L100)
  * `skipPath(...Regex)`
  * `skipDomain(...Regex)`

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->
Check commmit eaff3e1c8c4f2a92e560852e400619117c6a8e02, and uncomment `skipPath` and/or `skipDomain` as needed.
