### PR TITLE
Revert translated export markers to English for es, ja, ko, ru

### DIFF
--- a/library/src/main/res/values-es/strings.xml
+++ b/library/src/main/res/values-es/strings.xml
@@ -58,8 +58,8 @@
     <string name="chucker_export_text_selected_http_confirmation">¿Desea exportar las transacciones de red seleccionadas como archivo de texto?</string>
     <string name="chucker_export_har_selected_http_confirmation">¿Desea exportar las transacciones de red seleccionadas como archivo .har?</string>
     <string name="chucker_export_separator">==================</string>
-    <string name="chucker_export_prefix">/* Exportación Iniciada */</string>
-    <string name="chucker_export_postfix">/*  Exportación Finalizada  */</string>
+    <string name="chucker_export_prefix">/* Export Start */</string>
+    <string name="chucker_export_postfix">/*  Export End  */</string>
     <string name="chucker_check_readme"><a href="https://github.com/ChuckerTeam/chucker/blob/develop/README.md#configure-">Revisa las instrucciones de configuración en GitHub</a></string>
     <string name="chucker_setup">Configuración</string>
     <string name="chucker_binary_data">datos binarios</string>

--- a/library/src/main/res/values-ja/strings.xml
+++ b/library/src/main/res/values-ja/strings.xml
@@ -58,8 +58,8 @@
     <string name="chucker_export_text_selected_http_confirmation">選択したネットワークトランザクションをテキストファイルとしてエクスポートしますか？</string>
     <string name="chucker_export_har_selected_http_confirmation">選択したネットワークトランザクションを.harファイルとしてエクスポートしますか？</string>
     <string name="chucker_export_separator">==================</string>
-    <string name="chucker_export_prefix">/* エクスポート開始 */</string>
-    <string name="chucker_export_postfix">/*  エクスポート終了  */</string>
+    <string name="chucker_export_prefix">/* Export Start */</string>
+    <string name="chucker_export_postfix">/*  Export End  */</string>
     <string name="chucker_check_readme"><a href="https://github.com/ChuckerTeam/chucker/blob/develop/README.md#configure-">GitHubでセットアップ手順を確認</a></string>
     <string name="chucker_setup">セットアップ</string>
     <string name="chucker_binary_data">バイナリデータ</string>

--- a/library/src/main/res/values-ko/strings.xml
+++ b/library/src/main/res/values-ko/strings.xml
@@ -58,8 +58,8 @@
     <string name="chucker_export_text_selected_http_confirmation">선택한 네트워크 트랜잭션을 텍스트 파일로 내보내시겠습니까?</string>
     <string name="chucker_export_har_selected_http_confirmation">선택한 네트워크 트랜잭션을 .har 파일로 내보내시겠습니까?</string>
     <string name="chucker_export_separator">==================</string>
-    <string name="chucker_export_prefix">/* 내보내기 시작 */</string>
-    <string name="chucker_export_postfix">/*  내보내기 종료  */</string>
+    <string name="chucker_export_prefix">/* Export Start */</string>
+    <string name="chucker_export_postfix">/*  Export End  */</string>
     <string name="chucker_check_readme"><a href="https://github.com/ChuckerTeam/chucker/blob/develop/README.md#configure-">GitHub에서 설정 방법 확인하기</a></string>
     <string name="chucker_setup">설정</string>
     <string name="chucker_binary_data">바이너리 데이터</string>

--- a/library/src/main/res/values-ru/strings.xml
+++ b/library/src/main/res/values-ru/strings.xml
@@ -58,8 +58,8 @@
     <string name="chucker_export_text_selected_http_confirmation">Вы хотите экспортировать выбранные сетевые запросы в текстовый файл?</string>
     <string name="chucker_export_har_selected_http_confirmation">Вы хотите экспортировать выбранные сетевые запросы в файл .har?</string>
     <string name="chucker_export_separator">==================</string>
-    <string name="chucker_export_prefix">/* Начало экспорта */</string>
-    <string name="chucker_export_postfix">/* Конец экспорта */</string>
+    <string name="chucker_export_prefix">/* Export Start */</string>
+    <string name="chucker_export_postfix">/*  Export End  */</string>
     <string name="chucker_check_readme"><a href="https://github.com/ChuckerTeam/chucker/blob/develop/README.md#configure-">Инструкции по настройке на GitHub</a></string>
     <string name="chucker_setup">Настройка</string>
     <string name="chucker_binary_data">двоичные данные</string>


### PR DESCRIPTION
Follow-up to the review conversation on #1681. `chucker_export_prefix` and `chucker_export_postfix` wrap exported transaction dumps as comment-style delimiters and belong in English across every locale — that's what the default `values/strings.xml` ships, and what the recent locale additions all followed: #1623 (ko, ja), #1680 (uz, kk), #1681 (ur), #1682 (ar).

Four older locale files still carry translations for these two keys. Aligning them here:

| locale | before | after |
|---|---|---|
| es | `/* Exportación Iniciada */` / `/* Exportación Finalizada */` | `/* Export Start */` / `/* Export End */` |
| ja | `/* エクスポート開始 */` / `/* エクスポート終了 */` | `/* Export Start */` / `/* Export End */` |
| ko | `/* 내보내기 시작 */` / `/* 내보내기 종료 */` | `/* Export Start */` / `/* Export End */` |
| ru | `/* Начало экспорта */` / `/* Конец экспорта */` | `/* Export Start */` / `/* Export End */` |

`chucker_export_separator` is already `==================` (ASCII-only) in every locale — nothing to change there.

/cc @cortinico