### PR TITLE
Fix #1326: Move test dependency to test classpath

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -79,7 +79,6 @@ dependencies {
     ksp "androidx.room:room-compiler:$roomVersion"
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion"
 
     implementation "com.google.code.gson:gson:$gsonVersion"
 
@@ -99,6 +98,7 @@ dependencies {
     testImplementation "androidx.arch.core:core-testing:$androidXCoreVersion"
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutineVersion"
 
     androidTestImplementation "junit:junit:$junit4Version"
     androidTestImplementation "androidx.test:runner:$androidXTestRunner"


### PR DESCRIPTION
## :camera: Screenshots
None.

## :page_facing_up: Context
 * Fixes https://github.com/ChuckerTeam/chucker/issues/1326

## :pencil: Changes
Move test dependency to test. How? Because `implementation` is auto-exposed to `testImplementation`, so it worked before. Moving it to test directly should still work.

## :paperclip: Related PR
* Introduced in https://github.com/ChuckerTeam/chucker/pull/1214

## :no_entry_sign: Breaking
Removing a dependency is breaking change I guess, but since it was unintended it's not breaking?! idk 🤷🏻‍♂️

## :hammer_and_wrench: How to test
CI Should test it, tests should pass.

## :stopwatch: Next steps
Release 4.1.1
