### PR TITLE
Extend search functionality to include body and headers

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/repository/HttpTransactionDatabaseRepository.kt
@@ -15,15 +15,11 @@ internal class HttpTransactionDatabaseRepository(
         code: String,
         path: String,
     ): LiveData<List<HttpTransactionTuple>> {
-        val pathQuery = if (path.isNotEmpty()) "%$path%" else "%"
+        val codeQuery = if (code.isNotEmpty()) "$code%" else "%"
+        val searchQuery = if (path.isNotEmpty()) "%$path%" else "%"
         return transactionDao.getFilteredTuples(
-            "$code%",
-            pathQuery = pathQuery,
-            /*
-             * Refer <a href='https://github.com/ChuckerTeam/chucker/issues/847">Issue #847</a> for
-             * more context
-             */
-            graphQlQuery = pathQuery,
+            codeQuery = codeQuery,
+            searchQuery = searchQuery,
         )
     }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -22,13 +22,18 @@ internal interface HttpTransactionDao {
     @Query(
         "SELECT id, requestDate, tookMs, protocol, method, host, path, scheme, responseCode, " +
             "requestPayloadSize, responsePayloadSize, error, graphQLDetected, graphQlOperationName FROM " +
-            "transactions WHERE responseCode LIKE :codeQuery AND (path LIKE :pathQuery OR " +
-            "graphQlOperationName LIKE :graphQlQuery) ORDER BY requestDate DESC",
+            "transactions WHERE responseCode LIKE :codeQuery AND (" +
+            "path LIKE :searchQuery OR " +
+            "graphQlOperationName LIKE :searchQuery OR " +
+            "requestBody LIKE :searchQuery OR " +
+            "responseBody LIKE :searchQuery OR " +
+            "requestHeaders LIKE :searchQuery OR " +
+            "responseHeaders LIKE :searchQuery" +
+            ") ORDER BY requestDate DESC",
     )
     fun getFilteredTuples(
         codeQuery: String,
-        pathQuery: String,
-        graphQlQuery: String = "",
+        searchQuery: String,
     ): LiveData<List<HttpTransactionTuple>>
 
     @Insert

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModel.kt
@@ -34,7 +34,7 @@ internal class MainViewModel : ViewModel() {
             with(RepositoryProvider.transaction()) {
                 when {
                     searchQuery.isNullOrBlank() -> getSortedTransactionTuples()
-                    searchQuery.isDigitsOnly() -> getFilteredTransactionTuples(searchQuery, "")
+                    searchQuery.isDigitsOnly() -> getFilteredTransactionTuples(searchQuery, searchQuery)
                     else -> getFilteredTransactionTuples("", searchQuery)
                 }
             }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -200,7 +200,7 @@ internal class HttpTransactionDaoTest {
             insertTransaction(transactionTwo)
             insertTransaction(transactionThree)
 
-            testObject.getFilteredTuples(codeQuery = "418", pathQuery = "%abc%").observeForever { result ->
+            testObject.getFilteredTuples(codeQuery = "%", searchQuery = "%abc%").observeForever { result ->
                 assertTuples(listOf(transactionOne, transactionTwo), result)
             }
         }
@@ -234,7 +234,7 @@ internal class HttpTransactionDaoTest {
             insertTransaction(transactionFour)
 
             testObject
-                .getFilteredTuples(codeQuery = "%", pathQuery = "%get%", graphQlQuery = "%get%")
+                .getFilteredTuples(codeQuery = "%", searchQuery = "%get%")
                 .observeForever { result ->
                     assertTuples(listOf(transactionFour), result)
                 }
@@ -263,8 +263,142 @@ internal class HttpTransactionDaoTest {
             insertTransaction(transactionTwo)
             insertTransaction(transactionThree)
 
-            testObject.getFilteredTuples(codeQuery = "4%", pathQuery = "%").observeForever { result ->
+            testObject.getFilteredTuples(codeQuery = "4%", searchQuery = "%").observeForever { result ->
                 assertTuples(listOf(transactionThree, transactionOne), result)
+            }
+        }
+
+    @Test
+    fun `transaction tuples are filtered by request body`() =
+        runBlocking {
+            val transactionOne =
+                createRequest("test").withResponseData().apply {
+                    requestDate = 200L
+                    requestBody = "searchTermInBody"
+                }
+            val transactionTwo =
+                createRequest("other").withResponseData().apply {
+                    requestDate = 100L
+                    requestBody = "differentContent"
+                }
+
+            insertTransaction(transactionOne)
+            insertTransaction(transactionTwo)
+
+            testObject.getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInBody%").observeForever { result ->
+                assertTuples(listOf(transactionOne), result)
+            }
+        }
+
+    @Test
+    fun `transaction tuples are filtered by response body`() =
+        runBlocking {
+            val transactionOne =
+                createRequest("test").withResponseData().apply {
+                    requestDate = 200L
+                    responseBody = "searchTermInResponse"
+                }
+            val transactionTwo =
+                createRequest("other").withResponseData().apply {
+                    requestDate = 100L
+                    responseBody = "differentContent"
+                }
+
+            insertTransaction(transactionOne)
+            insertTransaction(transactionTwo)
+
+            testObject.getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInResponse%").observeForever { result ->
+                assertTuples(listOf(transactionOne), result)
+            }
+        }
+
+    @Test
+    fun `transaction tuples are filtered by request headers`() =
+        runBlocking {
+            val transactionOne =
+                createRequest("test").withResponseData().apply {
+                    requestDate = 200L
+                    setRequestHeaders(
+                        okhttp3.Headers.Builder()
+                            .add("Authorization", "Bearer searchTermInHeader")
+                            .build(),
+                    )
+                }
+            val transactionTwo =
+                createRequest("other").withResponseData().apply {
+                    requestDate = 100L
+                    setRequestHeaders(
+                        okhttp3.Headers.Builder()
+                            .add("Authorization", "Bearer differentToken")
+                            .build(),
+                    )
+                }
+
+            insertTransaction(transactionOne)
+            insertTransaction(transactionTwo)
+
+            testObject.getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInHeader%").observeForever { result ->
+                assertTuples(listOf(transactionOne), result)
+            }
+        }
+
+    @Test
+    fun `transaction tuples are filtered by response headers`() =
+        runBlocking {
+            val transactionOne =
+                createRequest("test").withResponseData().apply {
+                    requestDate = 200L
+                    setResponseHeaders(
+                        okhttp3.Headers.Builder()
+                            .add("X-Custom-Header", "searchTermInResponseHeader")
+                            .build(),
+                    )
+                }
+            val transactionTwo =
+                createRequest("other").withResponseData().apply {
+                    requestDate = 100L
+                    setResponseHeaders(
+                        okhttp3.Headers.Builder()
+                            .add("X-Custom-Header", "differentValue")
+                            .build(),
+                    )
+                }
+
+            insertTransaction(transactionOne)
+            insertTransaction(transactionTwo)
+
+            testObject.getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInResponseHeader%").observeForever { result ->
+                assertTuples(listOf(transactionOne), result)
+            }
+        }
+
+    @Test
+    fun `transaction tuples are filtered by header name`() =
+        runBlocking {
+            val transactionOne =
+                createRequest("test").withResponseData().apply {
+                    requestDate = 200L
+                    setRequestHeaders(
+                        okhttp3.Headers.Builder()
+                            .add("X-Special-Header", "value")
+                            .build(),
+                    )
+                }
+            val transactionTwo =
+                createRequest("other").withResponseData().apply {
+                    requestDate = 100L
+                    setRequestHeaders(
+                        okhttp3.Headers.Builder()
+                            .add("X-Different-Header", "value")
+                            .build(),
+                    )
+                }
+
+            insertTransaction(transactionOne)
+            insertTransaction(transactionTwo)
+
+            testObject.getFilteredTuples(codeQuery = "%", searchQuery = "%X-Special-Header%").observeForever { result ->
+                assertTuples(listOf(transactionOne), result)
             }
         }
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -307,9 +307,11 @@ internal class HttpTransactionDaoTest {
             insertTransaction(transactionOne)
             insertTransaction(transactionTwo)
 
-            testObject.getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInResponse%").observeForever { result ->
-                assertTuples(listOf(transactionOne), result)
-            }
+            testObject
+                .getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInResponse%")
+                .observeForever { result ->
+                    assertTuples(listOf(transactionOne), result)
+                }
         }
 
     @Test
