### PR TITLE
fix: remove unused wake lock permission

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -8,10 +8,6 @@
         </intent>
     </queries>
 
-    <uses-permission
-        android:name="android.permission.WAKE_LOCK"
-        android:maxSdkVersion="25" />
-
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application>


### PR DESCRIPTION
## :camera: Screenshots
No screenshots

## :page_facing_up: Context
Based on my code review, Chucker doesn't seem to need the Wake Lock Permission. Even the `ClearDatabaseService` is a short-term task and doesn't require it.

The permission's `maxSdkVersion` of 25 is also a problem, as it can conflict with apps that use Chucker and declare their own Wake Lock, forcing them to override it. See #1077 

If this permission is truly necessary, I apologize for my misunderstanding and would appreciate an explanation of the necessity.

## :pencil: Changes
Removed the wake lock permission from the library.

## :paperclip: Related PR
No related PR

## :no_entry_sign: Breaking
No breaking

## :hammer_and_wrench: How to test
Normal testing is fine, but I suggest testing on API Level 25 and below to be sure.

## :stopwatch: Next steps
No next steps
