### PR TITLE
Forcing LTR in response payload Recycler View

### DIFF
--- a/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
+++ b/library/src/main/res/layout/chucker_fragment_transaction_payload.xml
@@ -110,6 +110,7 @@
         android:paddingVertical="@dimen/chucker_doub_grid"
         android:scrollbars="vertical"
         android:visibility="invisible"
+        android:layoutDirection="ltr"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## :camera: Screenshots

### After Change
![image](https://github.com/user-attachments/assets/b4b1e614-d372-4460-a3af-900a0792f385)


### Before Change
![image](https://github.com/user-attachments/assets/4b9d47ce-a053-4269-ab50-865ac38f4522)
 

## :page_facing_up: Context
Suppose you have an app that supports right-to-left (RTL) languages, such as Arabic. In that case, the chucker app will also be RTL, which can sometimes hinder the readability of the response, especially if it is a large JSON. You depend on indentation to locate certain values for debugging purposes or to confirm that specific values have been received. For that reason, I suggest this change.

## :pencil: Changes
I have forced the layout direction of the RecyclerView to be LTR always.

## :no_entry_sign: Breaking
Nothing.

## :hammer_and_wrench: How to test
Change the Sysmte language of the test device to arabic, then In the sample App, update the `AndroidManifest.xml` to include `android:supportsRtl="true"` in `application` tag, then try to launch some HTTP requests and verify the results that have some json, try this before and after applying the change in the PR.

## :stopwatch: Next steps
Not sure, but the same should happen of the overview tab, but it is less critical than this one.
