### PR TITLE
Solution: method skipPaths on builder does not work as expected, issue #1237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please add your entries according to this format.
 * Kotlin to 2.0.20
 * AGP to 8.5.2
 * Fix Toolbar is not accessible on api level 35 [#1280]
+* Fixed the `skipPaths` method unexpectedly modified the passed arguments [#1237]
 
 ### Added
 * Added _save as text_ and _save as .har file_ options to save all transactions [#1214]

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -200,7 +200,9 @@ public class ChuckerInterceptor private constructor(
         /**
          * Sets a list of [String] to skip paths. When any of the [String] matches
          * a request path, the request will be skipped.
-         * NOTE: empty path segments like '/', '//' and so on are not supported and will be skipped
+         *
+         * **Note:** An empty path will be treated as the '/'.
+         * '//' will also be treated as the '/' path.
          */
         public fun skipPaths(vararg paths: String): Builder =
             apply {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -7,6 +7,7 @@ import com.chuckerteam.chucker.internal.support.CacheDirectoryProvider
 import com.chuckerteam.chucker.internal.support.PlainTextDecoder
 import com.chuckerteam.chucker.internal.support.RequestProcessor
 import com.chuckerteam.chucker.internal.support.ResponseProcessor
+import com.chuckerteam.chucker.internal.support.addNonBlankPathSegments
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -199,6 +200,7 @@ public class ChuckerInterceptor private constructor(
         /**
          * Sets a list of [String] to skip paths. When any of the [String] matches
          * a request path, the request will be skipped.
+         * NOTE: empty path segments like '/', '//' and so on are not supported and will be skipped
          */
         public fun skipPaths(vararg paths: String): Builder =
             apply {
@@ -207,7 +209,8 @@ public class ChuckerInterceptor private constructor(
                         HttpUrl.Builder()
                             .scheme("https")
                             .host("example.com")
-                            .addPathSegment(candidatePath).build()
+                            .addNonBlankPathSegments(candidatePath)
+                            .build()
                     this@Builder.skipPaths.add(httpUrl.encodedPath)
                 }
             }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/HttpUrlUtils.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/HttpUrlUtils.kt
@@ -1,0 +1,11 @@
+package com.chuckerteam.chucker.internal.support
+
+import okhttp3.HttpUrl
+
+private const val PATH_SEGMENTS_DELIMITER = "/"
+
+public fun HttpUrl.Builder.addNonBlankPathSegments(candidatePath: String): HttpUrl.Builder =
+    apply {
+        candidatePath.split(PATH_SEGMENTS_DELIMITER).filter { it.isNotBlank() }
+            .forEach { item -> addPathSegment(item) }
+    }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorSkipRequestTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptorSkipRequestTest.kt
@@ -1,5 +1,6 @@
 package com.chuckerteam.chucker.api
 
+import com.chuckerteam.chucker.internal.support.addNonBlankPathSegments
 import com.chuckerteam.chucker.util.ChuckerInterceptorDelegate
 import com.chuckerteam.chucker.util.ClientFactory
 import com.chuckerteam.chucker.util.NoLoggerRule
@@ -379,7 +380,11 @@ internal class ChuckerInterceptorSkipRequestTest {
         responseBody: String,
     ) {
         val httpUrl =
-            HttpUrl.Builder().scheme("https").host("testexample.com").addPathSegment(path).build()
+            HttpUrl.Builder()
+                .scheme("https")
+                .host("testexample.com")
+                .addNonBlankPathSegments(path)
+                .build()
 
         val request = Request.Builder().url(server.url(httpUrl.encodedPath)).build()
         server.enqueue(MockResponse().setBody(responseBody))


### PR DESCRIPTION
## :page_facing_up: Context
The [Issue](https://github.com/ChuckerTeam/chucker/issues/1237) occurs when we add path segments delimited by '/' as part of the filtering mechanism, and HttpUrl treats them as a single, large path segment.

## :pencil: Changes
I added methods to safely add skips_path.

### Why not use HttpUrl::addPathSegments?
The problem with addPathSegments is that it replaces a leading '/' with an empty path segment, turning '/' into '//'. This causes issues for HttpUrl in general.

#### For example
Both MockWebServer::url and HttpUrl.Builder::resolve don't handle '//' segments properly.
```kotlin
private fun executeRequestForPath(
        okHttpClient: OkHttpClient,
        path: String,
        responseBody: String,
    ) {
        val httpUrl =
            HttpUrl.Builder()
                .scheme("https")
                .host("testexample.com")
                .addPathSegments(path)
                .build()

        val request = Request.Builder().url(server.url(httpUrl.encodedPath)).build()
        server.enqueue(MockResponse().setBody(responseBody))
        okHttpClient.newCall(request).execute().readByteStringBody()
  }
```

| Path                            |  request.url                             | 
| -- |--|
| "" | http://localhost:52347/ |
| "     "| http://localhost:52347/%20%20%20%20|
| "/skip/path"| http://skip/path |
| "//skip//path" | http://skip//path |

I consider these results problematic for our tests as the logic is changed here.

Even if we found a workaround, user inputs would still be transformed from '/path/to/test' to '//path/to/test', which leads to unexpected behavior.

### Comparison table for user input conversion using HttpUrl method and custom extension

| User filter                             | with HttpUrl::addPathSegments                               | with addNonBlankPathSegments    |
|--------------------------------------------|----------------------------------------------|----------------------------------------------|
| ""                                         | /                                            | /                                            |
| "    "                                     | /%20%20%20%20                                |                                              |
| "example"                                  | /example                                     | /example                                     |
| "www.example.com/skip/path"                | /www.example.com/skip/path                   | /www.example.com/skip/path                   |
| "example.com/skip/path"                    | /example.com/skip/path                       | /example.com/skip/path                       |
| "90"                                       | /90                                          | /90                                          |
| "https://example/"                         | /https://example/                            | /https:/example                              |
| "/skip/path"                               | //skip/path                                  | /skip/path                                   |
| "/skip//"                                  | //skip//                                     | /skip                                        |
| "http://localhost:8080/skip/path/ext"      | /http://localhost:8080/skip/path/ext          | /http:/localhost:8080/skip/path/ext          |
|"//skip//path" | ///skip//path// | /skip/path |

#### Should we consider removing full URLs with hosts from tests, since there is a separate field for that purpose - 'skipDomain'?

## :no_entry_sign: Breaking
Duplicated and empty path segments will be ignored once this change is applied.
