### PR TITLE
Fix: Search functionality in the body tab

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadAdapter.kt
@@ -90,16 +90,16 @@ internal class TransactionBodyAdapter(private val onCopyBodyListener: () -> Unit
         foregroundColor: Int,
     ): List<SearchItemBodyLine> {
         val listOfSearchItems = arrayListOf<SearchItemBodyLine>()
-        items.filterIsInstance<TransactionPayloadItem.BodyLineItem>()
-            .withIndex()
+        items.withIndex()
             .forEach { (index, item) ->
+                if (item !is TransactionPayloadItem.BodyLineItem) return@forEach
                 val listOfOccurrences = item.line.indicesOf(newText)
                 if (listOfOccurrences.isNotEmpty()) {
                     // storing the occurrences and their positions
                     listOfOccurrences.forEach {
                         listOfSearchItems.add(
                             SearchItemBodyLine(
-                                indexBodyLine = index + 1,
+                                indexBodyLine = index,
                                 indexStartOfQuerySubString = it,
                             ),
                         )
@@ -114,12 +114,12 @@ internal class TransactionBodyAdapter(private val onCopyBodyListener: () -> Unit
                             backgroundColor,
                             foregroundColor,
                         )
-                    notifyItemChanged(index + 1)
+                    notifyItemChanged(index)
                 } else {
                     // Let's clear the spans if we haven't found the query string.
                     val removedSpansCount = item.line.clearHighlightSpans()
                     if (removedSpansCount > 0) {
-                        notifyItemChanged(index + 1)
+                        notifyItemChanged(index)
                     }
                 }
             }
@@ -147,12 +147,12 @@ internal class TransactionBodyAdapter(private val onCopyBodyListener: () -> Unit
     }
 
     internal fun resetHighlight() {
-        items.filterIsInstance<TransactionPayloadItem.BodyLineItem>()
-            .withIndex()
+        items.withIndex()
             .forEach { (index, item) ->
+                if (item !is TransactionPayloadItem.BodyLineItem) return@forEach
                 val removedSpansCount = item.line.clearHighlightSpans()
                 if (removedSpansCount > 0) {
-                    notifyItemChanged(index + 1)
+                    notifyItemChanged(index)
                 }
             }
     }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -320,6 +320,7 @@ internal class TransactionPayloadFragment :
                     backgroundSpanColor,
                     foregroundSpanColor,
                 )
+            println("listOfSearchQuery: $listOfSearchQuery")
             if (listOfSearchQuery.isNotEmpty()) {
                 scrollableIndices.addAll(listOfSearchQuery)
             } else {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionPayloadFragment.kt
@@ -320,7 +320,6 @@ internal class TransactionPayloadFragment :
                     backgroundSpanColor,
                     foregroundSpanColor,
                 )
-            println("listOfSearchQuery: $listOfSearchQuery")
             if (listOfSearchQuery.isNotEmpty()) {
                 scrollableIndices.addAll(listOfSearchQuery)
             } else {


### PR DESCRIPTION
This commit addresses and fixes the search functionality in the body ([issue reference](https://github.com/ChuckerTeam/chucker/issues/1334)) tab by:

- Including all items in the search instead of filtering only body line items.
- Correcting the index used for search and highlighting.
- Clearing spans when the query string is not found.
- Resetting highlight on all items.

These changes ensure that the search works correctly and highlights the correct lines in the body tab.

## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

https://github.com/user-attachments/assets/e039c24f-cbd2-4a66-bd32-bb74629267d2



## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
