### PR TITLE
fix: target Java 17 bytecode instead of Java 21 (fixes #1660)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Please add your entries according to this format.
 
 ### Fixed
 
+-   Fixed the published AAR being compiled with Java 21 bytecode (class file version 65), which broke compilation on JDK 17. The library now targets Java 17 again, as in 4.3.0 [#1660]
+
 ## Version 4.3.1 _(2026-02-28)_
 
 ### Fixed

--- a/library-no-op/build.gradle.kts
+++ b/library-no-op/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -10,9 +11,11 @@ android {
     compileSdk = rootProject.extra["compileSdkVersion"] as Int
     namespace = "com.chuckerteam.chucker"
 
+    // Build with the JDK 21 toolchain but emit Java 17 bytecode so the
+    // published library stays consumable by JDK 17 projects (see #1660).
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlin {
@@ -42,6 +45,7 @@ android {
 
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
         freeCompilerArgs.addAll(
             "-module-name",
             "com.github.ChuckerTeam.Chucker.library",

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -17,9 +18,12 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    // Build/test with the JDK 21 toolchain (required by Robolectric for the
+    // target Android SDK), but emit Java 17 bytecode so the published library
+    // stays consumable by JDK 17 projects (see #1660).
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlin {
@@ -68,6 +72,7 @@ android {
 
 tasks.withType<KotlinCompile>().configureEach {
     compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
         freeCompilerArgs.addAll(
             "-module-name",
             "com.github.ChuckerTeam.Chucker.library",


### PR DESCRIPTION
## Problem

Fixes #1660.

Chucker `4.3.1` shipped AARs compiled to **Java 21 bytecode (class file version 65)** instead of Java 17 (version 61). This breaks compilation for any consumer building on JDK 17:

```
bad class file: .../jetified-library-4.3.1-api.jar
class file has wrong version 65.0, should be 61.0
...
cannot access ChuckerInterceptor
```

`4.3.0` worked; rolling back resolves it. The regression is still present on `main`.

## Root cause

The bump slipped in via the AGP 9 upgrade (#1556), which changed the modules from `VERSION_17` / `jvmToolchain(17)` to `VERSION_21` / `jvmToolchain(21)`. Raising `targetCompatibility` (and the toolchain that drives Kotlin's `jvmTarget`) changed the emitted bytecode to version 65. AGP 9 only requires JDK 17, so the bump was unnecessary.

## Fix

The build/test **toolchain must stay on JDK 21** — Robolectric requires a JDK 21 runtime for the target Android SDK (downgrading the toolchain makes the unit tests fail with `UnsupportedOperationException` in `DefaultSdkProvider`). So instead of downgrading the toolchain, we keep building/testing on JDK 21 but constrain the *emitted* bytecode to Java 17 in the two **published** modules (`library`, `library-no-op`):

- restore `sourceCompatibility`/`targetCompatibility` to `VERSION_17`
- pin the Kotlin `jvmTarget` to `JVM_17`

The `sample` module and the CI JDK are left unchanged from `main`.

## Verification

Built the actual release AARs and checked **every** class in `classes.jar`:

```
library-release.aar:        208 classes → all major version: 61
library-no-op-release.aar:    8 classes → all major version: 61
```

Version 61 = Java 17, matching `4.3.0`. This includes the generated ViewBinding/Room classes, not just the Kotlin ones. `./gradlew :library:testDebugUnitTest` passes.

Suggest a `4.3.2` patch release once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)