### PR TITLE
Update gradle-wrapper-validation.yml

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -18,5 +18,5 @@ jobs:
     - name: Checkout latest code
       uses: actions/checkout@v4
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v4
+      uses: gradle/actions/wrapper-validation@v3
       


### PR DESCRIPTION
This is causing a lot of `ETIMEDOUT 104.16.72.101:443` failures
