### PR TITLE
Add Jetpack Compose Support to sample module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.wire) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.compose.compiler) apply false
 }
 
 apiValidation {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,10 @@ leakcanary = "2.14"
 # Apollo
 apollo = "3.8.6"
 
+# Compose
+composeBom = "2025.04.00"
+lifecycleViewmodelCompose = "2.8.4"
+
 # Testing
 junitGradlePlugin = "1.13.0.0"
 junit = "5.13.1"
@@ -91,6 +95,16 @@ leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-and
 # Apollo
 apollo-runtime = { group = "com.apollographql.apollo3", name = "apollo-runtime", version.ref = "apollo" }
 
+# Jetpack Compose
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+
+
 # Testing
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTestRules" }
@@ -117,4 +131,5 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktLintGradle" }
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }
 nexus-staging = { id = "io.codearte.nexus-staging", version.ref = "nexusStagingPlugin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.wire)
     alias(libs.plugins.apollo)
+    alias(libs.plugins.compose.compiler)
 }
 
 wire {
@@ -25,6 +26,10 @@ android {
     buildFeatures {
         viewBinding = true
         buildConfig = false
+    }
+
+    buildFeatures {
+        compose = true
     }
 
     buildTypes {
@@ -95,6 +100,13 @@ dependencies {
     implementation(libs.converter.gson)
 
     implementation(libs.apollo.runtime)
+
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling.preview)
 
     debugImplementation(libs.leakcanary.android)
 }


### PR DESCRIPTION
## :page_facing_up: Context
Configures the Sample module for Jetpack Compose by adding necessary dependencies and enabling Compose in Gradle, next step will be migrating XML layouts to Compose UI.

## :pencil: Changes
Enabled Compose in `sample/build.gradle.kts`

## :paperclip: Related PR
None

## :no_entry_sign: Breaking
None

## :hammer_and_wrench: How to test
Pull this branch and run `./gradlew clean build` – the project should compile and all tests should pass.

## :stopwatch: Next steps
Migrate existing XML layouts in the sample module to @Composable functions
