### PR TITLE
docs: recommend addNetworkInterceptor for OkHttp integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Please add your entries according to this format.
 
 -   Long-press the payload copy button to choose between copying the raw body or the formatted body [#1613]
 
+### Changed
+
+-   README now recommends `addNetworkInterceptor` and clarifies the trade-off vs. `addInterceptor` so headers added by other network interceptors show up in the Chucker UI [#759]
+
 ### Fixed
 
 -   Fixed the published AAR being compiled with Java 21 bytecode (class file version 65), which broke compilation on JDK 17. The library now targets Java 17 again, as in 4.3.0 [#1660]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ Please add your entries according to this format.
 
 -   Long-press the payload copy button to choose between copying the raw body or the formatted body [#1613]
 
-### Changed
-
--   README now recommends `addNetworkInterceptor` and clarifies the trade-off vs. `addInterceptor` so headers added by other network interceptors show up in the Chucker UI [#759]
-
 ### Fixed
 
 -   Fixed the published AAR being compiled with Java 21 bytecode (class file version 65), which broke compilation on JDK 17. The library now targets Java 17 again, as in 4.3.0 [#1660]

--- a/README.md
+++ b/README.md
@@ -117,8 +117,6 @@ val chuckerInterceptor = ChuckerInterceptor.Builder(context)
 
 // Don't forget to plug the ChuckerInterceptor inside the OkHttpClient
 val client = OkHttpClient.Builder()
-        // Prefer addNetworkInterceptor if you want to see the request/response
-        // exactly as it goes over the wire (headers from other interceptors, etc.).
         .addNetworkInterceptor(chuckerInterceptor)
         .build()
 ```

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ val client = OkHttpClient.Builder()
 
 **That's it!** 🎉 Chucker will now record all HTTP interactions made by your OkHttp client.
 
+> **Tip:** Use `addNetworkInterceptor(chuckerInterceptor)` instead of `addInterceptor(chuckerInterceptor)` if you want Chucker to display everything OkHttp sends on the wire, including headers added by other network interceptors (e.g. `Content-Length`, `Accept-Encoding`, cookies from `CookieJar`). Application interceptors only observe the request as your app builds it. See OkHttp's [Interceptors](https://square.github.io/okhttp/features/interceptors/) docs for the full comparison.
+
 Historically, Chucker was distributed through JitPack.
 You can find older version of Chucker here: [![JitPack](https://jitpack.io/v/ChuckerTeam/chucker.svg)](https://jitpack.io/#ChuckerTeam/chucker).
 
@@ -115,7 +117,9 @@ val chuckerInterceptor = ChuckerInterceptor.Builder(context)
 
 // Don't forget to plug the ChuckerInterceptor inside the OkHttpClient
 val client = OkHttpClient.Builder()
-        .addInterceptor(chuckerInterceptor)
+        // Prefer addNetworkInterceptor if you want to see the request/response
+        // exactly as it goes over the wire (headers from other interceptors, etc.).
+        .addNetworkInterceptor(chuckerInterceptor)
         .build()
 ```
 


### PR DESCRIPTION
## :camera: Screenshots

n/a — docs only.

## :page_facing_up: Context

Closes #759.

Following the current README, users register Chucker as an application interceptor:

```kotlin
val client = OkHttpClient.Builder()
        .addInterceptor(chuckerInterceptor)
        .build()
```

That works, but it hides everything OkHttp itself adds later in the chain — `Content-Length`, `Accept-Encoding`, cookies from `CookieJar`, headers from other network interceptors. People show up asking why headers they can see in Charles/mitmproxy aren't in Chucker.

The issue asks for the docs to at least surface the choice.

## :pencil: Changes

- README **Install** section: added a callout after the minimal example pointing users at `addNetworkInterceptor` and explaining why (with a link to OkHttp's Interceptors docs).
- README **Configure** section: switched the fuller example to `addNetworkInterceptor` with an inline comment on the trade-off, so someone copy-pasting the configured setup gets the on-the-wire view by default.
- CHANGELOG: `### Changed` entry under `Unreleased` referencing #759.

Kept the `addInterceptor` example in the Install section so folks who genuinely want the app-layer view still see it — the callout just makes the choice explicit.

## :paperclip: Related PR

None.

## :no_entry_sign: Breaking

No. Docs only, no API surface changed.

## :hammer_and_wrench: How to test

Render the README on GitHub and confirm the callout and inline comment land in the right sections. `CHANGELOG.md` renders normally.

## :stopwatch: Next steps

None.