### PR TITLE
fix: URLs with spaces in cURL command generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please add your entries according to this format.
 
 ## Unreleased
 
+### Fixed
+
+-   Fixed share of `curl` when URL contains spaces [#1464]
+
 ## Version 4.2.0 _(2025-07-12)_
 
 ### Added

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharable.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharable.kt
@@ -28,7 +28,7 @@ internal class TransactionCurlCommandSharable(
                 // try to keep to a single line and use a subshell to preserve any line breaks
                 writeUtf8(" --data $'${requestBody.replace("\n", "\\n")}'")
             }
-            writeUtf8((if (compressed) " --compressed " else " ") + transaction.getFormattedUrl(encode = false))
+            writeUtf8((if (compressed) " --compressed " else " ") + transaction.getFormattedUrl(encode = true))
         }
 
     private fun isCompressed(header: HttpHeader): Boolean =

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharableTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/TransactionCurlCommandSharableTest.kt
@@ -137,4 +137,16 @@ internal class TransactionCurlCommandSharableTest {
             assertThat(sharedContent).isEqualTo(expected)
         }
     }
+
+    @Test
+    fun `create cURL command with space in URL`() {
+        val transaction = TestTransactionFactory.createTransaction("GET").apply {
+            url = "http://localhost/get Users"
+        }
+        val sharableTransaction = TransactionCurlCommandSharable(transaction)
+
+        val sharedContent = sharableTransaction.toSharableUtf8Content(context)
+
+        assertThat(sharedContent).isEqualTo("curl -X GET http://localhost/get%20Users")
+    }
 }


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->
<img width="540" height="1200" alt="screen" src="https://github.com/user-attachments/assets/5ad1abbc-172f-4351-8fb5-e1573ca742c4" />


## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/ChuckerTeam/chucker/issues) to link here? Or an external link? -->
close #1464

## :pencil: Changes
<!-- Which code did you change? How? -->
<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->
use encoded url in the generated curl command

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->
none

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->
none

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->
the added unit test case, and real request made in the sample app

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
none