### PR TITLE
Feature/added UI tests for radio button selection and export button visibility

### DIFF
--- a/sample/src/androidTest/java/com/chuckerteam/chucker/sample/ChuckerUITestLabels.kt
+++ b/sample/src/androidTest/java/com/chuckerteam/chucker/sample/ChuckerUITestLabels.kt
@@ -1,0 +1,14 @@
+package com.chuckerteam.chucker.sample
+
+object ChuckerUITestLabels {
+    const val INTERCEPTOR_TYPE_LABEL = "Interceptor type:"
+    const val APPLICATION_RADIO_BUTTON = "Application"
+    const val NETWORK_RADIO_BUTTON = "Network"
+
+    const val DO_HTTP_ACTIVITY_BUTTON = "DO HTTP ACTIVITY"
+    const val DO_GRAPHQL_ACTIVITY_BUTTON = "DO GRAPHQL ACTIVITY"
+    const val LAUNCH_CHUCKER_BUTTON = "LAUNCH CHUCKER DIRECTLY"
+
+    const val EXPORT_LOG_FILE_BUTTON = "EXPORT TO LOG FILE"
+    const val EXPORT_HAR_FILE_BUTTON = "EXPORT TO HAR FILE"
+}

--- a/sample/src/androidTest/java/com/chuckerteam/chucker/sample/ChuckerUITestLabels.kt
+++ b/sample/src/androidTest/java/com/chuckerteam/chucker/sample/ChuckerUITestLabels.kt
@@ -4,11 +4,9 @@ object ChuckerUITestLabels {
     const val INTERCEPTOR_TYPE_LABEL = "Interceptor type:"
     const val APPLICATION_RADIO_BUTTON = "Application"
     const val NETWORK_RADIO_BUTTON = "Network"
-
     const val DO_HTTP_ACTIVITY_BUTTON = "DO HTTP ACTIVITY"
     const val DO_GRAPHQL_ACTIVITY_BUTTON = "DO GRAPHQL ACTIVITY"
     const val LAUNCH_CHUCKER_BUTTON = "LAUNCH CHUCKER DIRECTLY"
-
     const val EXPORT_LOG_FILE_BUTTON = "EXPORT TO LOG FILE"
     const val EXPORT_HAR_FILE_BUTTON = "EXPORT TO HAR FILE"
 }

--- a/sample/src/androidTest/java/com/chuckerteam/chucker/sample/MainActivityTest.kt
+++ b/sample/src/androidTest/java/com/chuckerteam/chucker/sample/MainActivityTest.kt
@@ -1,42 +1,86 @@
+package com.chuckerteam.chucker.sample
+
 import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.chuckerteam.chucker.sample.MainActivity
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class MainActivityTest {
+    @Before
+    fun setup() {
+        ActivityScenario.launch(MainActivity::class.java)
+    }
+
     @Test
     fun testUIComponentsAreDisplayed() {
-        ActivityScenario.launch(MainActivity::class.java)
-
-        // Interceptor type label
-        onView(withText("Interceptor type:")).check(matches(isDisplayed()))
-
-        // Application radio button
-        onView(withText("Application")).check(matches(isDisplayed()))
-        onView(withText("Application")).perform(click())
-
-        // Network radio button
-        onView(withText("Network")).check(matches(isDisplayed()))
-        onView(withText("Network")).perform(click())
-
-        // Buttons
-        onView(withText("DO HTTP ACTIVITY")).check(matches(isDisplayed()))
-        onView(withText("DO GRAPHQL ACTIVITY")).check(matches(isDisplayed()))
-        onView(withText("LAUNCH CHUCKER DIRECTLY")).check(matches(isDisplayed()))
-        onView(withText("EXPORT TO LOG FILE")).check(matches(isDisplayed()))
-        onView(withText("EXPORT TO HAR FILE")).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.INTERCEPTOR_TYPE_LABEL)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.APPLICATION_RADIO_BUTTON)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.APPLICATION_RADIO_BUTTON)).perform(click())
+        onView(withText(ChuckerUITestLabels.NETWORK_RADIO_BUTTON)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.NETWORK_RADIO_BUTTON)).perform(click())
+        onView(withText(ChuckerUITestLabels.DO_HTTP_ACTIVITY_BUTTON)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.DO_GRAPHQL_ACTIVITY_BUTTON)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.LAUNCH_CHUCKER_BUTTON)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.EXPORT_LOG_FILE_BUTTON)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.EXPORT_HAR_FILE_BUTTON)).check(matches(isDisplayed()))
     }
 
     @Test
     fun testButtonInteractions() {
-        ActivityScenario.launch(MainActivity::class.java)
-        onView(withText("DO HTTP ACTIVITY")).perform(click())
+        onView(withText(ChuckerUITestLabels.DO_HTTP_ACTIVITY_BUTTON)).perform(click())
+    }
+
+    @Test
+    fun testRadioButtonSelection() {
+        onView(withText(ChuckerUITestLabels.APPLICATION_RADIO_BUTTON))
+            .perform(click())
+            .check(matches(isChecked()))
+
+        onView(withText(ChuckerUITestLabels.NETWORK_RADIO_BUTTON))
+            .perform(click())
+            .check(matches(isChecked()))
+    }
+
+    @Test
+    fun testHttpActivityButtonClick() {
+        onView(withText(ChuckerUITestLabels.DO_HTTP_ACTIVITY_BUTTON)).perform(click())
+    }
+
+    @Test
+    fun testGraphQLActivityButtonClick() {
+        onView(withText(ChuckerUITestLabels.DO_GRAPHQL_ACTIVITY_BUTTON)).perform(click())
+    }
+
+    @Test
+    fun testLaunchChuckerDirectlyButtonClick() {
+        onView(withText(ChuckerUITestLabels.LAUNCH_CHUCKER_BUTTON)).perform(click())
+    }
+
+    @Test
+    fun testExportButtonsVisibility() {
+        onView(withText(ChuckerUITestLabels.EXPORT_LOG_FILE_BUTTON)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.EXPORT_HAR_FILE_BUTTON)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testAllButtonClicks() {
+        val buttons =
+            listOf(
+                ChuckerUITestLabels.DO_HTTP_ACTIVITY_BUTTON,
+                ChuckerUITestLabels.DO_GRAPHQL_ACTIVITY_BUTTON,
+                ChuckerUITestLabels.LAUNCH_CHUCKER_BUTTON,
+            )
+
+        buttons.forEach { buttonText ->
+            onView(withText(buttonText)).perform(click())
+        }
     }
 }

