### PR TITLE
### Display Name Formatter ✍️

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+-   Added transaction display name formatter [#1339]
+
 ### Added
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ _A fork of [Chuck](https://github.com/jgilfelt/chuck)_
     - [Redact-Header 👮‍♂️](#redact-header-️)
     - [Decode-Body 📖](#decode-body-)
     - [Notification Permission 🔔](#notification-permission-)
+    - [Display Name Formatter ✍️](#display-name-formatter-)
   - [Migrating 🚗](#migrating-)
   - [Snapshots 📦](#snapshots-)
   - [FAQ ❓](#faq-)
@@ -166,6 +167,19 @@ show a notification as soon as the `android.permission.POST_NOTIFICATIONS` permi
 and click `Allow` in the dialog with permission request. In case you don't allow this permission or dismiss that dialog by mistake, on every Chucker launch there will be
 a snackbar with a button to open your app settings where you can change permissions settings. Note, you need to grant `android.permission.POST_NOTIFICATIONS` to your app in Settings as there
 will be no separate app in Apps list in Settings.
+
+### Display Name Formatter ✍️
+
+Allows to customize transaction display name on the screen with transactions list.
+Could be useful to map long paths into short display names for reading convenience.
+Providing null values will fallback to default display name.
+Please note, that new formatter will take place only after transactions list screen start/restart.
+
+```kotlin
+Chucker.setHttpTransactionNameFormatter { transaction ->
+    // provide CharSequence that acts as custom display name of transaction
+}
+```
 
 ## Migrating 🚗
 

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/Chucker.kt
@@ -18,4 +18,9 @@ public object Chucker {
     public fun dismissNotifications(context: Context) {
         // Empty method for the library-no-op artifact
     }
+
+    @JvmStatic
+    public fun setHttpTransactionNameFormatter(formatter: ChuckerHttpTransactionNameFormatter?) {
+        // Empty method for the library-no-op artifact
+    }
 }

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerHttpTransaction.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerHttpTransaction.kt
@@ -1,0 +1,14 @@
+package com.chuckerteam.chucker.api
+
+/**
+ * No-op declaration.
+ */
+public data class ChuckerHttpTransaction(
+    var method: String?,
+    var scheme: String?,
+    var host: String?,
+    var path: String?,
+    val responseCode: Int?,
+    var requestDate: Long?,
+    var tookMs: Long?,
+)

--- a/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerHttpTransactionNameFormatter.kt
+++ b/library-no-op/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerHttpTransactionNameFormatter.kt
@@ -1,0 +1,8 @@
+package com.chuckerteam.chucker.api
+
+/**
+ * No-op declaration.
+ */
+public fun interface ChuckerHttpTransactionNameFormatter {
+    public fun provideTransactionDisplayName(transaction: ChuckerHttpTransaction): CharSequence?
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,12 +22,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlin {
-        jvmToolchain(11)
+        jvmToolchain(17)
     }
 
     buildFeatures {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,12 +22,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     kotlin {
-        jvmToolchain(17)
+        jvmToolchain(11)
     }
 
     buildFeatures {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/Chucker.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/Chucker.kt
@@ -25,6 +25,11 @@ public object Chucker {
     internal var showNotifications: Boolean = true
 
     /**
+     * Keep track of latest transaction name formatted.
+     */
+    internal var formatter: ChuckerHttpTransactionNameFormatter? = null
+
+    /**
      * Check if this instance is the operation one or no-op.
      * @return `true` if this is the operation instance.
      */
@@ -40,6 +45,15 @@ public object Chucker {
     public fun getLaunchIntent(context: Context): Intent {
         return Intent(context, MainActivity::class.java)
             .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+
+    /**
+     * Sets the [ChuckerHttpTransactionNameFormatter] to customize transaction display name.
+     * Changes take place only after transaction list screen start/restart.
+     */
+    @JvmStatic
+    public fun setHttpTransactionNameFormatter(formatter: ChuckerHttpTransactionNameFormatter?) {
+        this.formatter = formatter
     }
 
     /**

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerHttpTransaction.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerHttpTransaction.kt
@@ -1,0 +1,14 @@
+package com.chuckerteam.chucker.api
+
+/**
+ * Exposed http transaction data
+ */
+public data class ChuckerHttpTransaction(
+    var method: String?,
+    var scheme: String?,
+    var host: String?,
+    var path: String?,
+    val responseCode: Int?,
+    var requestDate: Long?,
+    var tookMs: Long?,
+)

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerHttpTransactionNameFormatter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerHttpTransactionNameFormatter.kt
@@ -1,0 +1,14 @@
+package com.chuckerteam.chucker.api
+
+/**
+ * Chucker custom display name formatter for a http transaction.
+ */
+public fun interface ChuckerHttpTransactionNameFormatter {
+    /**
+     * Transforms [transaction] data into custom transaction display name that appears in the list of transactions.
+     *
+     * @param transaction - http transaction
+     * @return custom display name. null value falls back to default display name formatting, i.e. methods and path
+     */
+    public fun provideTransactionDisplayName(transaction: ChuckerHttpTransaction): CharSequence?
+}

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -85,7 +85,7 @@ internal class MainActivity :
 
         mainBinding = ChuckerActivityMainBinding.inflate(layoutInflater)
         transactionsAdapter =
-            TransactionAdapter(this) { transactionId ->
+            TransactionAdapter(this, Chucker.formatter) { transactionId ->
                 TransactionActivity.start(this, transactionId)
             }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -145,7 +145,7 @@ internal class TransactionAdapter internal constructor(
                         method = method,
                         scheme = scheme,
                         host = host,
-                        path = transaction.getFormattedPath(encode = false),
+                        path = getFormattedPath(encode = false),
                         responseCode = responseCode,
                         requestDate = requestDate,
                         tookMs = tookMs,


### PR DESCRIPTION
Allows to customize transaction display name on the screen with transactions list. Could be useful to map long paths into short display names for reading convenience. Providing null values will fallback to default display name. Please note, that new formatter will take place only after transactions list screen start/restart.

```kotlin
Chucker.setHttpTransactionNameFormatter { transaction ->
    // provide CharSequence that acts as custom display name of transaction
}
```

## :page_facing_up: Context
Optional Transaction Display Name Formatter
[Display Name Formatter](https://github.com/ChuckerTeam/chucker/issues/1339)

## :pencil: Changes
-   Added transaction display name formatter [#1339]

## :no_entry_sign: Breaking
Non breaking changes.

## :hammer_and_wrench: How to test
Set any custom formatter as shown below and test null and non null values. 
Null values fallback to default display name.
```kotlin
Chucker.setHttpTransactionNameFormatter { transaction ->
    // provide CharSequence that acts as custom display name of transaction
}
```

## :stopwatch: Next steps
No plans. Potentially interface could be extended to also support custom display name in push-notifications.
