### PR TITLE
Upgrade target and compile SDK versions to 36

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,8 +55,8 @@ tasks.register<Delete>("clean") {
 
 extra.apply {
     set("minSdkVersion", 21)
-    set("targetSdkVersion", 35)
-    set("compileSdkVersion", 35)
+    set("targetSdkVersion", 36)
+    set("compileSdkVersion", 36)
 }
 
 nexusPublishing {


### PR DESCRIPTION
## :camera: Recording
https://github.com/user-attachments/assets/468d6599-dc65-4d67-8932-cf693e5eae6d

## :page_facing_up: Context
This PR upgrades the `compileSdkVersion` and `targetSdkVersion` to API level 36, aligning the project with the latest Android SDK and enabling testing against the most recent platform behavior changes.
No related issue is currently linked.

## :pencil: Changes

- Updated compileSdk and targetSdk versions to 36 in the Gradle configuration files.
- Ensured compatibility by syncing and rebuilding the project successfully.

_No new features or UI changes were introduced. This is purely a build configuration upgrade._

## :paperclip: Related PR
None.

## :no_entry_sign: Breaking
No breaking changes introduced.

## :hammer_and_wrench: How to test

- Run the sample app confirm nothing is broken.
- Validate that the app builds and runs as expected on Android 16 (API 34+) and emulators with API 36.


## :stopwatch: Next steps
Monitor for any compatibility issues with newer Android SDK behaviors in runtime.