--- a/sample/src/androidTest/java/com/chuckerteam/chucker/sample/MainActivityTest.kt
+++ b/sample/src/androidTest/java/com/chuckerteam/chucker/sample/MainActivityTest.kt
@@ -8,6 +8,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.Matchers.not
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -82,5 +83,31 @@ class MainActivityTest {
         buttons.forEach { buttonText ->
             onView(withText(buttonText)).perform(click())
         }
+    }
+
+    @Test
+    fun testOnlyOneRadioButtonCheckedAtATime() {
+        onView(withText(ChuckerUITestLabels.APPLICATION_RADIO_BUTTON)).perform(click())
+        onView(withText(ChuckerUITestLabels.APPLICATION_RADIO_BUTTON)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.NETWORK_RADIO_BUTTON)).check(matches(not(isChecked())))
+        onView(withText(ChuckerUITestLabels.NETWORK_RADIO_BUTTON)).perform(click())
+        onView(withText(ChuckerUITestLabels.NETWORK_RADIO_BUTTON)).check(matches(isChecked()))
+        onView(withText(ChuckerUITestLabels.APPLICATION_RADIO_BUTTON)).check(matches(not(isChecked())))
+    }
+
+    @Test
+    fun testRadioButtonSelectionVisualState() {
+        onView(withText(ChuckerUITestLabels.APPLICATION_RADIO_BUTTON))
+            .check(matches(isDisplayed()))
+            .perform(click())
+        onView(withText(ChuckerUITestLabels.NETWORK_RADIO_BUTTON))
+            .check(matches(isDisplayed()))
+            .perform(click())
+    }
+
+    @Test
+    fun testExportButtonsAreVisibleWithoutScrolling() {
+        onView(withText(ChuckerUITestLabels.EXPORT_LOG_FILE_BUTTON)).check(matches(isDisplayed()))
+        onView(withText(ChuckerUITestLabels.EXPORT_HAR_FILE_BUTTON)).check(matches(isDisplayed()))
     }
 }


### PR DESCRIPTION
:camera: Screenshot 
<img width="820" alt="Screenshot 2025-05-06 at 10 43 02 PM" src="https://github.com/user-attachments/assets/61a2d9f9-3d62-4680-be1c-1801d6efe3cd" />


:page_facing_up: Context
This PR improves the test coverage for MainActivity by verifying correct behavior of the interceptor type radio buttons and ensuring the export buttons are visible on screen without requiring scrolling. These additions help maintain UI stability and selection logic as the app evolves.

:pencil: Changes
Added testOnlyOneRadioButtonCheckedAtATime to validate toggle logic between "Application" and "Network"

Added testRadioButtonSelectionVisualState to ensure both radio buttons are visible and interactable

Added testExportButtonsAreVisibleWithoutScrolling to confirm visibility of "EXPORT TO LOG FILE" and "EXPORT TO HAR FILE" buttons

Updated ChuckerUITestLabels with any required string constants

:paperclip: Related PR
N/A

:no_entry_sign: Breaking
No breaking changes.

:hammer_and_wrench: How to test
Run the updated test class:

All tests should pass under MainActivityTest.