### PR TITLE
Lazy initialize and reuse clearAction in NotificationHelper

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -48,6 +48,27 @@ internal class NotificationHelper(
         )
     }
 
+    private val clearAction by lazy {
+        val clearTransactionsBroadcastIntent =
+            Intent(context, ClearDatabaseJobIntentServiceReceiver::class.java)
+
+        val clearActionIntent =
+            PendingIntent.getBroadcast(
+                context,
+                INTENT_REQUEST_CODE,
+                clearTransactionsBroadcastIntent,
+                immutableFlag(),
+            )
+
+        val clearTitle = context.getString(R.string.chucker_clear)
+
+        NotificationCompat.Action(
+            R.drawable.chucker_ic_delete_white,
+            clearTitle,
+            clearActionIntent,
+        )
+    }
+
     init {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val transactionsChannel =
@@ -95,7 +116,7 @@ internal class NotificationHelper(
                     .setColor(ContextCompat.getColor(context, R.color.chucker_color_primary))
                     .setContentTitle(context.getString(R.string.chucker_http_notification_title))
                     .setAutoCancel(true)
-                    .addAction(createClearAction())
+                    .addAction(clearAction)
             val inboxStyle = NotificationCompat.InboxStyle()
             synchronized(transactionBuffer) {
                 var count = 0
@@ -118,24 +139,6 @@ internal class NotificationHelper(
             }
             notificationManager.notify(TRANSACTION_NOTIFICATION_ID, builder.build())
         }
-    }
-
-    private fun createClearAction(): NotificationCompat.Action {
-        val clearTitle = context.getString(R.string.chucker_clear)
-        val clearTransactionsBroadcastIntent =
-            Intent(context, ClearDatabaseJobIntentServiceReceiver::class.java)
-        val pendingBroadcastIntent =
-            PendingIntent.getBroadcast(
-                context,
-                INTENT_REQUEST_CODE,
-                clearTransactionsBroadcastIntent,
-                PendingIntent.FLAG_ONE_SHOT or immutableFlag(),
-            )
-        return NotificationCompat.Action(
-            R.drawable.chucker_ic_delete_white,
-            clearTitle,
-            pendingBroadcastIntent,
-        )
     }
 
     fun dismissNotifications() {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/NotificationHelper.kt
@@ -49,22 +49,17 @@ internal class NotificationHelper(
     }
 
     private val clearAction by lazy {
-        val clearTransactionsBroadcastIntent =
-            Intent(context, ClearDatabaseJobIntentServiceReceiver::class.java)
-
         val clearActionIntent =
             PendingIntent.getBroadcast(
                 context,
                 INTENT_REQUEST_CODE,
-                clearTransactionsBroadcastIntent,
+                Intent(context, ClearDatabaseJobIntentServiceReceiver::class.java),
                 immutableFlag(),
             )
 
-        val clearTitle = context.getString(R.string.chucker_clear)
-
         NotificationCompat.Action(
             R.drawable.chucker_ic_delete_white,
-            clearTitle,
+            context.getString(R.string.chucker_clear),
             clearActionIntent,
         )
     }


### PR DESCRIPTION
## :page_facing_up: Context
This PR is going to address this [issue-1570](https://github.com/ChuckerTeam/chucker/issues/1570)

## :pencil: Changes
In the issue it is reported that the ANR is coming from createClearAction() function within Notification Helper. 

From debugging with logs, I found out that every time new http request notification is posted, this function is called and a fresh pending intent is created via ActivityManagerService via a Binder IPC call. Under high concurrency (many simultaneous HTTP responses), this might be causing an ANR. 

Changes: 
1. I have moved this **clearAction** to a single variable (lazy initialized).
2. Also removed flag FLAG_ONE_SHOT since the pendingIntent will be reused multiple times after change 1
