### PR TITLE
Test: Add unit tests for MainViewModel

### DIFF
--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
@@ -1,0 +1,165 @@
+package com.chuckerteam.chucker.internal.ui
+
+import android.text.TextUtils
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
+import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
+import com.chuckerteam.chucker.internal.data.repository.HttpTransactionRepository
+import com.chuckerteam.chucker.internal.data.repository.RepositoryProvider
+import com.chuckerteam.chucker.internal.support.NotificationHelper
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+@ExperimentalCoroutinesApi
+internal class MainViewModelTest {
+
+    @get:Rule
+    val instantExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @MockK
+    private lateinit var transactionRepository: HttpTransactionRepository
+
+    @MockK
+    private lateinit var transactionObserver: Observer<List<HttpTransactionTuple>>
+
+    private lateinit var viewModel: MainViewModel
+
+    private val emptyTransactionList = MutableLiveData<List<HttpTransactionTuple>>()
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic(TextUtils::class)
+
+        every { transactionObserver.onChanged(any()) } just runs
+
+        every { transactionRepository.getSortedTransactionTuples() } returns emptyTransactionList
+        every {
+            transactionRepository.getFilteredTransactionTuples(
+                any(),
+                any()
+            )
+        } returns emptyTransactionList
+
+        mockkObject(RepositoryProvider)
+        every { RepositoryProvider.transaction() } returns transactionRepository
+
+        mockkObject(NotificationHelper)
+        every { NotificationHelper.clearBuffer() } just runs
+
+        viewModel = MainViewModel()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `when search query is empty, getSortedTransactionTuples is called`() = runTest {
+        val expectedTuples = listOf(mockk<HttpTransactionTuple>(relaxed = true))
+        val transactionLiveData = MutableLiveData<List<HttpTransactionTuple>>()
+        every { transactionRepository.getSortedTransactionTuples() } returns transactionLiveData
+        every { TextUtils.isDigitsOnly(any()) } returns false
+
+        viewModel.transactions.observeForever(transactionObserver)
+        viewModel.updateItemsFilter("")
+        transactionLiveData.value = expectedTuples
+
+        verify { transactionRepository.getSortedTransactionTuples() }
+        verify { transactionObserver.onChanged(expectedTuples) }
+    }
+
+    @Test
+    fun `when search query contains only digits, getFilteredTransactionTuples is called with correct parameters`() =
+        runTest {
+            val searchQuery = "123"
+            val expectedTuples = listOf(mockk<HttpTransactionTuple>(relaxed = true))
+            val transactionLiveData = MutableLiveData<List<HttpTransactionTuple>>()
+            every {
+                transactionRepository.getFilteredTransactionTuples(
+                    searchQuery,
+                    ""
+                )
+            } returns transactionLiveData
+            every { TextUtils.isDigitsOnly(searchQuery) } returns true
+
+            viewModel.transactions.observeForever(transactionObserver)
+            viewModel.updateItemsFilter(searchQuery)
+            transactionLiveData.value = expectedTuples
+
+            verify { transactionRepository.getFilteredTransactionTuples(searchQuery, "") }
+            verify { transactionObserver.onChanged(expectedTuples) }
+        }
+
+    @Test
+    fun `when search query contains text, getFilteredTransactionTuples is called with correct parameters`() =
+        runTest {
+            val searchQuery = "test"
+            val expectedTuples = listOf(mockk<HttpTransactionTuple>(relaxed = true))
+            val transactionLiveData = MutableLiveData<List<HttpTransactionTuple>>()
+            every {
+                transactionRepository.getFilteredTransactionTuples(
+                    "",
+                    searchQuery
+                )
+            } returns transactionLiveData
+            every { TextUtils.isDigitsOnly(searchQuery) } returns false
+
+            viewModel.transactions.observeForever(transactionObserver)
+            viewModel.updateItemsFilter(searchQuery)
+            transactionLiveData.value = expectedTuples
+
+            verify { transactionRepository.getFilteredTransactionTuples("", searchQuery) }
+            verify { transactionObserver.onChanged(expectedTuples) }
+        }
+
+    @Test
+    fun `getAllTransactions returns repository data`() = runTest {
+        val expectedTransactions = listOf(mockk<HttpTransaction>(relaxed = true))
+        coEvery { transactionRepository.getAllTransactions() } returns expectedTransactions
+
+        val result = viewModel.getAllTransactions()
+
+        assertEquals(expectedTransactions, result)
+        coVerify { transactionRepository.getAllTransactions() }
+    }
+
+    @Test
+    fun `clearTransactions clears repository and notification buffer`() = runTest {
+        coEvery { transactionRepository.deleteAllTransactions() } just runs
+
+        viewModel.clearTransactions()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify { transactionRepository.deleteAllTransactions() }
+        verify { NotificationHelper.clearBuffer() }
+    }
+}

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 
 @ExperimentalCoroutinesApi
 internal class MainViewModelTest {
-
     @get:Rule
     val instantExecutorRule = InstantTaskExecutorRule()
 
@@ -63,7 +62,7 @@ internal class MainViewModelTest {
         every {
             transactionRepository.getFilteredTransactionTuples(
                 any(),
-                any()
+                any(),
             )
         } returns emptyTransactionList
 
@@ -83,19 +82,20 @@ internal class MainViewModelTest {
     }
 
     @Test
-    fun `when search query is empty, getSortedTransactionTuples is called`() = runTest {
-        val expectedTuples = listOf(mockk<HttpTransactionTuple>(relaxed = true))
-        val transactionLiveData = MutableLiveData<List<HttpTransactionTuple>>()
-        every { transactionRepository.getSortedTransactionTuples() } returns transactionLiveData
-        every { TextUtils.isDigitsOnly(any()) } returns false
+    fun `when search query is empty, getSortedTransactionTuples is called`() =
+        runTest {
+            val expectedTuples = listOf(mockk<HttpTransactionTuple>(relaxed = true))
+            val transactionLiveData = MutableLiveData<List<HttpTransactionTuple>>()
+            every { transactionRepository.getSortedTransactionTuples() } returns transactionLiveData
+            every { TextUtils.isDigitsOnly(any()) } returns false
 
-        viewModel.transactions.observeForever(transactionObserver)
-        viewModel.updateItemsFilter("")
-        transactionLiveData.value = expectedTuples
+            viewModel.transactions.observeForever(transactionObserver)
+            viewModel.updateItemsFilter("")
+            transactionLiveData.value = expectedTuples
 
-        verify { transactionRepository.getSortedTransactionTuples() }
-        verify { transactionObserver.onChanged(expectedTuples) }
-    }
+            verify { transactionRepository.getSortedTransactionTuples() }
+            verify { transactionObserver.onChanged(expectedTuples) }
+        }
 
     @Test
     fun `when search query contains only digits, getFilteredTransactionTuples is called with correct parameters`() =
@@ -106,7 +106,7 @@ internal class MainViewModelTest {
             every {
                 transactionRepository.getFilteredTransactionTuples(
                     searchQuery,
-                    ""
+                    "",
                 )
             } returns transactionLiveData
             every { TextUtils.isDigitsOnly(searchQuery) } returns true
@@ -128,7 +128,7 @@ internal class MainViewModelTest {
             every {
                 transactionRepository.getFilteredTransactionTuples(
                     "",
-                    searchQuery
+                    searchQuery,
                 )
             } returns transactionLiveData
             every { TextUtils.isDigitsOnly(searchQuery) } returns false
@@ -142,24 +142,26 @@ internal class MainViewModelTest {
         }
 
     @Test
-    fun `getAllTransactions returns repository data`() = runTest {
-        val expectedTransactions = listOf(mockk<HttpTransaction>(relaxed = true))
-        coEvery { transactionRepository.getAllTransactions() } returns expectedTransactions
+    fun `getAllTransactions returns repository data`() =
+        runTest {
+            val expectedTransactions = listOf(mockk<HttpTransaction>(relaxed = true))
+            coEvery { transactionRepository.getAllTransactions() } returns expectedTransactions
 
-        val result = viewModel.getAllTransactions()
+            val result = viewModel.getAllTransactions()
 
-        assertEquals(expectedTransactions, result)
-        coVerify { transactionRepository.getAllTransactions() }
-    }
+            assertEquals(expectedTransactions, result)
+            coVerify { transactionRepository.getAllTransactions() }
+        }
 
     @Test
-    fun `clearTransactions clears repository and notification buffer`() = runTest {
-        coEvery { transactionRepository.deleteAllTransactions() } just runs
+    fun `clearTransactions clears repository and notification buffer`() =
+        runTest {
+            coEvery { transactionRepository.deleteAllTransactions() } just runs
 
-        viewModel.clearTransactions()
-        testDispatcher.scheduler.advanceUntilIdle()
+            viewModel.clearTransactions()
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify { transactionRepository.deleteAllTransactions() }
-        verify { NotificationHelper.clearBuffer() }
-    }
+            coVerify { transactionRepository.deleteAllTransactions() }
+            verify { NotificationHelper.clearBuffer() }
+        }
 }


### PR DESCRIPTION
## :camera: Screenshots

|MainViewModel Unit Test Case |MainViewModel Unit Test Coverage |
|:---:|:---:|
|<img width="380" alt="Screenshot1" src="https://github.com/user-attachments/assets/ab4d897c-e1a5-444d-aa16-8865a4c87876">|<img width="380" alt="Screenshot1" src="https://github.com/user-attachments/assets/961c4c18-4606-40e7-80d5-8f1ef0c28efc">|

## :page_facing_up: Context
Add comprehensive unit tests for the MainViewModel to ensure proper functionality of transaction filtering, searching, and management.


## :pencil: Changes
Added new test class MainViewModelTest.kt with the following test coverage:

- Testing empty search query behavior
- Testing digit-only search query behavior
- Testing text search query behavior
- Testing getAllTransactions functionality
- Testing clearTransactions functionality


## :no_entry_sign: Breaking
No breaking changes - This is a test-only addition
