### PR TITLE
fix: Remove penaltyDeath from StrictMode in sample app

### DIFF
--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -89,7 +89,6 @@ class MainActivity : ComponentActivity() {
                 .detectDiskReads()
                 .detectDiskWrites()
                 .penaltyLog()
-                .penaltyDeath()
                 .build(),
         )
     }


### PR DESCRIPTION
## :page_facing_up: Context

The sample app currently uses `StrictMode.ThreadPolicy.Builder().penaltyDeath()` which causes the app to crash immediately when any disk I/O operation is detected on the main thread. This makes the sample app difficult to use during development and testing.

## :pencil: Changes

- Removed `.penaltyDeath()` from the StrictMode ThreadPolicy configuration in `MainActivity.kt`
- Kept `.penaltyLog()` to continue logging violations without crashing the app

This allows developers to:
- Run the sample app without crashes
- Still see StrictMode violations in logcat for debugging
- Test Chucker functionality more easily

## :hammer_and_wrench: How to test

1. Build and run the sample app
2. Perform HTTP requests using the sample app UI
3. Verify the app doesn't crash on StrictMode violations
4. Check logcat to confirm violations are still being logged

## :no_entry_sign: Breaking

No breaking changes - this only affects the sample app, not the library itself.