### PR TITLE
Move the Central Publishing

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -35,7 +35,7 @@ jobs:
         path: '~/.m2/repository/'
 
     - name: Publish to the Staging Repository
-      run: ./gradlew publishReleasePublicationToStagingRepository --no-parallel
+      run: ./gradlew publishToSonatype --no-parallel
       env:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}

--- a/.github/workflows/publish-snapshot.yaml
+++ b/.github/workflows/publish-snapshot.yaml
@@ -40,7 +40,7 @@ jobs:
         path: '~/.m2/repository/'
 
     - name: Publish to the Snapshot Repository
-      run: ./gradlew publishReleasePublicationToSnapshotRepository --no-parallel
+      run: ./gradlew publishToSonatype --no-parallel
       env:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.kotlinx.binary.compatibility.validator)
-    alias(libs.plugins.nexus.staging)
+    alias(libs.plugins.nexus.publish)
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
@@ -59,8 +59,11 @@ extra.apply {
     set("compileSdkVersion", 35)
 }
 
-configure<io.codearte.gradle.nexus.NexusStagingExtension> {
-    username = findProperty("NEXUS_USERNAME") as String?
-    password = findProperty("NEXUS_PASSWORD") as String?
-    stagingProfileId = "ea09119de9f4"
+nexusPublishing {
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ androidxTestRules = "1.6.1"
 androidxEspresso = "3.6.1"
 
 # Publishing
-nexusStagingPlugin = "0.30.0"
+nexusPublishPlugin = "2.0.0"
 
 [libraries]
 # Google Libraries
@@ -130,6 +130,6 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktLintGradle" }
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryCompatibilityValidator" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }
-nexus-staging = { id = "io.codearte.nexus-staging", version.ref = "nexusStagingPlugin" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublishPlugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 


### PR DESCRIPTION
## :page_facing_up: Context
This is needed as the library is still attempting to publish to OSSHR. I'm migrating it over to Central Publishing instead.