@@ -319,7 +321,8 @@ internal class HttpTransactionDaoTest {
                 createRequest("test").withResponseData().apply {
                     requestDate = 200L
                     setRequestHeaders(
-                        okhttp3.Headers.Builder()
+                        okhttp3.Headers
+                            .Builder()
                             .add("Authorization", "Bearer searchTermInHeader")
                             .build(),
                     )
@@ -328,7 +331,8 @@ internal class HttpTransactionDaoTest {
                 createRequest("other").withResponseData().apply {
                     requestDate = 100L
                     setRequestHeaders(
-                        okhttp3.Headers.Builder()
+                        okhttp3.Headers
+                            .Builder()
                             .add("Authorization", "Bearer differentToken")
                             .build(),
                     )
@@ -337,9 +341,11 @@ internal class HttpTransactionDaoTest {
             insertTransaction(transactionOne)
             insertTransaction(transactionTwo)
 
-            testObject.getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInHeader%").observeForever { result ->
-                assertTuples(listOf(transactionOne), result)
-            }
+            testObject
+                .getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInHeader%")
+                .observeForever { result ->
+                    assertTuples(listOf(transactionOne), result)
+                }
         }
 
     @Test
@@ -349,7 +355,8 @@ internal class HttpTransactionDaoTest {
                 createRequest("test").withResponseData().apply {
                     requestDate = 200L
                     setResponseHeaders(
-                        okhttp3.Headers.Builder()
+                        okhttp3.Headers
+                            .Builder()
                             .add("X-Custom-Header", "searchTermInResponseHeader")
                             .build(),
                     )
@@ -358,7 +365,8 @@ internal class HttpTransactionDaoTest {
                 createRequest("other").withResponseData().apply {
                     requestDate = 100L
                     setResponseHeaders(
-                        okhttp3.Headers.Builder()
+                        okhttp3.Headers
+                            .Builder()
                             .add("X-Custom-Header", "differentValue")
                             .build(),
                     )
@@ -367,9 +375,11 @@ internal class HttpTransactionDaoTest {
             insertTransaction(transactionOne)
             insertTransaction(transactionTwo)
 
-            testObject.getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInResponseHeader%").observeForever { result ->
-                assertTuples(listOf(transactionOne), result)
-            }
+            testObject
+                .getFilteredTuples(codeQuery = "%", searchQuery = "%searchTermInResponseHeader%")
+                .observeForever { result ->
+                    assertTuples(listOf(transactionOne), result)
+                }
         }
 
     @Test
@@ -379,7 +389,8 @@ internal class HttpTransactionDaoTest {
                 createRequest("test").withResponseData().apply {
                     requestDate = 200L
                     setRequestHeaders(
-                        okhttp3.Headers.Builder()
+                        okhttp3.Headers
+                            .Builder()
                             .add("X-Special-Header", "value")
                             .build(),
                     )
@@ -388,7 +399,8 @@ internal class HttpTransactionDaoTest {
                 createRequest("other").withResponseData().apply {
                     requestDate = 100L
                     setRequestHeaders(
-                        okhttp3.Headers.Builder()
+                        okhttp3.Headers
+                            .Builder()
                             .add("X-Different-Header", "value")
                             .build(),
                     )

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/ui/MainViewModelTest.kt
@@ -108,7 +108,7 @@ internal class MainViewModelTest {
             every {
                 transactionRepository.getFilteredTransactionTuples(
                     searchQuery,
-                    "",
+                    searchQuery,
                 )
             } returns transactionLiveData
             every { TextUtils.isDigitsOnly(searchQuery) } returns true
@@ -117,7 +117,7 @@ internal class MainViewModelTest {
             viewModel.updateItemsFilter(searchQuery)
             transactionLiveData.value = expectedTuples
 
-            verify { transactionRepository.getFilteredTransactionTuples(searchQuery, "") }
+            verify { transactionRepository.getFilteredTransactionTuples(searchQuery, searchQuery) }
             verify { transactionObserver.onChanged(expectedTuples) }
         }
 


### PR DESCRIPTION
- Add search support for requestBody and responseBody fields
- Add search support for requestHeaders and responseHeaders (both header names and values)
- Maintain existing GraphQL operation name search functionality
- Update SQL query in HttpTransactionDao to search across all relevant fields
- Update MainViewModel to pass searchQuery for both code and text searches
- Add comprehensive tests for body and headers search functionality

This enhancement allows users to search transactions not only by URL path and GraphQL operation name, but also by content in request/response bodies and headers, making it easier to find specific transactions.