### PR TITLE
Implement support for select multiple request

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -6,7 +6,9 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 import com.chuckerteam.chucker.internal.data.room.ChuckerDatabase
 import com.chuckerteam.chucker.internal.support.distinctUntilChanged
 
-internal class HttpTransactionDatabaseRepository(private val database: ChuckerDatabase) : HttpTransactionRepository {
+internal class HttpTransactionDatabaseRepository(
+    private val database: ChuckerDatabase,
+) : HttpTransactionRepository {
     private val transactionDao get() = database.transactionDao()
 
     override fun getFilteredTransactionTuples(
@@ -25,14 +27,12 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
         )
     }
 
-    override fun getTransaction(transactionId: Long): LiveData<HttpTransaction?> {
-        return transactionDao.getById(transactionId)
+    override fun getTransaction(transactionId: Long): LiveData<HttpTransaction?> =
+        transactionDao
+            .getById(transactionId)
             .distinctUntilChanged { old, new -> old?.hasTheSameContent(new) != false }
-    }
 
-    override fun getSortedTransactionTuples(): LiveData<List<HttpTransactionTuple>> {
-        return transactionDao.getSortedTuples()
-    }
+    override fun getSortedTransactionTuples(): LiveData<List<HttpTransactionTuple>> = transactionDao.getSortedTuples()
 
     override suspend fun deleteAllTransactions() {
         transactionDao.deleteAll()
@@ -43,9 +43,7 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
         transaction.id = id ?: 0
     }
 
-    override suspend fun updateTransaction(transaction: HttpTransaction): Int {
-        return transactionDao.update(transaction)
-    }
+    override suspend fun updateTransaction(transaction: HttpTransaction): Int = transactionDao.update(transaction)
 
     override suspend fun deleteOldTransactions(threshold: Long) {
         transactionDao.deleteBefore(threshold)
@@ -57,4 +55,11 @@ internal class HttpTransactionDatabaseRepository(private val database: ChuckerDa
         val timestamp = minTimestamp ?: 0L
         return transactionDao.getTransactionsInTimeRange(timestamp)
     }
+
+    override suspend fun deleteSelectedTransactions(selectedTransactions: List<Long>) {
+        transactionDao.deleteSelected(selectedTransactions)
+    }
+
+    override suspend fun getSelectedTransactions(selectedTransactions: List<Long>): List<HttpTransaction> =
+        transactionDao.getSelectedTransactions(selectedTransactions)
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
@@ -30,4 +30,19 @@ internal interface HttpTransactionRepository {
     suspend fun getAllTransactions(): List<HttpTransaction>
 
     fun getTransactionsInTimeRange(minTimestamp: Long?): List<HttpTransaction>
+
+    /**
+     * Deletes all transactions that match the given list of transaction IDs.
+     *
+     * @param selectedTransactions A list of transaction IDs to be deleted.
+     */
+    suspend fun deleteSelectedTransactions(selectedTransactions: List<Long>)
+
+    /**
+     * Retrieves a list of full [HttpTransaction] objects for the provided list of IDs.
+     *
+     * @param selectedTransactions A list of transaction IDs to fetch.
+     * @return A list of [HttpTransaction] matching the given IDs.
+     */
+    suspend fun getSelectedTransactions(selectedTransactions: List<Long>): List<HttpTransaction>
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionRepository.kt
@@ -9,6 +9,7 @@ import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
  * with [HttpTransaction] and [HttpTransactionTuple]. Please use [HttpTransactionDatabaseRepository] that
  * uses Room and SqLite to run those operations.
  */
+@Suppress("TooManyFunctions")
 internal interface HttpTransactionRepository {
     suspend fun insertTransaction(transaction: HttpTransaction)
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 
-@Database(entities = [HttpTransaction::class], version = 9, exportSchema = false)
+@Database(entities = [HttpTransaction::class], version = 10, exportSchema = false)
 internal abstract class ChuckerDatabase : RoomDatabase() {
     abstract fun transactionDao(): HttpTransactionDao
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -9,6 +9,7 @@ import androidx.room.Update
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.data.entity.HttpTransactionTuple
 
+@Suppress("TooManyFunctions")
 @Dao
 internal interface HttpTransactionDao {
     @Query(

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -50,4 +50,10 @@ internal interface HttpTransactionDao {
 
     @Query("SELECT * FROM transactions WHERE requestDate >= :timestamp")
     fun getTransactionsInTimeRange(timestamp: Long): List<HttpTransaction>
+
+    @Query("DELETE FROM transactions WHERE id IN (:selectedTransactions)")
+    suspend fun deleteSelected(selectedTransactions: List<Long>)
+
+    @Query("SELECT * FROM transactions WHERE id IN (:selectedTransactions)")
+    suspend fun getSelectedTransactions(selectedTransactions: List<Long>): List<HttpTransaction>
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -274,9 +274,9 @@ internal class MainActivity :
 
     override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
-        val selectedIds =
-            savedInstanceState.getLongArray(KEY_SELECTED_TRANSACTION_IDS)?.toList() ?: emptyList()
+        val selectedIds = savedInstanceState.getLongArray(KEY_SELECTED_TRANSACTION_IDS)?.toList().orEmpty()
         viewModel.restoreSelection(selectedIds)
+        transactionsAdapter.setSelectedTransactionIds(selectedIds)
     }
 
     private fun exportTransactions(

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -198,6 +198,7 @@ internal class MainActivity :
         searchView.setIconifiedByDefault(true)
     }
 
+    @Suppress("LongMethod")
     override fun onOptionsItemSelected(item: MenuItem): Boolean =
         when (item.itemId) {
             R.id.clear -> {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainActivity.kt
@@ -213,8 +213,14 @@ internal class MainActivity :
             }
 
             R.id.share_text -> {
+                val stringId =
+                    if (viewModel.isItemSelected.value == true) {
+                        R.string.chucker_export_text_selected_http_confirmation
+                    } else {
+                        R.string.chucker_export_text_http_confirmation
+                    }
                 showDialog(
-                    getExportDialogData(R.string.chucker_export_text_http_confirmation),
+                    getExportDialogData(stringId),
                     onPositiveClick = {
                         exportTransactions(EXPORT_TXT_FILE_NAME) { transactions ->
                             TransactionListDetailsSharable(transactions, encodeUrls = false)
@@ -226,8 +232,14 @@ internal class MainActivity :
             }
 
             R.id.share_har -> {
+                val stringId =
+                    if (viewModel.isItemSelected.value == true) {
+                        R.string.chucker_export_har_selected_http_confirmation
+                    } else {
+                        R.string.chucker_export_har_http_confirmation
+                    }
                 showDialog(
-                    getExportDialogData(R.string.chucker_export_har_http_confirmation),
+                    getExportDialogData(stringId),
                     onPositiveClick = {
                         exportTransactions(EXPORT_HAR_FILE_NAME) { transactions ->
                             TransactionDetailsHarSharable(
@@ -285,7 +297,7 @@ internal class MainActivity :
     ) {
         val applicationContext = this.applicationContext
         lifecycleScope.launch {
-            val transactions = viewModel.getAllTransactions()
+            val transactions = viewModel.getTransactions()
             if (transactions.isEmpty()) {
                 showToast(applicationContext.getString(R.string.chucker_export_empty_text))
                 return@launch
@@ -393,7 +405,7 @@ internal class MainActivity :
     }
 
     private suspend fun prepareDataToSave(exportType: ExportType): Source? {
-        val transactions = viewModel.getAllTransactions()
+        val transactions = viewModel.getTransactions()
         if (transactions.isEmpty()) {
             showToast(applicationContext.getString(R.string.chucker_save_empty_text))
             return null

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -14,8 +14,6 @@ import com.chuckerteam.chucker.internal.support.NotificationHelper
 import kotlinx.coroutines.launch
 
 internal class MainViewModel : ViewModel() {
-    // region private values
-
     /**
      * Holds the current search filter used to filter transactions.
      */
@@ -30,10 +28,6 @@ internal class MainViewModel : ViewModel() {
      * Indicates whether any transaction is currently selected.
      */
     private val mutableIsItemSelected = MutableLiveData(false)
-
-    // endregion Private values
-
-    // region public values
 
     internal val transactions: LiveData<List<HttpTransactionTuple>> =
         currentFilter.switchMap { searchQuery ->
@@ -52,15 +46,11 @@ internal class MainViewModel : ViewModel() {
      */
     internal val isItemSelected: LiveData<Boolean> = mutableIsItemSelected.distinctUntilChanged()
 
-    // endregion public values
-
-    // region public function
-
     /**
      * Returns either all transactions or only the selected ones,
      * depending on whether items are selected.
      */
-    suspend fun getAllTransactions(): List<HttpTransaction> {
+    suspend fun getTransactions(): List<HttpTransaction> {
         val ids = mutableSelectedItemIds.value.orEmpty()
         return if (mutableIsItemSelected.value == true && ids.isNotEmpty()) {
             RepositoryProvider.transaction().getSelectedTransactions(ids)
@@ -154,6 +144,4 @@ internal class MainViewModel : ViewModel() {
             mutableIsItemSelected.value = false
             NotificationHelper.clearBuffer()
         }
-
-    // endregion public function
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -4,6 +4,7 @@ import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
@@ -13,37 +14,146 @@ import com.chuckerteam.chucker.internal.support.NotificationHelper
 import kotlinx.coroutines.launch
 
 internal class MainViewModel : ViewModel() {
+    // region private values
+
+    /**
+     * Holds the current search filter used to filter transactions.
+     */
     private val currentFilter = MutableLiveData("")
 
-    val transactions: LiveData<List<HttpTransactionTuple>> =
+    /**
+     * Holds the list of selected transaction IDs.
+     */
+    private val mutableSelectedItemIds = MutableLiveData<List<Long>>(emptyList())
+
+    /**
+     * Indicates whether any transaction is currently selected.
+     */
+    private val mutableIsItemSelected = MutableLiveData(false)
+
+    // endregion Private values
+
+    // region public values
+
+    internal val transactions: LiveData<List<HttpTransactionTuple>> =
         currentFilter.switchMap { searchQuery ->
             with(RepositoryProvider.transaction()) {
                 when {
-                    searchQuery.isNullOrBlank() -> {
-                        getSortedTransactionTuples()
-                    }
-
-                    searchQuery.isDigitsOnly() -> {
-                        getFilteredTransactionTuples(searchQuery, "")
-                    }
-
-                    else -> {
-                        getFilteredTransactionTuples("", searchQuery)
-                    }
+                    searchQuery.isNullOrBlank() -> getSortedTransactionTuples()
+                    searchQuery.isDigitsOnly() -> getFilteredTransactionTuples(searchQuery, "")
+                    else -> getFilteredTransactionTuples("", searchQuery)
                 }
             }
         }
 
-    suspend fun getAllTransactions(): List<HttpTransaction> = RepositoryProvider.transaction().getAllTransactions()
+    /**
+     * LiveData indicating whether any items are currently selected.
+     * Observers are notified only when the value changes.
+     */
+    internal val isItemSelected: LiveData<Boolean> = mutableIsItemSelected.distinctUntilChanged()
 
-    fun updateItemsFilter(searchQuery: String) {
+    // endregion public values
+
+    // region public function
+
+    /**
+     * Returns either all transactions or only the selected ones,
+     * depending on whether items are selected.
+     */
+    suspend fun getAllTransactions(): List<HttpTransaction> {
+        val ids = mutableSelectedItemIds.value.orEmpty()
+        return if (mutableIsItemSelected.value == true && ids.isNotEmpty()) {
+            RepositoryProvider.transaction().getSelectedTransactions(ids)
+        } else {
+            RepositoryProvider.transaction().getAllTransactions()
+        }
+    }
+
+    /**
+     * Toggles the selection state of the given transaction ID.
+     * If the ID is already selected, it will be removed from the selection.
+     * If not selected, it will be added to the selection list.
+     *
+     * Also updates the selection mode state accordingly.
+     * This is typically used on regular tap events when selection mode is active.
+     *
+     * @param itemId The transaction ID to toggle.
+     */
+    internal fun toggleSelection(itemId: Long) {
+        val current = mutableSelectedItemIds.value.orEmpty().toMutableList()
+        if (current.contains(itemId)) {
+            current.remove(itemId)
+        } else {
+            current.add(itemId)
+        }
+        mutableSelectedItemIds.value = current
+        mutableIsItemSelected.value = current.isNotEmpty()
+    }
+
+    /**
+     * Starts the selection mode with the given transaction ID.
+     * If already in selection mode, behaves the same as [toggleSelection] to allow toggling.
+     * If not in selection mode, this marks the item as the first selected and enters selection mode.
+     *
+     * This is typically triggered via a long-press interaction.
+     *
+     * @param itemId The transaction ID to start selection with.
+     */
+    internal fun startSelection(itemId: Long) {
+        if (mutableIsItemSelected.value == true) {
+            toggleSelection(itemId)
+        } else {
+            mutableSelectedItemIds.value = listOf(itemId)
+            mutableIsItemSelected.value = true
+        }
+    }
+
+    /**
+     * Updates the transaction filter string to trigger filtering of transactions.
+     *
+     * @param searchQuery The new filter text value.
+     */
+    internal fun updateItemsFilter(searchQuery: String) {
         currentFilter.value = searchQuery
     }
 
-    fun clearTransactions() {
-        viewModelScope.launch {
-            RepositoryProvider.transaction().deleteAllTransactions()
-        }
-        NotificationHelper.clearBuffer()
+    /**
+     * Returns the list of currently selected transaction IDs.
+     *
+     * @return A list of selected transaction IDs, or an empty list if none are selected.
+     */
+    internal fun getSelectedIds(): List<Long> = mutableSelectedItemIds.value.orEmpty()
+
+    /**
+     * Restores a previously saved selection state by setting the provided list of transaction IDs.
+     * Also updates the selection mode based on whether the list is empty or not.
+     *
+     * This is typically used when restoring selection after configuration changes,
+     * such as screen rotation or process recreation.
+     *
+     * @param ids The list of transaction IDs to restore as selected.
+     */
+    internal fun restoreSelection(ids: List<Long>) {
+        mutableSelectedItemIds.value = ids
+        mutableIsItemSelected.value = ids.isNotEmpty()
     }
+
+    /**
+     * Clears all transactions or only selected ones, based on the selection state.
+     * Also resets selection state and clears notification buffer.
+     */
+    internal fun clearTransactions() =
+        viewModelScope.launch {
+            val ids = mutableSelectedItemIds.value.orEmpty()
+            if (mutableIsItemSelected.value == true && ids.isNotEmpty()) {
+                RepositoryProvider.transaction().deleteSelectedTransactions(ids)
+            } else {
+                RepositoryProvider.transaction().deleteAllTransactions()
+            }
+            mutableSelectedItemIds.value = emptyList()
+            mutableIsItemSelected.value = false
+            NotificationHelper.clearBuffer()
+        }
+
+    // endregion public function
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -35,8 +35,6 @@ internal class TransactionAdapter internal constructor(
 ) : ListAdapter<HttpTransactionTuple, TransactionAdapter.TransactionViewHolder>(
         TransactionDiffCallback,
     ) {
-    // region private values
-
     private var isSelectionMode = false
     private val selectedTransactionIds = mutableSetOf<Long>()
     private val colorDefault: Int = ContextCompat.getColor(context, R.color.chucker_status_default)
@@ -54,8 +52,6 @@ internal class TransactionAdapter internal constructor(
         TypedValue().also {
             context.theme.resolveAttribute(android.R.attr.selectableItemBackground, it, true)
         }
-
-    // endregion Private values
 
     override fun onCreateViewHolder(
         parent: ViewGroup,

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -3,6 +3,7 @@ package com.chuckerteam.chucker.internal.ui.transaction
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources
@@ -19,22 +20,43 @@ import com.chuckerteam.chucker.internal.support.TransactionDiffCallback
 import java.text.DateFormat
 import javax.net.ssl.HttpsURLConnection
 
+/**
+ * Adapter for displaying a list of [HttpTransactionTuple] items in a RecyclerView.
+ * Supports single-tap and long-tap interaction for click and multi-select operations.
+ *
+ * @param context The application context for resource access.
+ * @param onTransactionClick Callback invoked on single click with transaction ID.
+ * @param onTransactionLongClick Callback invoked on long click with transaction ID.
+ */
 internal class TransactionAdapter internal constructor(
     context: Context,
     private val onTransactionClick: (Long) -> Unit,
+    private val onTransactionLongClick: (Long) -> Unit,
 ) : ListAdapter<HttpTransactionTuple, TransactionAdapter.TransactionViewHolder>(
         TransactionDiffCallback,
     ) {
+    // region private values
+
+    /** Holds the adapter positions of currently selected items */
+    private var isSelectionMode = false
+    private val selectedTransactionIds = mutableSetOf<Long>()
     private val colorDefault: Int = ContextCompat.getColor(context, R.color.chucker_status_default)
     private val colorRequested: Int =
-        ContextCompat.getColor(
-            context,
-            R.color.chucker_status_requested,
-        )
+        ContextCompat.getColor(context, R.color.chucker_status_requested)
     private val colorError: Int = ContextCompat.getColor(context, R.color.chucker_status_error)
     private val color500: Int = ContextCompat.getColor(context, R.color.chucker_status_500)
     private val color400: Int = ContextCompat.getColor(context, R.color.chucker_status_400)
     private val color300: Int = ContextCompat.getColor(context, R.color.chucker_status_300)
+    private val colorSelected =
+        ContextCompat.getColor(context, R.color.chucker_status_multiple_selection)
+
+    /** Fallback background from theme for unselected items */
+    private val backgroundSelectableAttr =
+        TypedValue().also {
+            context.theme.resolveAttribute(android.R.attr.selectableItemBackground, it, true)
+        }
+
+    // endregion Private values
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -54,6 +76,38 @@ internal class TransactionAdapter internal constructor(
         position: Int,
     ) = holder.bind(getItem(position))
 
+    /**
+     * Updates the adapter's internal selection mode state.
+     * When enabled, regular taps on items will toggle selection instead of triggering click actions.
+     *
+     * This is typically called from the UI layer (e.g., Activity) in response to
+     * changes in the ViewModel's selection state.
+     *
+     * @param enabled True to enable selection mode, false to disable it.
+     */
+    internal fun setSelectionMode(enabled: Boolean) {
+        isSelectionMode = enabled
+    }
+
+    /**
+     * Clears all currently selected transaction items and refreshes only the affected rows in the adapter.
+     *
+     * This method ensures that selection highlights are removed without unnecessarily rebinding
+     * unaffected items. It looks up the adapter position of each previously selected transaction ID
+     * and triggers a UI refresh for that specific position.
+     *
+     * Typically called when exiting selection mode or after bulk operations like deletion.
+     */
+    internal fun clearSelections() {
+        val previouslySelectedIds = selectedTransactionIds.toSet()
+        selectedTransactionIds.clear()
+
+        previouslySelectedIds.forEachIndexed { index, id ->
+            val position = currentList.indexOfFirst { it.id == id }
+            if (position != -1) notifyItemChanged(position)
+        }
+    }
+
     inner class TransactionViewHolder(
         private val itemBinding: ChuckerListItemTransactionBinding,
     ) : RecyclerView.ViewHolder(itemBinding.root) {
@@ -61,15 +115,28 @@ internal class TransactionAdapter internal constructor(
 
         init {
             itemView.setOnClickListener {
-                transactionId?.let {
-                    onTransactionClick.invoke(it)
+                val id = transactionId ?: return@setOnClickListener
+                if (isSelectionMode) {
+                    onTransactionLongClick(id)
+                    toggleSelection(id)
+                } else {
+                    onTransactionClick(id)
                 }
+            }
+
+            itemView.setOnLongClickListener {
+                val id = transactionId ?: return@setOnLongClickListener false
+                onTransactionLongClick(id)
+                toggleSelection(id)
+                true
             }
         }
 
         @SuppressLint("SetTextI18n")
         fun bind(transaction: HttpTransactionTuple) {
             transactionId = transaction.id
+
+            updateSelectionState(transaction.id)
 
             itemBinding.apply {
                 displayGraphQlFields(transaction.graphQlOperationName, transaction.graphQlDetected)
@@ -79,7 +146,7 @@ internal class TransactionAdapter internal constructor(
 
                 setProtocolImage(if (transaction.isSsl) ProtocolResources.Https() else ProtocolResources.Http())
 
-                if (transaction.status === HttpTransaction.Status.Complete) {
+                if (transaction.status == HttpTransaction.Status.Complete) {
                     code.text = transaction.responseCode.toString()
                     duration.text = transaction.durationString
                     size.text = transaction.totalSizeString
@@ -88,7 +155,8 @@ internal class TransactionAdapter internal constructor(
                     duration.text = ""
                     size.text = ""
                 }
-                if (transaction.status === HttpTransaction.Status.Failed) {
+
+                if (transaction.status == HttpTransaction.Status.Failed) {
                     code.text = "!!!"
                 }
             }
@@ -96,12 +164,43 @@ internal class TransactionAdapter internal constructor(
             setStatusColor(transaction)
         }
 
+        /**
+         * Toggles the selection state of the given transaction ID.
+         * If the item is already selected, it will be unselected.
+         * If not selected, it will be added to the selection list.
+         *
+         * Triggers a UI update for the current item to reflect the selection change.
+         *
+         * @param id The unique transaction ID to toggle selection for.
+         */
+        private fun toggleSelection(id: Long) {
+            if (selectedTransactionIds.contains(id)) {
+                selectedTransactionIds.remove(id)
+            } else {
+                selectedTransactionIds.add(id)
+            }
+            notifyItemChanged(adapterPosition)
+        }
+
+        /**
+         * Updates the visual appearance of the item based on its selection state.
+         * Applies a highlighted background if selected, or the default background otherwise.
+         *
+         * This should be called during binding to reflect correct UI state.
+         *
+         * @param transactionId The ID of the transaction to check against the selected set.
+         */
+        private fun updateSelectionState(transactionId: Long) {
+            if (selectedTransactionIds.contains(transactionId)) {
+                itemView.setBackgroundColor(colorSelected)
+            } else {
+                itemView.setBackgroundResource(backgroundSelectableAttr.resourceId)
+            }
+        }
+
         private fun setProtocolImage(resources: ProtocolResources) {
             itemBinding.ssl.setImageDrawable(
-                AppCompatResources.getDrawable(
-                    itemView.context,
-                    resources.icon,
-                ),
+                AppCompatResources.getDrawable(itemView.context, resources.icon),
             )
             ImageViewCompat.setImageTintList(
                 itemBinding.ssl,
@@ -134,6 +233,7 @@ private fun ChuckerListItemTransactionBinding.displayGraphQlFields(
     graphqlPath.isVisible = graphQLDetected
 
     if (graphQLDetected) {
-        graphqlPath.text = graphQlOperationName ?: root.resources.getString(R.string.chucker_graphql_operation_is_empty)
+        graphqlPath.text = graphQlOperationName
+            ?: root.resources.getString(R.string.chucker_graphql_operation_is_empty)
     }
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -37,7 +37,6 @@ internal class TransactionAdapter internal constructor(
     ) {
     // region private values
 
-    /** Holds the adapter positions of currently selected items */
     private var isSelectionMode = false
     private val selectedTransactionIds = mutableSetOf<Long>()
     private val colorDefault: Int = ContextCompat.getColor(context, R.color.chucker_status_default)
@@ -106,6 +105,23 @@ internal class TransactionAdapter internal constructor(
             val position = currentList.indexOfFirst { it.id == id }
             if (position != -1) notifyItemChanged(position)
         }
+    }
+
+    /**
+     * Sets the list of selected transaction IDs.
+     *
+     * This is typically used to restore selection state after a configuration change (e.g., screen rotation),
+     * ensuring that the UI reflects the correct selection with proper background highlights.
+     *
+     * Since this affects potentially all items, a full data set refresh is triggered using [notifyDataSetChanged].
+     *
+     * @param ids The list of transaction IDs to mark as selected.
+     */
+    @SuppressLint("NotifyDataSetChanged")
+    internal fun setSelectedTransactionIds(ids: List<Long>) {
+        selectedTransactionIds.clear()
+        selectedTransactionIds.addAll(ids)
+        notifyDataSetChanged()
     }
 
     inner class TransactionViewHolder(

--- a/library/src/main/res/values-es/strings.xml
+++ b/library/src/main/res/values-es/strings.xml
@@ -50,10 +50,13 @@
     <string name="chucker_share_transaction_subject">Detalles de la transacción</string>
     <string name="chucker_share_all_transactions_subject">Todas las transacciones</string>
     <string name="chucker_clear_http_confirmation">¿Quieres limpiar por completo el historial de llamadas?</string>
+    <string name="chucker_clear_selected_http_confirmation">¿Desea borrar las transacciones de red seleccionadas?</string>
     <string name="chucker_export_text_http_confirmation">¿Quieres exportar todas las transacciones de red como un archivo de texto?</string>
     <string name="chucker_export_har_http_confirmation">¿Quieres exportar todas las transacciones de red como un archivo .har?</string>
     <string name="chucker_save_text_http_confirmation">¿Quieres guardar todas las transacciones de red como un archivo de texto?</string>
     <string name="chucker_save_har_http_confirmation">¿Quieres guardar todas las transacciones de red como un archivo .har?</string>
+    <string name="chucker_export_text_selected_http_confirmation">¿Desea exportar las transacciones de red seleccionadas como archivo de texto?</string>
+    <string name="chucker_export_har_selected_http_confirmation">¿Desea exportar las transacciones de red seleccionadas como archivo .har?</string>
     <string name="chucker_export_separator">==================</string>
     <string name="chucker_export_prefix">/* Exportación Iniciada */</string>
     <string name="chucker_export_postfix">/*  Exportación Finalizada  */</string>

--- a/library/src/main/res/values-night/colors.xml
+++ b/library/src/main/res/values-night/colors.xml
@@ -18,6 +18,7 @@
     <color name="chucker_status_500">#e53935</color>
     <color name="chucker_status_400">#ffb74d</color>
     <color name="chucker_status_300">#64b5f6</color>
+    <color name="chucker_status_multiple_selection">#40FFFFFF</color>
 
     <color name="chucker_background_span_color">#ffe082</color>
     <color name="chucker_foreground_span_color">#ef5350</color>

--- a/library/src/main/res/values-ru/strings.xml
+++ b/library/src/main/res/values-ru/strings.xml
@@ -50,10 +50,13 @@
     <string name="chucker_share_transaction_subject">Детали запроса</string>
     <string name="chucker_share_all_transactions_subject">Все запросы</string>
     <string name="chucker_clear_http_confirmation">Очистить всю историю запросов?</string>
+    <string name="chucker_clear_selected_http_confirmation">Вы хотите очистить выбранные сетевые запросы?</string>
     <string name="chucker_export_text_http_confirmation">Экспортировать все сетевые запросы как текстовый файл?</string>
     <string name="chucker_export_har_http_confirmation">Экспортировать все сетевые запросы как файл .har?</string>
     <string name="chucker_save_text_http_confirmation">Сохранить все сетевые запросы как текстовый файл?</string>
     <string name="chucker_save_har_http_confirmation">Сохранить все сетевые запросы как файл .har?</string>
+    <string name="chucker_export_text_selected_http_confirmation">Вы хотите экспортировать выбранные сетевые запросы в текстовый файл?</string>
+    <string name="chucker_export_har_selected_http_confirmation">Вы хотите экспортировать выбранные сетевые запросы в файл .har?</string>
     <string name="chucker_export_separator">==================</string>
     <string name="chucker_export_prefix">/* Начало экспорта */</string>
     <string name="chucker_export_postfix">/* Конец экспорта */</string>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -18,6 +18,7 @@
     <color name="chucker_status_500">#B71C1C</color>
     <color name="chucker_status_400">#FF9800</color>
     <color name="chucker_status_300">#0D47A1</color>
+    <color name="chucker_status_multiple_selection">#40000000</color>
 
     <color name="chucker_background_span_color">#ffffff00</color>
     <color name="chucker_foreground_span_color">#ffff0000</color>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -50,11 +50,14 @@
     <string name="chucker_share_all_transactions_title">Share transactions</string>
     <string name="chucker_share_transaction_subject">Transaction details</string>
     <string name="chucker_share_all_transactions_subject">All transactions</string>
-    <string name="chucker_clear_http_confirmation">Do you want to clear complete network calls history?</string>
+    <string name="chucker_clear_http_confirmation">Do you want to clear the complete network calls history?</string>
+    <string name="chucker_clear_selected_http_confirmation">Do you want to clear the selected network transactions?</string>
     <string name="chucker_export_text_http_confirmation">Do you want to export all network transactions as a text file?</string>
     <string name="chucker_export_har_http_confirmation">Do you want to export all network transactions as a .har file?</string>
     <string name="chucker_save_text_http_confirmation">Do you want to save all network transactions as a text file?</string>
     <string name="chucker_save_har_http_confirmation">Do you want to save all network transactions as a .har file?</string>
+    <string name="chucker_export_text_selected_http_confirmation">Do you want to export selected network transactions as a text file?</string>
+    <string name="chucker_export_har_selected_http_confirmation">Do you want to export selected network transactions as a .har file?</string>
     <string name="chucker_export_separator">==================</string>
     <string name="chucker_export_prefix">/* Export Start */</string>
     <string name="chucker_export_postfix">/*  Export End  */</string>

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
@@ -144,12 +144,12 @@ internal class MainViewModelTest {
         }
 
     @Test
-    fun `getAllTransactions returns repository data`() =
+    fun `getTransactions returns repository data`() =
         runTest {
             val expectedTransactions = listOf(mockk<HttpTransaction>(relaxed = true))
             coEvery { transactionRepository.getAllTransactions() } returns expectedTransactions
 
-            val result = viewModel.getAllTransactions()
+            val result = viewModel.getTransactions()
 
             assertEquals(expectedTransactions, result)
             coVerify { transactionRepository.getAllTransactions() }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
@@ -73,12 +73,14 @@ internal class MainViewModelTest {
         every { NotificationHelper.clearBuffer() } just runs
 
         viewModel = MainViewModel()
+        viewModel.isItemSelected.observeForever {}
     }
 
     @After
     fun tearDown() {
         Dispatchers.resetMain()
         unmockkAll()
+        viewModel.isItemSelected.removeObserver {}
     }
 
     @Test
@@ -164,4 +166,73 @@ internal class MainViewModelTest {
             coVerify { transactionRepository.deleteAllTransactions() }
             verify { NotificationHelper.clearBuffer() }
         }
+
+    @Test
+    fun `toggleSelection should add item when not selected`() {
+        val id = 1L
+        viewModel.toggleSelection(id)
+
+        val selected = viewModel.getSelectedIds()
+        assertEquals(listOf(id), selected)
+        assertEquals(true, viewModel.isItemSelected.value)
+    }
+
+    @Test
+    fun `toggleSelection should remove item when already selected`() {
+        val id = 1L
+        viewModel.toggleSelection(id)
+        viewModel.toggleSelection(id)
+
+        val selected = viewModel.getSelectedIds()
+        assertEquals(emptyList<Long>(), selected)
+        assertEquals(false, viewModel.isItemSelected.value)
+    }
+
+    @Test
+    fun `startSelection should toggle item if already in selection mode`() {
+        val id = 1L
+        viewModel.toggleSelection(id)
+        viewModel.startSelection(id)
+
+        val selected = viewModel.getSelectedIds()
+        assertEquals(emptyList<Long>(), selected)
+        assertEquals(false, viewModel.isItemSelected.value)
+    }
+
+    @Test
+    fun `startSelection should start selection mode if not already active`() {
+        val id = 2L
+        viewModel.startSelection(id)
+
+        val selected = viewModel.getSelectedIds()
+        assertEquals(listOf(id), selected)
+        assertEquals(true, viewModel.isItemSelected.value)
+    }
+
+    @Test
+    fun `getSelectedIds should return currently selected IDs`() {
+        val ids = listOf(1L, 2L)
+        ids.forEach { viewModel.toggleSelection(it) }
+
+        val result = viewModel.getSelectedIds()
+        assertEquals(ids, result)
+    }
+
+    @Test
+    fun `restoreSelection should update selected IDs and state`() {
+        val restoredIds = listOf(1L, 2L, 3L)
+
+        viewModel.restoreSelection(restoredIds)
+
+        assertEquals(restoredIds, viewModel.getSelectedIds())
+        assertEquals(true, viewModel.isItemSelected.value)
+    }
+
+    @Test
+    fun `restoreSelection with empty list should clear selection state`() {
+        viewModel.restoreSelection(emptyList())
+
+        assertEquals(emptyList<Long>(), viewModel.getSelectedIds())
+        assertEquals(false, viewModel.isItemSelected.value)
+    }
 }


### PR DESCRIPTION
## :camera: Screenshots

|Light Mode | Dark Mode|
|:---:|:---:|
|<img width="380" alt="Screenshot1" src="https://github.com/user-attachments/assets/38d408cc-c381-415f-8d64-dd2164e9da84">|<img width="380" alt="Screenshot2" src="https://github.com/user-attachments/assets/9a56035f-fbc7-4d04-8729-c7f8fcffb717">|

Tested the flow - here is the testing video @cortinico 

https://github.com/user-attachments/assets/e236a4fc-14a0-455c-a2a7-2b500e8c510e


## :page_facing_up: Context

Issue link: https://github.com/ChuckerTeam/chucker/issues/1127

## :pencil: Changes

- Added multiple selection support in the transaction list.
- Used ID-based selection tracking for accurate and stable selection state.
- Applied selection highlight colour for both light and dark themes.

## :hammer_and_wrench: How to test

- Long-press any transaction to start selection mode.
- Tap additional items to select/deselect them.
- Verify selection highlight is applied using updated colour.
- Tap a selected item to unselect it.

Closes https://github.com/ChuckerTeam/chucker/pull/1130