### PR TITLE
Refactor: Update Gradle and lint configurations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         kotlinVersion = '2.1.0'
-        androidGradleVersion = '8.7.3'
+        androidGradleVersion = '8.9.1'
         coroutineVersion = '1.10.1'
 
         // Google libraries

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/library-no-op/build.gradle
+++ b/library-no-op/build.gradle
@@ -26,20 +26,17 @@ android {
         minSdk rootProject.minSdkVersion
     }
 
-    lintOptions {
-        warningsAsErrors true
-        abortOnError true
-        // We don't want to impose RTL on consuming applications.
-        disable 'RtlEnabled'
-        // Don't fail build if some dependencies outdated
-        disable 'GradleDependency'
-    }
 
     publishing {
         singleVariant('release') {
             withSourcesJar()
             withJavadocJar()
         }
+    }
+    lint {
+        abortOnError true
+        disable 'RtlEnabled', 'GradleDependency'
+        warningsAsErrors true
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -35,14 +35,6 @@ android {
         buildConfig = false
     }
 
-    lintOptions {
-        warningsAsErrors true
-        abortOnError true
-        // We don't want to impose RTL on consuming applications.
-        disable 'RtlEnabled'
-        // Don't fail build if some dependencies outdated
-        disable 'GradleDependency'
-    }
 
     testOptions {
         unitTests {
@@ -60,6 +52,11 @@ android {
             withSourcesJar()
             withJavadocJar()
         }
+    }
+    lint {
+        abortOnError true
+        disable 'RtlEnabled', 'GradleDependency'
+        warningsAsErrors true
     }
 }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/BitmapUtils.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/BitmapUtils.kt
@@ -7,6 +7,7 @@ import android.graphics.Matrix
 import android.graphics.Paint
 import androidx.annotation.ColorInt
 import androidx.core.graphics.ColorUtils
+import androidx.core.graphics.createBitmap
 import androidx.palette.graphics.Palette
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -24,7 +25,7 @@ internal suspend fun Bitmap.calculateLuminance(): Double? {
 private fun Bitmap.replaceAlphaWithColor(
     @ColorInt color: Int,
 ): Bitmap {
-    val result = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+    val result = createBitmap(width, height)
     result.eraseColor(color)
     Canvas(result).apply {
         drawBitmap(this@replaceAlphaWithColor, Matrix(), BITMAP_PAINT)

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/ChessboardDrawable.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/ChessboardDrawable.kt
@@ -1,8 +1,6 @@
 package com.chuckerteam.chucker.internal.support
 
 import android.content.Context
-import android.graphics.Bitmap
-import android.graphics.Bitmap.Config.ARGB_8888
 import android.graphics.BitmapShader
 import android.graphics.Canvas
 import android.graphics.ColorFilter
@@ -17,6 +15,7 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
 import androidx.annotation.Px
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.createBitmap
 
 internal class ChessboardDrawable(
     @ColorInt evenColor: Int,
@@ -25,7 +24,7 @@ internal class ChessboardDrawable(
 ) : Drawable() {
     private val chessboardPaint =
         Paint().apply {
-            val patternBitmap = Bitmap.createBitmap(squareSize * 2, squareSize * 2, ARGB_8888)
+            val patternBitmap = createBitmap(squareSize * 2, squareSize * 2)
             patternBitmap.eraseColor(evenColor)
 
             color = oddColor

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -9,11 +9,11 @@ import android.os.Build
 import android.util.LongSparseArray
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import androidx.core.util.size
 import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.api.Chucker
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import com.chuckerteam.chucker.internal.ui.BaseChuckerActivity
-import java.util.HashSet
 
 internal class NotificationHelper(val context: Context) {
     companion object {
@@ -68,7 +68,7 @@ internal class NotificationHelper(val context: Context) {
         synchronized(transactionBuffer) {
             transactionIdsSet.add(transaction.id)
             transactionBuffer.put(transaction.id, transaction)
-            if (transactionBuffer.size() > BUFFER_SIZE) {
+            if (transactionBuffer.size > BUFFER_SIZE) {
                 transactionBuffer.removeAt(0)
             }
         }
@@ -97,7 +97,7 @@ internal class NotificationHelper(val context: Context) {
             val inboxStyle = NotificationCompat.InboxStyle()
             synchronized(transactionBuffer) {
                 var count = 0
-                for (i in transactionBuffer.size() - 1 downTo 0) {
+                for (i in transactionBuffer.size - 1 downTo 0) {
                     val bufferedTransaction = transactionBuffer.valueAt(i)
                     if ((bufferedTransaction != null) && count < BUFFER_SIZE) {
                         if (count == 0) {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -1,6 +1,6 @@
 package com.chuckerteam.chucker.internal.ui
 
-import android.text.TextUtils
+import androidx.core.text.isDigitsOnly
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -22,9 +22,11 @@ internal class MainViewModel : ViewModel() {
                     searchQuery.isNullOrBlank() -> {
                         getSortedTransactionTuples()
                     }
-                    TextUtils.isDigitsOnly(searchQuery) -> {
+
+                    searchQuery.isDigitsOnly() -> {
                         getFilteredTransactionTuples(searchQuery, "")
                     }
+
                     else -> {
                         getFilteredTransactionTuples("", searchQuery)
                     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -46,13 +46,6 @@ android {
         }
     }
 
-    lintOptions {
-        warningsAsErrors true
-        abortOnError true
-        disable 'AcceptsUserCertificates'
-        // Don't fail build if some dependencies outdated
-        disable 'GradleDependency'
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
@@ -61,6 +54,11 @@ android {
 
     kotlin {
         jvmToolchain(11)
+    }
+    lint {
+        abortOnError true
+        disable 'AcceptsUserCertificates', 'GradleDependency'
+        warningsAsErrors true
     }
 }
 


### PR DESCRIPTION
This commit updates the Gradle version and refactors lint configurations across multiple modules:

-   Updated the Android Gradle plugin version from `8.7.3` to `8.9.1` in the root `build.gradle` file.
-   Updated the Gradle wrapper to version `8.11.1` in `gradle-wrapper.properties`.
-   Replaced `lintOptions` with `lint` in the `library`, `sample`, and `library-no-op` modules.
-   Moved the `warningsAsErrors`, `abortOnError`, and `disable` configurations from `lintOptions` to `lint` in `library`, `sample` and `library-no-op`.
-   Applied the `disable 'RtlEnabled', 'GradleDependency'` to the `library`, and `library-no-op` modules.
-   Applied the `disable 'AcceptsUserCertificates', 'GradleDependency'` to the `sample` module.

## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
